### PR TITLE
Implement derived keys.

### DIFF
--- a/key/aziot-key-client/src/lib.rs
+++ b/key/aziot-key-client/src/lib.rs
@@ -136,6 +136,46 @@ impl Client {
 		Ok(res.handle)
 	}
 
+	pub fn create_derived_key(
+		&self,
+		base_handle: &aziot_key_common::KeyHandle,
+		derivation_data: &[u8],
+	) -> std::io::Result<aziot_key_common::KeyHandle> {
+		let mut stream = self.connector.connect()?;
+
+		let body = aziot_key_common_http::create_derived_key::Request {
+			base_handle: base_handle.clone(),
+			derivation_data: http_common::ByteString(derivation_data.to_owned()),
+		};
+
+		let res: aziot_key_common_http::create_derived_key::Response = request(
+			&mut stream,
+			&http::Method::POST,
+			"/derivedkey",
+			Some(&body),
+		)?;
+		Ok(res.handle)
+	}
+
+	pub fn export_derived_key(
+		&self,
+		handle: &aziot_key_common::KeyHandle,
+	) -> std::io::Result<Vec<u8>> {
+		let mut stream = self.connector.connect()?;
+
+		let body = aziot_key_common_http::export_derived_key::Request {
+			handle: handle.clone(),
+		};
+
+		let res: aziot_key_common_http::export_derived_key::Response = request(
+			&mut stream,
+			&http::Method::POST,
+			"/derivedkey/export",
+			Some(&body),
+		)?;
+		Ok(res.key.0)
+	}
+
 	pub fn sign(
 		&self,
 		handle: &aziot_key_common::KeyHandle,

--- a/key/aziot-key-common-http/src/lib.rs
+++ b/key/aziot-key-common-http/src/lib.rs
@@ -8,6 +8,23 @@ pub struct Error {
 	pub message: std::borrow::Cow<'static, str>,
 }
 
+pub mod create_derived_key {
+	#[derive(Debug, serde::Deserialize, serde::Serialize)]
+	pub struct Request {
+		#[serde(rename = "baseKeyHandle")]
+		pub base_handle: aziot_key_common::KeyHandle,
+
+		#[serde(rename = "derivationData")]
+		pub derivation_data: http_common::ByteString,
+	}
+
+	#[derive(Debug, serde::Deserialize, serde::Serialize)]
+	pub struct Response {
+		#[serde(rename = "keyHandle")]
+		pub handle: aziot_key_common::KeyHandle,
+	}
+}
+
 pub mod create_key_if_not_exists {
 	#[derive(Debug, serde::Deserialize, serde::Serialize)]
 	pub struct Request {
@@ -90,6 +107,20 @@ pub mod encrypt {
 	#[derive(Debug, serde::Deserialize, serde::Serialize)]
 	pub struct Response {
 		pub ciphertext: http_common::ByteString,
+	}
+}
+
+pub mod export_derived_key {
+	#[derive(Debug, serde::Deserialize, serde::Serialize)]
+	pub struct Request {
+		#[serde(rename = "keyHandle")]
+		pub handle: aziot_key_common::KeyHandle,
+	}
+
+	#[derive(Debug, serde::Deserialize, serde::Serialize)]
+	pub struct Response {
+		#[serde(rename = "key")]
+		pub key: http_common::ByteString,
 	}
 }
 

--- a/key/aziot-keyd/src/error.rs
+++ b/key/aziot-keyd/src/error.rs
@@ -40,6 +40,7 @@ pub enum InternalError {
 	CreateKeyPairIfNotExists(crate::keys::CreateKeyPairIfNotExistsError),
 	GetKeyPairPublicParameter(crate::keys::GetKeyPairPublicParameterError),
 	Decrypt(crate::keys::DecryptError),
+	DeriveKey(crate::keys::DeriveKeyError),
 	Encrypt(crate::keys::EncryptError),
 	GenerateNonce(openssl::error::ErrorStack),
 	LoadKey(crate::keys::LoadKeyError),
@@ -57,6 +58,7 @@ impl std::fmt::Display for InternalError {
 			InternalError::CreateKeyIfNotExistsImport(_) => f.write_str("could not import key"),
 			InternalError::CreateKeyPairIfNotExists(_) => f.write_str("could not create key pair"),
 			InternalError::Decrypt(_) => f.write_str("could not decrypt"),
+			InternalError::DeriveKey(_) => f.write_str("could not derive key"),
 			InternalError::Encrypt(_) => f.write_str("could not encrypt"),
 			InternalError::GetKeyPairPublicParameter(_) => f.write_str("could not get key pair parameter"),
 			InternalError::GenerateNonce(_) => f.write_str("could not generate nonce"),
@@ -77,6 +79,7 @@ impl std::error::Error for InternalError {
 			InternalError::CreateKeyIfNotExistsImport(err) => Some(err),
 			InternalError::CreateKeyPairIfNotExists(err) => Some(err),
 			InternalError::Decrypt(err) => Some(err),
+			InternalError::DeriveKey(err) => Some(err),
 			InternalError::Encrypt(err) => Some(err),
 			InternalError::GetKeyPairPublicParameter(err) => Some(err),
 			InternalError::GenerateNonce(err) => Some(err),
@@ -156,6 +159,15 @@ impl From<crate::keys::ImportKeyError> for Error {
 		match err.err.0 {
 			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::CreateKeyIfNotExistsImport(err)),
+		}
+	}
+}
+
+impl From<crate::keys::DeriveKeyError> for Error {
+	fn from(err: crate::keys::DeriveKeyError) -> Self {
+		match err.err.0 {
+			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			_ => Error::Internal(InternalError::DeriveKey(err)),
 		}
 	}
 }

--- a/key/aziot-keyd/src/http/create_derived_key.rs
+++ b/key/aziot-keyd/src/http/create_derived_key.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+pub(super) fn handle(
+	req: hyper::Request<hyper::Body>,
+	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_keyd::Server>>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<hyper::Response<hyper::Body>, hyper::Request<hyper::Body>>> + Send>> {
+	Box::pin(async move {
+		if req.uri().path() != "/derivedkey" {
+			return Err(req);
+		}
+
+		let (http::request::Parts { method, headers, .. }, body) = req.into_parts();
+		let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
+
+		if method != hyper::Method::POST {
+			return Ok(super::err_response(
+				hyper::StatusCode::METHOD_NOT_ALLOWED,
+				Some((hyper::header::ALLOW, "POST")),
+				"method not allowed".into(),
+			));
+		}
+
+		if content_type.as_deref() != Some("application/json") {
+			return Ok(super::err_response(
+				hyper::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+				None,
+				"request body must be application/json".into(),
+			));
+		}
+
+		let body = match hyper::body::to_bytes(body).await {
+			Ok(body) => body,
+			Err(err) => return Ok(super::err_response(
+				hyper::StatusCode::BAD_REQUEST,
+				None,
+				super::error_to_message(&err).into(),
+			)),
+		};
+		let body: aziot_key_common_http::create_derived_key::Request = match serde_json::from_slice(&body) {
+			Ok(body) => body,
+			Err(err) => return Ok(super::err_response(
+				hyper::StatusCode::UNPROCESSABLE_ENTITY,
+				None,
+				super::error_to_message(&err).into(),
+			)),
+		};
+
+		let mut inner = inner.lock().await;
+		let inner = &mut *inner;
+
+		let handle = match inner.create_derived_key(&body.base_handle, &body.derivation_data.0) {
+			Ok(handle) => handle,
+			Err(err) => return Ok(super::ToHttpResponse::to_http_response(&err)),
+		};
+
+		let res = aziot_key_common_http::create_derived_key::Response {
+			handle,
+		};
+		let res = super::json_response(hyper::StatusCode::OK, &res);
+		Ok(res)
+	})
+}

--- a/key/aziot-keyd/src/http/export_derived_key.rs
+++ b/key/aziot-keyd/src/http/export_derived_key.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+pub(super) fn handle(
+	req: hyper::Request<hyper::Body>,
+	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_keyd::Server>>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<hyper::Response<hyper::Body>, hyper::Request<hyper::Body>>> + Send>> {
+	Box::pin(async move {
+		if req.uri().path() != "/derivedkey/export" {
+			return Err(req);
+		}
+
+		let (http::request::Parts { method, headers, .. }, body) = req.into_parts();
+		let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
+
+		if method != hyper::Method::POST {
+			return Ok(super::err_response(
+				hyper::StatusCode::METHOD_NOT_ALLOWED,
+				Some((hyper::header::ALLOW, "POST")),
+				"method not allowed".into(),
+			));
+		}
+
+		if content_type.as_deref() != Some("application/json") {
+			return Ok(super::err_response(
+				hyper::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+				None,
+				"request body must be application/json".into(),
+			));
+		}
+
+		let body = match hyper::body::to_bytes(body).await {
+			Ok(body) => body,
+			Err(err) => return Ok(super::err_response(
+				hyper::StatusCode::BAD_REQUEST,
+				None,
+				super::error_to_message(&err).into(),
+			)),
+		};
+		let body: aziot_key_common_http::export_derived_key::Request = match serde_json::from_slice(&body) {
+			Ok(body) => body,
+			Err(err) => return Ok(super::err_response(
+				hyper::StatusCode::UNPROCESSABLE_ENTITY,
+				None,
+				super::error_to_message(&err).into(),
+			)),
+		};
+
+		let mut inner = inner.lock().await;
+		let inner = &mut *inner;
+
+		let derived_key = match inner.export_derived_key(&body.handle) {
+			Ok(derived_key) => derived_key,
+			Err(err) => return Ok(super::ToHttpResponse::to_http_response(&err)),
+		};
+
+		let res = aziot_key_common_http::export_derived_key::Response {
+			key: http_common::ByteString(derived_key),
+		};
+		let res = super::json_response(hyper::StatusCode::OK, &res);
+		Ok(res)
+	})
+}

--- a/key/aziot-keyd/src/http/mod.rs
+++ b/key/aziot-keyd/src/http/mod.rs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+mod create_derived_key;
 mod create_key_if_not_exists;
 mod create_key_pair_if_not_exists;
 mod decrypt;
 mod encrypt;
+mod export_derived_key;
 mod get_key_pair_public_parameter;
 mod load;
 mod sign;
@@ -35,10 +37,12 @@ impl hyper::service::Service<hyper::Request<hyper::Body>> for Server {
 
 		Box::pin(async move {
 			const ROUTES: &[Route] = &[
+				create_derived_key::handle,
 				create_key_if_not_exists::handle,
 				create_key_pair_if_not_exists::handle,
 				decrypt::handle,
 				encrypt::handle,
+				export_derived_key::handle,
 				get_key_pair_public_parameter::handle,
 				load::handle,
 				sign::handle,

--- a/key/aziot-keys/aziot-keys.h
+++ b/key/aziot-keys/aziot-keys.h
@@ -135,6 +135,7 @@ typedef struct {
     KEYGEN_ERROR (*create_key_if_not_exists)(const char *id, uintptr_t length);
     KEYGEN_ERROR (*load_key)(const char *id);
     KEYGEN_ERROR (*import_key)(const char *id, const uint8_t *bytes, uintptr_t bytes_len);
+    KEYGEN_ERROR (*derive_key)(const char *base_id, const uint8_t *derivation_data, uintptr_t derivation_data_len, unsigned char *derived_key, uintptr_t *derived_key_len);
     KEYGEN_ERROR (*sign)(const char *id, KEYGEN_SIGN_MECHANISM mechanism, const void *parameters, const unsigned char *digest, uintptr_t digest_len, unsigned char *signature, uintptr_t *signature_len);
     /**
      * Verifies the signature of the given digest using the key identified by the specified `id`.
@@ -158,6 +159,16 @@ typedef struct {
 } KEYGEN_FUNCTION_LIST_2_0_0_0;
 
 /**
+ * Holds parameters for a sign operation with the [`KEYGEN_SIGN_MECHANISM_DERIVED`] mechanism.
+ */
+typedef struct {
+    const unsigned char *derivation_data;
+    uintptr_t derivation_data_len;
+    KEYGEN_SIGN_MECHANISM mechanism;
+    const void *parameters;
+} KEYGEN_SIGN_DERIVED_PARAMETERS;
+
+/**
  * Holds parameters for an encrypt operation with the [`KEYGEN_ENCRYPT_MECHANISM_AEAD`] mechanism.
  */
 typedef struct {
@@ -167,12 +178,27 @@ typedef struct {
     uintptr_t aad_len;
 } KEYGEN_ENCRYPT_AEAD_PARAMETERS;
 
+/**
+ * Holds parameters for an encrypt operation with the [`KEYGEN_ENCRYPT_MECHANISM_DERIVED`] mechanism.
+ */
+typedef struct {
+    const unsigned char *derivation_data;
+    uintptr_t derivation_data_len;
+    KEYGEN_ENCRYPT_MECHANISM mechanism;
+    const void *parameters;
+} KEYGEN_ENCRYPT_DERIVED_PARAMETERS;
+
 typedef unsigned int KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM;
 
 /**
  * AEAD (eg AES-256-GCM)
  */
 #define KEYGEN_ENCRYPT_MECHANISM_AEAD 1
+
+/**
+ * Encrypt with a derived key. The `parameters` parameter must be set to a `KEYGEN_ENCRYPT_DERIVED_PARAMETERS` value.
+ */
+#define KEYGEN_ENCRYPT_MECHANISM_DERIVED 3
 
 /**
  * RSA PKCS1
@@ -234,6 +260,11 @@ typedef unsigned int KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM;
 #define KEYGEN_KEY_PAIR_PARAMETER_TYPE_RSA_MODULUS 4
 
 /**
+ * Sign with a derived key. The `parameters` parameter must be set to a `KEYGEN_SIGN_DERIVED_PARAMETERS` value.
+ */
+#define KEYGEN_SIGN_MECHANISM_DERIVED 3
+
+/**
  * ECDSA
  */
 #define KEYGEN_SIGN_MECHANISM_ECDSA 1
@@ -271,4 +302,6 @@ typedef unsigned int KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM;
  */
 KEYGEN_ERROR KEYGEN_get_function_list(KEYGEN_VERSION version,
                                       const KEYGEN_FUNCTION_LIST **pfunction_list);
+
+
 

--- a/key/aziot-keys/src/lib.rs
+++ b/key/aziot-keys/src/lib.rs
@@ -206,6 +206,14 @@ pub struct KEYGEN_FUNCTION_LIST_2_0_0_0 {
 		bytes_len: usize,
 	) -> KEYGEN_ERROR,
 
+	pub derive_key: unsafe extern "C" fn(
+		base_id: *const std::os::raw::c_char,
+		derivation_data: *const u8,
+		derivation_data_len: usize,
+		derived_key: *mut std::os::raw::c_uchar,
+		derived_key_len: *mut usize,
+	) -> KEYGEN_ERROR,
+
 	pub sign: unsafe extern "C" fn(
 		id: *const std::os::raw::c_char,
 		mechanism: KEYGEN_SIGN_MECHANISM,
@@ -338,6 +346,23 @@ pub const KEYGEN_SIGN_MECHANISM_ECDSA: KEYGEN_SIGN_MECHANISM = KEYGEN_SIGN_MECHA
 /// HMAC-SHA256
 pub const KEYGEN_SIGN_MECHANISM_HMAC_SHA256: KEYGEN_SIGN_MECHANISM = KEYGEN_SIGN_MECHANISM { inner: 2 };
 
+/// Sign with a derived key. The `parameters` parameter must be set to a `KEYGEN_SIGN_DERIVED_PARAMETERS` value.
+pub const KEYGEN_SIGN_MECHANISM_DERIVED: KEYGEN_SIGN_MECHANISM = KEYGEN_SIGN_MECHANISM { inner: 3 };
+
+
+/// Holds parameters for a sign operation with the [`KEYGEN_SIGN_MECHANISM_DERIVED`] mechanism.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub struct KEYGEN_SIGN_DERIVED_PARAMETERS {
+	pub derivation_data: *const std::os::raw::c_uchar,
+	pub derivation_data_len: usize,
+	pub mechanism: KEYGEN_SIGN_MECHANISM,
+	pub parameters: *const std::ffi::c_void,
+}
+
+#[no_mangle]
+pub extern "C" fn cbindgen_unused_KEYGEN_SIGN_DERIVED_PARAMETERS() -> KEYGEN_SIGN_DERIVED_PARAMETERS { unimplemented!(); }
+
 
 /// Represents the mechanism used for an encrypt operation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -349,6 +374,9 @@ pub const KEYGEN_ENCRYPT_MECHANISM_AEAD: KEYGEN_ENCRYPT_MECHANISM = KEYGEN_ENCRY
 
 /// RSA PKCS1
 pub const KEYGEN_ENCRYPT_MECHANISM_RSA_PKCS1: KEYGEN_ENCRYPT_MECHANISM = KEYGEN_ENCRYPT_MECHANISM { inner: 2 };
+
+/// Encrypt with a derived key. The `parameters` parameter must be set to a `KEYGEN_ENCRYPT_DERIVED_PARAMETERS` value.
+pub const KEYGEN_ENCRYPT_MECHANISM_DERIVED: KEYGEN_ENCRYPT_MECHANISM = KEYGEN_ENCRYPT_MECHANISM { inner: 3 };
 
 
 /// Holds parameters for an encrypt operation with the [`KEYGEN_ENCRYPT_MECHANISM_AEAD`] mechanism.
@@ -363,6 +391,20 @@ pub struct KEYGEN_ENCRYPT_AEAD_PARAMETERS {
 
 #[no_mangle]
 pub extern "C" fn cbindgen_unused_KEYGEN_ENCRYPT_AEAD_PARAMETERS() -> KEYGEN_ENCRYPT_AEAD_PARAMETERS { unimplemented!(); }
+
+
+/// Holds parameters for an encrypt operation with the [`KEYGEN_ENCRYPT_MECHANISM_DERIVED`] mechanism.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub struct KEYGEN_ENCRYPT_DERIVED_PARAMETERS {
+	pub derivation_data: *const std::os::raw::c_uchar,
+	pub derivation_data_len: usize,
+	pub mechanism: KEYGEN_ENCRYPT_MECHANISM,
+	pub parameters: *const std::ffi::c_void,
+}
+
+#[no_mangle]
+pub extern "C" fn cbindgen_unused_KEYGEN_ENCRYPT_DERIVED_PARAMETERS() -> KEYGEN_ENCRYPT_DERIVED_PARAMETERS { unimplemented!(); }
 
 
 /// Catches the error, if any, and returns it. Otherwise returns [`KEYGEN_SUCCESS`].


### PR DESCRIPTION
Derived keys are a third kind of key handled by libaziot-keys and aziot-keyd.
The derivation uses a base key and arbitrary data. libaziot-keys combines these
in some implementation-defined way to create a new symmetric key, that can then
be used for signing, encryption and decryption.