### PR TITLE
Rename `KEYGEN_*` things exported from libaziot-keys to `AZIOT_KEYS_*`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ SHELL := /bin/bash
 default:
 	cd key/aziot-keys/ && $(CBINDGEN) --config cbindgen.toml --output aziot-keys.h.tmp $(CBINDGEN_VERBOSE)
 	cp key/aziot-keys/cbindgen.prelude.h key/aziot-keys/aziot-keys.h.new
-	< key/aziot-keys/aziot-keys.h.tmp grep -v 'cbindgen_unused' >> key/aziot-keys/aziot-keys.h.new
+	< key/aziot-keys/aziot-keys.h.tmp grep -v 'cbindgen_unused_' >> key/aziot-keys/aziot-keys.h.new
 	$(RM) key/aziot-keys/aziot-keys.h.tmp
 	if ! diff -q key/aziot-keys/aziot-keys.h key/aziot-keys/aziot-keys.h.new; then \
 		mv key/aziot-keys/aziot-keys.h.new key/aziot-keys/aziot-keys.h; \
@@ -77,9 +77,9 @@ default:
 	if ! [ -f key/aziot-keyd/src/keys.generated.rs ]; then \
 		$(BINDGEN) \
 			--blacklist-type '__.*' \
-			--whitelist-function 'KEYGEN_.*' \
-			--whitelist-type 'KEYGEN_.*' \
-			--whitelist-var 'KEYGEN_.*' \
+			--whitelist-function 'aziot_keys_.*' \
+			--whitelist-type 'AZIOT_KEYS_.*' \
+			--whitelist-var 'AZIOT_KEYS_.*' \
 			-o key/aziot-keyd/src/keys.generated.rs.tmp \
 			$(BINDGEN_VERBOSE) \
 			key/aziot-keys/aziot-keys.h \

--- a/cert/aziot-cert-client-async/Cargo.toml
+++ b/cert/aziot-cert-client-async/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/cert/aziot-cert-common-http/Cargo.toml
+++ b/cert/aziot-cert-common-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/cert/aziot-cert-common/Cargo.toml
+++ b/cert/aziot-cert-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-cert-common"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/cert/aziot-certd/Cargo.toml
+++ b/cert/aziot-certd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-certd"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 build = "build/main.rs"
 

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-common"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/iotedged/Cargo.toml
+++ b/iotedged/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iotedged"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/key/aziot-key-client-async/Cargo.toml
+++ b/key/aziot-key-client-async/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-key-client-async"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/key/aziot-key-client/Cargo.toml
+++ b/key/aziot-key-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-key-client"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/key/aziot-key-common-http/Cargo.toml
+++ b/key/aziot-key-common-http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-key-common-http"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/key/aziot-key-common/Cargo.toml
+++ b/key/aziot-key-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-key-common"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/key/aziot-key-openssl-engine/Cargo.toml
+++ b/key/aziot-key-openssl-engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
 license = "MIT"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 build = "build/main.rs"
 

--- a/key/aziot-keyd/Cargo.toml
+++ b/key/aziot-keyd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-keyd"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/key/aziot-keyd/src/error.rs
+++ b/key/aziot-keyd/src/error.rs
@@ -111,7 +111,7 @@ impl From<crate::keys::SetLibraryParameterError> for Error {
 impl From<crate::keys::CreateKeyPairIfNotExistsError> for Error {
 	fn from(err: crate::keys::CreateKeyPairIfNotExistsError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::CreateKeyPairIfNotExists(err)),
 		}
 	}
@@ -120,7 +120,7 @@ impl From<crate::keys::CreateKeyPairIfNotExistsError> for Error {
 impl From<crate::keys::LoadKeyPairError> for Error {
 	fn from(err: crate::keys::LoadKeyPairError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::LoadKeyPair(err)),
 		}
 	}
@@ -130,7 +130,7 @@ impl From<crate::keys::GetKeyPairPublicParameterError> for Error {
 	fn from(err: crate::keys::GetKeyPairPublicParameterError) -> Self {
 		match err {
 			crate::keys::GetKeyPairPublicParameterError::Api {
-				err: crate::keys::KeysRawError(crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER),
+				err: crate::keys::KeysRawError(crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER),
 			} =>
 				Error::InvalidParameter(None),
 
@@ -142,7 +142,7 @@ impl From<crate::keys::GetKeyPairPublicParameterError> for Error {
 impl From<crate::keys::CreateKeyIfNotExistsError> for Error {
 	fn from(err: crate::keys::CreateKeyIfNotExistsError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::CreateKeyIfNotExistsGenerate(err)),
 		}
 	}
@@ -151,7 +151,7 @@ impl From<crate::keys::CreateKeyIfNotExistsError> for Error {
 impl From<crate::keys::LoadKeyError> for Error {
 	fn from(err: crate::keys::LoadKeyError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::LoadKey(err)),
 		}
 	}
@@ -160,7 +160,7 @@ impl From<crate::keys::LoadKeyError> for Error {
 impl From<crate::keys::ImportKeyError> for Error {
 	fn from(err: crate::keys::ImportKeyError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::CreateKeyIfNotExistsImport(err)),
 		}
 	}
@@ -169,7 +169,7 @@ impl From<crate::keys::ImportKeyError> for Error {
 impl From<crate::keys::DeriveKeyError> for Error {
 	fn from(err: crate::keys::DeriveKeyError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::DeriveKey(err)),
 		}
 	}
@@ -178,7 +178,7 @@ impl From<crate::keys::DeriveKeyError> for Error {
 impl From<crate::keys::SignError> for Error {
 	fn from(err: crate::keys::SignError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::Sign(err)),
 		}
 	}
@@ -187,7 +187,7 @@ impl From<crate::keys::SignError> for Error {
 impl From<crate::keys::VerifyError> for Error {
 	fn from(err: crate::keys::VerifyError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::Verify(err)),
 		}
 	}
@@ -196,7 +196,7 @@ impl From<crate::keys::VerifyError> for Error {
 impl From<crate::keys::EncryptError> for Error {
 	fn from(err: crate::keys::EncryptError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::Encrypt(err)),
 		}
 	}
@@ -205,7 +205,7 @@ impl From<crate::keys::EncryptError> for Error {
 impl From<crate::keys::DecryptError> for Error {
 	fn from(err: crate::keys::DecryptError) -> Self {
 		match err.err.0 {
-			crate::keys::sys::KEYGEN_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
+			crate::keys::sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => Error::InvalidParameter(None),
 			_ => Error::Internal(InternalError::Decrypt(err)),
 		}
 	}

--- a/key/aziot-keyd/src/keys.rs
+++ b/key/aziot-keyd/src/keys.rs
@@ -2,14 +2,14 @@
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Copy, Debug)]
-pub struct KeysRawError(pub(crate) sys::KEYGEN_ERROR);
+pub struct KeysRawError(pub(crate) sys::AZIOT_KEYS_STATUS);
 
 impl std::fmt::Display for KeysRawError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self.0 {
-			sys::KEYGEN_ERROR_FATAL => f.write_str("KEYGEN_ERROR_FATAL"),
-			sys::KEYGEN_ERROR_INVALID_PARAMETER => f.write_str("KEYGEN_ERROR_INVALID_PARAMETER"),
-			sys::KEYGEN_ERROR_EXTERNAL => f.write_str("KEYGEN_ERROR_EXTERNAL"),
+			sys::AZIOT_KEYS_ERROR_FATAL => f.write_str("AZIOT_KEYS_ERROR_FATAL"),
+			sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER => f.write_str("AZIOT_KEYS_ERROR_INVALID_PARAMETER"),
+			sys::AZIOT_KEYS_ERROR_EXTERNAL => f.write_str("AZIOT_KEYS_ERROR_EXTERNAL"),
 			err => write!(f, "0x{:08x}", err),
 		}
 	}
@@ -21,38 +21,38 @@ pub(crate) enum Keys {
 		set_parameter: unsafe extern "C" fn(
 			name: *const std::os::raw::c_char,
 			value: *const std::os::raw::c_char,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		create_key_pair_if_not_exists: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
 			preferred_algorithms: *const std::os::raw::c_char,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		load_key_pair: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		get_key_pair_parameter: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
-			r#type: sys::KEYGEN_KEY_PAIR_PARAMETER_TYPE,
+			r#type: sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE,
 			value: *mut std::os::raw::c_uchar,
 			value_len: *mut usize,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		create_key_if_not_exists: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
 			length: usize,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		load_key: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		import_key: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
 			bytes: *const u8,
 			bytes_len: usize,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		derive_key: unsafe extern "C" fn(
 			base_id: *const std::os::raw::c_char,
@@ -60,66 +60,66 @@ pub(crate) enum Keys {
 			derivation_data_len: usize,
 			derived_key: *mut std::os::raw::c_uchar,
 			derived_key_len: *mut usize,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		sign: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
-			mechanism: sys::KEYGEN_SIGN_MECHANISM,
+			mechanism: sys::AZIOT_KEYS_SIGN_MECHANISM,
 			parameters: *const std::ffi::c_void,
 			digest: *const std::os::raw::c_uchar,
 			digest_len: usize,
 			signature: *mut std::os::raw::c_uchar,
 			signature_len: *mut usize,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		verify: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
-			mechanism: sys::KEYGEN_SIGN_MECHANISM,
+			mechanism: sys::AZIOT_KEYS_SIGN_MECHANISM,
 			parameters: *const std::ffi::c_void,
 			digest: *const std::os::raw::c_uchar,
 			digest_len: usize,
 			signature: *const std::os::raw::c_uchar,
 			signature_len: usize,
 			ok: *mut std::os::raw::c_int,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		encrypt: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
-			mechanism: sys::KEYGEN_SIGN_MECHANISM,
+			mechanism: sys::AZIOT_KEYS_SIGN_MECHANISM,
 			parameters: *const std::ffi::c_void,
 			plaintext: *const std::os::raw::c_uchar,
 			plaintext_len: usize,
 			ciphertext: *mut std::os::raw::c_uchar,
 			ciphertext_len: *mut usize,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 
 		decrypt: unsafe extern "C" fn(
 			id: *const std::os::raw::c_char,
-			mechanism: sys::KEYGEN_SIGN_MECHANISM,
+			mechanism: sys::AZIOT_KEYS_SIGN_MECHANISM,
 			parameters: *const std::ffi::c_void,
 			ciphertext: *const std::os::raw::c_uchar,
 			ciphertext_len: usize,
 			plaintext: *mut std::os::raw::c_uchar,
 			plaintext_len: *mut usize,
-		) -> sys::KEYGEN_ERROR,
+		) -> sys::AZIOT_KEYS_STATUS,
 	},
 }
 
 impl Keys {
 	pub(crate) fn new() -> Result<Self, LoadLibraryError> {
 		unsafe {
-			let mut function_list: *const sys::KEYGEN_FUNCTION_LIST = std::ptr::null_mut();
-			keys_fn(|| sys::KEYGEN_get_function_list(sys::KEYGEN_VERSION_2_0_0_0, &mut function_list)).map_err(LoadLibraryError::GetFunctionList)?;
+			let mut function_list: *const sys::AZIOT_KEYS_FUNCTION_LIST = std::ptr::null_mut();
+			keys_ok(sys::aziot_keys_get_function_list(sys::AZIOT_KEYS_VERSION_2_0_0_0, &mut function_list)).map_err(LoadLibraryError::GetFunctionList)?;
 
 			let api_version = (*function_list).version;
-			if api_version != sys::KEYGEN_VERSION_2_0_0_0 {
+			if api_version != sys::AZIOT_KEYS_VERSION_2_0_0_0 {
 				return Err(LoadLibraryError::UnsupportedApiVersion(api_version));
 			}
 
-			// KEYGEN_FUNCTION_LIST has looser alignment than KEYGEN_FUNCTION_LIST_2_0_0_0, but the pointer comes from the library itself,
+			// AZIOT_KEYS_FUNCTION_LIST has looser alignment than AZIOT_KEYS_FUNCTION_LIST_2_0_0_0, but the pointer comes from the library itself,
 			// so it will be correctly aligned already.
 			#[allow(clippy::cast_ptr_alignment)]
-			let function_list: *const sys::KEYGEN_FUNCTION_LIST_2_0_0_0 = function_list as _;
+			let function_list: *const sys::AZIOT_KEYS_FUNCTION_LIST_2_0_0_0 = function_list as _;
 
 			let result = Keys::V2_0_0_0 {
 				set_parameter:
@@ -170,7 +170,7 @@ impl Keys {
 pub enum LoadLibraryError {
 	GetFunctionList(KeysRawError),
 	MissingFunction(&'static str),
-	UnsupportedApiVersion(sys::KEYGEN_VERSION),
+	UnsupportedApiVersion(sys::AZIOT_KEYS_VERSION),
 }
 
 impl std::fmt::Display for LoadLibraryError {
@@ -191,7 +191,7 @@ impl Keys {
 		unsafe {
 			match self {
 				Keys::V2_0_0_0 { set_parameter, .. } => {
-					keys_fn(|| set_parameter(
+					keys_ok(set_parameter(
 						name.as_ptr(),
 						value.as_ptr(),
 					)).map_err(|err| SetLibraryParameterError { name: name.to_string_lossy().into_owned(), err })?;
@@ -227,7 +227,7 @@ impl Keys {
 		unsafe {
 			match self {
 				Keys::V2_0_0_0 { create_key_pair_if_not_exists, .. } => {
-					keys_fn(|| create_key_pair_if_not_exists(
+					keys_ok(create_key_pair_if_not_exists(
 						id.as_ptr(),
 						preferred_algorithms.map_or(std::ptr::null(), std::ffi::CStr::as_ptr),
 					)).map_err(|err| CreateKeyPairIfNotExistsError { err })?;
@@ -261,7 +261,7 @@ impl Keys {
 		unsafe {
 			match self {
 				Keys::V2_0_0_0 { load_key_pair, .. } => {
-					keys_fn(|| load_key_pair(
+					keys_ok(load_key_pair(
 						id.as_ptr(),
 					)).map_err(|err| LoadKeyPairError { err })?;
 
@@ -297,12 +297,12 @@ impl Keys {
 				Keys::V2_0_0_0 { get_key_pair_parameter, .. } => {
 					match parameter_name {
 						"algorithm" => {
-							let mut algorithm: sys::KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM = 0;
+							let mut algorithm: sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_ALGORITHM = 0;
 							let mut algorithm_len = std::mem::size_of_val(&algorithm);
 
-							keys_fn(|| get_key_pair_parameter(
+							keys_ok(get_key_pair_parameter(
 								id.as_ptr(),
-								sys::KEYGEN_KEY_PAIR_PARAMETER_TYPE_ALGORITHM,
+								sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_ALGORITHM,
 								&mut algorithm as *mut _ as _,
 								&mut algorithm_len,
 							)).map_err(|err| GetKeyPairPublicParameterError::Api { err })?;
@@ -312,8 +312,8 @@ impl Keys {
 							}
 
 							let algorithm = match algorithm {
-								sys::KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM_EC => "ECDSA".to_owned(),
-								sys::KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM_RSA => "RSA".to_owned(),
+								sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_ALGORITHM_EC => "ECDSA".to_owned(),
+								sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_ALGORITHM_RSA => "RSA".to_owned(),
 								algorithm => return Err(GetKeyPairPublicParameterError::UnrecognizedKeyAlgorithm { algorithm }),
 							};
 							Ok(algorithm)
@@ -323,11 +323,11 @@ impl Keys {
 							// These are all byte-buf parameters, so they can be handled identically.
 
 							let parameter_type = match parameter_name {
-								"ec-curve-oid" => sys::KEYGEN_KEY_PAIR_PARAMETER_TYPE_EC_CURVE_OID,
-								"ec-point" => sys::KEYGEN_KEY_PAIR_PARAMETER_TYPE_EC_POINT,
-								"rsa-modulus" => sys::KEYGEN_KEY_PAIR_PARAMETER_TYPE_RSA_MODULUS,
-								"rsa-exponent" => sys::KEYGEN_KEY_PAIR_PARAMETER_TYPE_RSA_EXPONENT,
-								_ => return Err(GetKeyPairPublicParameterError::Api { err: KeysRawError(sys::KEYGEN_ERROR_INVALID_PARAMETER) }),
+								"ec-curve-oid" => sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_EC_CURVE_OID,
+								"ec-point" => sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_EC_POINT,
+								"rsa-modulus" => sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_RSA_MODULUS,
+								"rsa-exponent" => sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_RSA_EXPONENT,
+								_ => return Err(GetKeyPairPublicParameterError::Api { err: KeysRawError(sys::AZIOT_KEYS_ERROR_INVALID_PARAMETER) }),
 							};
 
 							let parameter_value =
@@ -350,7 +350,7 @@ impl Keys {
 #[derive(Debug)]
 pub enum GetKeyPairPublicParameterError {
 	Api { err: KeysRawError },
-	UnrecognizedKeyAlgorithm { algorithm: sys::KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM },
+	UnrecognizedKeyAlgorithm { algorithm: sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_ALGORITHM },
 	UnrecognizedKeyAlgorithmLength { algorithm_len: usize },
 }
 
@@ -379,7 +379,7 @@ impl Keys {
 		unsafe {
 			match self {
 				Keys::V2_0_0_0 { create_key_if_not_exists, .. } => {
-					keys_fn(|| create_key_if_not_exists(
+					keys_ok(create_key_if_not_exists(
 						id.as_ptr(),
 						length,
 					)).map_err(|err| CreateKeyIfNotExistsError { err })?;
@@ -413,7 +413,7 @@ impl Keys {
 		unsafe {
 			match self {
 				Keys::V2_0_0_0 { load_key, .. } => {
-					keys_fn(|| load_key(
+					keys_ok(load_key(
 						id.as_ptr(),
 					)).map_err(|err| LoadKeyError { err })?;
 
@@ -447,7 +447,7 @@ impl Keys {
 		unsafe {
 			match self {
 				Keys::V2_0_0_0 { import_key, .. } => {
-					keys_fn(|| import_key(
+					keys_ok(import_key(
 						id.as_ptr(),
 						bytes.as_ptr(),
 						bytes.len(),
@@ -487,7 +487,7 @@ impl Keys {
 
 					let mut derived_key_len = 0;
 
-					keys_fn(|| derive_key(
+					keys_ok(derive_key(
 						base_id.as_ptr(),
 						derivation_data.as_ptr(),
 						derivation_data_len,
@@ -500,7 +500,7 @@ impl Keys {
 						vec![0_u8; derived_key_len]
 					};
 
-					keys_fn(|| derive_key(
+					keys_ok(derive_key(
 						base_id.as_ptr(),
 						derivation_data.as_ptr(),
 						derivation_data_len,
@@ -542,7 +542,7 @@ impl Keys {
 	pub(crate) fn sign(
 		&mut self,
 		id: &std::ffi::CStr,
-		mechanism: sys::KEYGEN_SIGN_MECHANISM,
+		mechanism: sys::AZIOT_KEYS_SIGN_MECHANISM,
 		parameters: *const std::ffi::c_void,
 		digest: &[u8],
 	) -> Result<Vec<u8>, SignError> {
@@ -553,7 +553,7 @@ impl Keys {
 
 					let mut signature_len = 0;
 
-					keys_fn(|| sign(
+					keys_ok(sign(
 						id.as_ptr(),
 						mechanism,
 						parameters,
@@ -568,7 +568,7 @@ impl Keys {
 						vec![0_u8; signature_len]
 					};
 
-					keys_fn(|| sign(
+					keys_ok(sign(
 						id.as_ptr(),
 						mechanism,
 						parameters,
@@ -612,7 +612,7 @@ impl Keys {
 	pub(crate) fn verify(
 		&mut self,
 		id: &std::ffi::CStr,
-		mechanism: sys::KEYGEN_SIGN_MECHANISM,
+		mechanism: sys::AZIOT_KEYS_SIGN_MECHANISM,
 		parameters: *const std::ffi::c_void,
 		digest: &[u8],
 		signature: &[u8],
@@ -625,7 +625,7 @@ impl Keys {
 
 					let mut ok = 0;
 
-					keys_fn(|| verify(
+					keys_ok(verify(
 						id.as_ptr(),
 						mechanism,
 						parameters,
@@ -662,7 +662,7 @@ impl Keys {
 	pub(crate) fn encrypt(
 		&mut self,
 		id: &std::ffi::CStr,
-		mechanism: sys::KEYGEN_ENCRYPT_MECHANISM,
+		mechanism: sys::AZIOT_KEYS_ENCRYPT_MECHANISM,
 		parameters: *const std::ffi::c_void,
 		plaintext: &[u8],
 	) -> Result<Vec<u8>, EncryptError> {
@@ -673,7 +673,7 @@ impl Keys {
 
 					let mut ciphertext_len = 0;
 
-					keys_fn(|| encrypt(
+					keys_ok(encrypt(
 						id.as_ptr(),
 						mechanism,
 						parameters,
@@ -688,7 +688,7 @@ impl Keys {
 						vec![0_u8; ciphertext_len]
 					};
 
-					keys_fn(|| encrypt(
+					keys_ok(encrypt(
 						id.as_ptr(),
 						mechanism,
 						parameters,
@@ -732,7 +732,7 @@ impl Keys {
 	pub(crate) fn decrypt(
 		&mut self,
 		id: &std::ffi::CStr,
-		mechanism: sys::KEYGEN_ENCRYPT_MECHANISM,
+		mechanism: sys::AZIOT_KEYS_ENCRYPT_MECHANISM,
 		parameters: *const std::ffi::c_void,
 		ciphertext: &[u8],
 	) -> Result<Vec<u8>, DecryptError> {
@@ -743,7 +743,7 @@ impl Keys {
 
 					let mut plaintext_len = 0;
 
-					keys_fn(|| decrypt(
+					keys_ok(decrypt(
 						id.as_ptr(),
 						mechanism,
 						parameters,
@@ -758,7 +758,7 @@ impl Keys {
 						vec![0_u8; plaintext_len]
 					};
 
-					keys_fn(|| decrypt(
+					keys_ok(decrypt(
 						id.as_ptr(),
 						mechanism,
 						parameters,
@@ -798,9 +798,9 @@ impl std::fmt::Display for DecryptError {
 impl std::error::Error for DecryptError {
 }
 
-fn keys_fn(f: impl FnOnce() -> sys::KEYGEN_ERROR) -> Result<(), KeysRawError> {
-	match f() {
-		sys::KEYGEN_SUCCESS => Ok(()),
+fn keys_ok(result: sys::AZIOT_KEYS_STATUS) -> Result<(), KeysRawError> {
+	match result {
+		sys::AZIOT_KEYS_SUCCESS => Ok(()),
 		err => Err(KeysRawError(err)),
 	}
 }
@@ -808,16 +808,16 @@ fn keys_fn(f: impl FnOnce() -> sys::KEYGEN_ERROR) -> Result<(), KeysRawError> {
 unsafe fn get_key_pair_parameter_byte_buf(
 	get_key_pair_parameter: unsafe extern "C" fn(
 		id: *const std::os::raw::c_char,
-		r#type: sys::KEYGEN_KEY_PAIR_PARAMETER_TYPE,
+		r#type: sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE,
 		value: *mut std::os::raw::c_uchar,
 		value_len: *mut usize,
-	) -> sys::KEYGEN_ERROR,
+	) -> sys::AZIOT_KEYS_STATUS,
 	id: &std::ffi::CStr,
-	r#type: sys::KEYGEN_KEY_PAIR_PARAMETER_TYPE,
+	r#type: sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE,
 ) -> Result<Vec<u8>, KeysRawError> {
 	let mut value_len: usize = 0;
 
-	keys_fn(|| get_key_pair_parameter(
+	keys_ok(get_key_pair_parameter(
 		id.as_ptr(),
 		r#type,
 		std::ptr::null_mut(),
@@ -826,7 +826,7 @@ unsafe fn get_key_pair_parameter_byte_buf(
 
 	let mut value = vec![0_u8; value_len];
 
-	keys_fn(|| get_key_pair_parameter(
+	keys_ok(get_key_pair_parameter(
 		id.as_ptr(),
 		r#type,
 		value.as_mut_ptr(),

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -170,27 +170,27 @@ impl Server {
 		let (id, id_cstr) = key_handle_to_id(handle, &mut self.keys)?;
 		let signature = match (id, mechanism) {
 			(KeyId::KeyPair(_), aziot_key_common::SignMechanism::Ecdsa) =>
-				self.keys.sign(&id_cstr, keys::sys::KEYGEN_SIGN_MECHANISM_ECDSA, std::ptr::null(), digest)?,
+				self.keys.sign(&id_cstr, keys::sys::AZIOT_KEYS_SIGN_MECHANISM_ECDSA, std::ptr::null(), digest)?,
 
 			(KeyId::Key(_), aziot_key_common::SignMechanism::HmacSha256) =>
 				self.keys.sign(
 					&id_cstr,
-					keys::sys::KEYGEN_SIGN_MECHANISM_HMAC_SHA256,
+					keys::sys::AZIOT_KEYS_SIGN_MECHANISM_HMAC_SHA256,
 					std::ptr::null(),
 					digest,
 				)?,
 
 			(KeyId::Derived(_, derivation_data), aziot_key_common::SignMechanism::HmacSha256) => {
-				let parameters = keys::sys::KEYGEN_SIGN_DERIVED_PARAMETERS {
+				let parameters = keys::sys::AZIOT_KEYS_SIGN_DERIVED_PARAMETERS {
 					derivation_data: derivation_data.as_ptr(),
 					derivation_data_len: derivation_data.len(),
-					mechanism: keys::sys::KEYGEN_SIGN_MECHANISM_HMAC_SHA256,
+					mechanism: keys::sys::AZIOT_KEYS_SIGN_MECHANISM_HMAC_SHA256,
 					parameters: std::ptr::null(),
 				};
 
 				self.keys.sign(
 					&id_cstr,
-					keys::sys::KEYGEN_SIGN_MECHANISM_DERIVED,
+					keys::sys::AZIOT_KEYS_SIGN_MECHANISM_DERIVED,
 					&parameters as *const _ as *const std::ffi::c_void,
 					digest,
 				)?
@@ -212,7 +212,7 @@ impl Server {
 
 		let ciphertext = match (id, mechanism) {
 			(KeyId::Key(_), aziot_key_common::EncryptMechanism::Aead { iv, aad }) => {
-				let parameters = keys::sys::KEYGEN_ENCRYPT_AEAD_PARAMETERS {
+				let parameters = keys::sys::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS {
 					iv: iv.as_ptr(),
 					iv_len: iv.len(),
 					aad: aad.as_ptr(),
@@ -221,7 +221,7 @@ impl Server {
 
 				self.keys.encrypt(
 					&id_cstr,
-					keys::sys::KEYGEN_ENCRYPT_MECHANISM_AEAD,
+					keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD,
 					&parameters as *const _ as *const std::ffi::c_void,
 					plaintext,
 				)?
@@ -230,7 +230,7 @@ impl Server {
 			(KeyId::KeyPair(_), aziot_key_common::EncryptMechanism::RsaPkcs1) => {
 				self.keys.encrypt(
 					&id_cstr,
-					keys::sys::KEYGEN_ENCRYPT_MECHANISM_RSA_PKCS1,
+					keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_RSA_PKCS1,
 					std::ptr::null_mut(),
 					plaintext,
 				)?
@@ -239,30 +239,30 @@ impl Server {
 			(KeyId::KeyPair(_), aziot_key_common::EncryptMechanism::RsaNoPadding) => {
 				self.keys.encrypt(
 					&id_cstr,
-					keys::sys::KEYGEN_ENCRYPT_MECHANISM_RSA_NO_PADDING,
+					keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_RSA_NO_PADDING,
 					std::ptr::null_mut(),
 					plaintext,
 				)?
 			},
 
 			(KeyId::Derived(_, derivation_data), aziot_key_common::EncryptMechanism::Aead { iv, aad }) => {
-				let parameters = keys::sys::KEYGEN_ENCRYPT_AEAD_PARAMETERS {
+				let parameters = keys::sys::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS {
 					iv: iv.as_ptr(),
 					iv_len: iv.len(),
 					aad: aad.as_ptr(),
 					aad_len: aad.len(),
 				};
 
-				let parameters = keys::sys::KEYGEN_ENCRYPT_DERIVED_PARAMETERS {
+				let parameters = keys::sys::AZIOT_KEYS_ENCRYPT_DERIVED_PARAMETERS {
 					derivation_data: derivation_data.as_ptr(),
 					derivation_data_len: derivation_data.len(),
-					mechanism: keys::sys::KEYGEN_ENCRYPT_MECHANISM_AEAD,
+					mechanism: keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD,
 					parameters: &parameters as *const _ as *const std::ffi::c_void,
 				};
 
 				self.keys.encrypt(
 					&id_cstr,
-					keys::sys::KEYGEN_ENCRYPT_MECHANISM_DERIVED,
+					keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_DERIVED,
 					&parameters as *const _ as *const std::ffi::c_void,
 					plaintext,
 				)?
@@ -284,7 +284,7 @@ impl Server {
 
 		let plaintext = match (id, mechanism) {
 			(KeyId::Key(_), aziot_key_common::EncryptMechanism::Aead { iv, aad }) => {
-				let parameters = keys::sys::KEYGEN_ENCRYPT_AEAD_PARAMETERS {
+				let parameters = keys::sys::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS {
 					iv: iv.as_ptr(),
 					iv_len: iv.len(),
 					aad: aad.as_ptr(),
@@ -293,30 +293,30 @@ impl Server {
 
 				self.keys.decrypt(
 					&id_cstr,
-					keys::sys::KEYGEN_ENCRYPT_MECHANISM_AEAD,
+					keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD,
 					&parameters as *const _ as *const std::ffi::c_void,
 					ciphertext,
 				)?
 			},
 
 			(KeyId::Derived(_, derivation_data), aziot_key_common::EncryptMechanism::Aead { iv, aad }) => {
-				let parameters = keys::sys::KEYGEN_ENCRYPT_AEAD_PARAMETERS {
+				let parameters = keys::sys::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS {
 					iv: iv.as_ptr(),
 					iv_len: iv.len(),
 					aad: aad.as_ptr(),
 					aad_len: aad.len(),
 				};
 
-				let parameters = keys::sys::KEYGEN_ENCRYPT_DERIVED_PARAMETERS {
+				let parameters = keys::sys::AZIOT_KEYS_ENCRYPT_DERIVED_PARAMETERS {
 					derivation_data: derivation_data.as_ptr(),
 					derivation_data_len: derivation_data.len(),
-					mechanism: keys::sys::KEYGEN_ENCRYPT_MECHANISM_AEAD,
+					mechanism: keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD,
 					parameters: &parameters as *const _ as *const std::ffi::c_void,
 				};
 
 				self.keys.decrypt(
 					&id_cstr,
-					keys::sys::KEYGEN_ENCRYPT_MECHANISM_DERIVED,
+					keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_DERIVED,
 					&parameters as *const _ as *const std::ffi::c_void,
 					ciphertext,
 				)?
@@ -391,7 +391,7 @@ fn key_handle_to_id(handle: &aziot_key_common::KeyHandle, keys: &mut keys::Keys)
 	let ok =
 		keys.verify(
 			master_encryption_key_id,
-			keys::sys::KEYGEN_SIGN_MECHANISM_HMAC_SHA256,
+			keys::sys::AZIOT_KEYS_SIGN_MECHANISM_HMAC_SHA256,
 			std::ptr::null(),
 			sr.as_bytes(),
 			&sig,
@@ -443,7 +443,7 @@ fn key_id_to_handle(id: &KeyId<'_>, keys: &mut keys::Keys) -> Result<aziot_key_c
 	let sig =
 		keys.sign(
 			master_encryption_key_id,
-			keys::sys::KEYGEN_SIGN_MECHANISM_HMAC_SHA256,
+			keys::sys::AZIOT_KEYS_SIGN_MECHANISM_HMAC_SHA256,
 			std::ptr::null(),
 			sr.as_bytes(),
 		).map_err(|err| Error::Internal(InternalError::Sign(err)))?;

--- a/key/aziot-keys/Cargo.toml
+++ b/key/aziot-keys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aziot-keys"
 version = "0.1.0"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [lib]

--- a/key/aziot-keys/aziot-keys.h
+++ b/key/aziot-keys/aziot-keys.h
@@ -6,12 +6,12 @@
  *
  * # API conventions
  *
- * All functions return an `unsigned int` to indicate success or failure. See the [`KEYGEN_ERROR`] type's docs for details about these constants.
+ * All functions return an `unsigned int` to indicate success or failure. See the [`AZIOT_KEYS_STATUS`] type's docs for details about these constants.
  *
- * The only function exported by this library is [`KEYGEN_get_function_list`]. Call this function to get the version of the API
+ * The only function exported by this library is [`aziot_keys_get_function_list`]. Call this function to get the version of the API
  * that this library exports, as well as the function pointers to the key operations. See its docs for more details.
  *
- * All calls to [`KEYGEN_get_function_list`] or any function in [`KEYGEN_FUNCTION_LIST`] are serialized, ie a function will not be called
+ * All calls to [`aziot_keys_get_function_list`] or any function in [`AZIOT_KEYS_FUNCTION_LIST`] are serialized, ie a function will not be called
  * while another function is running. However, it is not guaranteed that all function calls will be made from the same operating system thread.
  * Thus, implementations do not need to worry about locking to prevent concurrent access, but should also not store data in thread-local storage.
  */
@@ -21,7 +21,7 @@
 /**
  * Represents the version of the API exported by this library.
  */
-typedef unsigned int KEYGEN_VERSION;
+typedef unsigned int AZIOT_KEYS_VERSION;
 
 /**
  * The base struct of all of function lists.
@@ -30,38 +30,38 @@ typedef struct {
     /**
      * The version of the API represented in this function list.
      *
-     * The specific subtype of `KEYGEN_FUNCTION_LIST` can be determined by inspecting this value.
+     * The specific subtype of `AZIOT_KEYS_FUNCTION_LIST` can be determined by inspecting this value.
      */
-    KEYGEN_VERSION version;
-} KEYGEN_FUNCTION_LIST;
+    AZIOT_KEYS_VERSION version;
+} AZIOT_KEYS_FUNCTION_LIST;
 
 /**
  * Error type. This is a transparent wrapper around a `std::os::raw::c_uint` (`unsigned int`).
  *
- * Either `KEYGEN_SUCCESS` or one of the `KEYGEN_ERROR_*` constants.
+ * Either `AZIOT_KEYS_SUCCESS` or one of the `AZIOT_KEYS_ERROR_*` constants.
  */
-typedef unsigned int KEYGEN_ERROR;
+typedef unsigned int AZIOT_KEYS_STATUS;
 
-typedef unsigned int KEYGEN_KEY_PAIR_PARAMETER_TYPE;
+typedef unsigned int AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE;
 
 /**
  * Represents the mechanism used for a sign operation.
  */
-typedef unsigned int KEYGEN_SIGN_MECHANISM;
+typedef unsigned int AZIOT_KEYS_SIGN_MECHANISM;
 
 /**
  * Represents the mechanism used for an encrypt operation.
  */
-typedef unsigned int KEYGEN_ENCRYPT_MECHANISM;
+typedef unsigned int AZIOT_KEYS_ENCRYPT_MECHANISM;
 
 /**
- * The specific implementation of [`KEYGEN_FUNCTION_LIST`] for API version 2.0.0.0
+ * The specific implementation of [`AZIOT_KEYS_FUNCTION_LIST`] for API version 2.0.0.0
  */
 typedef struct {
     /**
-     * The value of `base.version` must be [`KEYGEN_VERSION_2_0_0_0`].
+     * The value of `base.version` must be [`AZIOT_KEYS_VERSION_2_0_0_0`].
      */
-    KEYGEN_FUNCTION_LIST base;
+    AZIOT_KEYS_FUNCTION_LIST base;
     /**
      * Set a parameter on this library.
      *
@@ -74,14 +74,14 @@ typedef struct {
      *
      * # Errors
      *
-     * - `KEYGEN_ERROR_INVALID_PARAMETER`:
+     * - `AZIOT_KEYS_ERROR_INVALID_PARAMETER`:
      *   - `name` is `NULL`.
      *   - `name` is not recognized by this implementation.
      *   - `value` is invalid.
      *
-     * - `KEYGEN_ERROR_FATAL`
+     * - `AZIOT_KEYS_ERROR_FATAL`
      */
-    KEYGEN_ERROR (*set_parameter)(const char *name, const char *value);
+    AZIOT_KEYS_STATUS (*set_parameter)(const char *name, const char *value);
     /**
      * Create or load a key identified by the specified `id`.
      *
@@ -108,186 +108,186 @@ typedef struct {
      *
      * # Errors
      *
-     * - `KEYGEN_ERROR_INVALID_PARAMETER`:
+     * - `AZIOT_KEYS_ERROR_INVALID_PARAMETER`:
      *   - `id` is NULL.
      *   - `ppublic_key` is `NULL`.
      *   - `pprivate_key` is `NULL`.
      *
-     * - `KEYGEN_ERROR_EXTERNAL`
+     * - `AZIOT_KEYS_ERROR_EXTERNAL`
      */
-    KEYGEN_ERROR (*create_key_pair_if_not_exists)(const char *id, const char *preferred_algorithms);
-    KEYGEN_ERROR (*load_key_pair)(const char *id);
+    AZIOT_KEYS_STATUS (*create_key_pair_if_not_exists)(const char *id, const char *preferred_algorithms);
+    AZIOT_KEYS_STATUS (*load_key_pair)(const char *id);
     /**
      * Gets the value of a parameter of the key identified by the specified `id`.
      *
-     * `type_` must be set to one of the `KEYGEN_KEY_PAIR_PARAMETER_TYPE_*` constants.
+     * `type_` must be set to one of the `AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_*` constants.
      *
      * # Errors
      *
-     * - `KEYGEN_ERROR_INVALID_PARAMETER`:
+     * - `AZIOT_KEYS_ERROR_INVALID_PARAMETER`:
      *   - `id` is NULL.
      *   - The key specified by `id` does not exist.
      *   - `type_` is not a valid parameter type for the key specified by `id`.
      *
-     * - `KEYGEN_ERROR_EXTERNAL`
+     * - `AZIOT_KEYS_ERROR_EXTERNAL`
      */
-    KEYGEN_ERROR (*get_key_pair_parameter)(const char *id, KEYGEN_KEY_PAIR_PARAMETER_TYPE type_, unsigned char *value, uintptr_t *value_len);
-    KEYGEN_ERROR (*create_key_if_not_exists)(const char *id, uintptr_t length);
-    KEYGEN_ERROR (*load_key)(const char *id);
-    KEYGEN_ERROR (*import_key)(const char *id, const uint8_t *bytes, uintptr_t bytes_len);
-    KEYGEN_ERROR (*derive_key)(const char *base_id, const uint8_t *derivation_data, uintptr_t derivation_data_len, unsigned char *derived_key, uintptr_t *derived_key_len);
-    KEYGEN_ERROR (*sign)(const char *id, KEYGEN_SIGN_MECHANISM mechanism, const void *parameters, const unsigned char *digest, uintptr_t digest_len, unsigned char *signature, uintptr_t *signature_len);
+    AZIOT_KEYS_STATUS (*get_key_pair_parameter)(const char *id, AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE type_, unsigned char *value, uintptr_t *value_len);
+    AZIOT_KEYS_STATUS (*create_key_if_not_exists)(const char *id, uintptr_t length);
+    AZIOT_KEYS_STATUS (*load_key)(const char *id);
+    AZIOT_KEYS_STATUS (*import_key)(const char *id, const uint8_t *bytes, uintptr_t bytes_len);
+    AZIOT_KEYS_STATUS (*derive_key)(const char *base_id, const uint8_t *derivation_data, uintptr_t derivation_data_len, unsigned char *derived_key, uintptr_t *derived_key_len);
+    AZIOT_KEYS_STATUS (*sign)(const char *id, AZIOT_KEYS_SIGN_MECHANISM mechanism, const void *parameters, const unsigned char *digest, uintptr_t digest_len, unsigned char *signature, uintptr_t *signature_len);
     /**
      * Verifies the signature of the given digest using the key identified by the specified `id`.
      *
-     * `mechanism` must be set to one of the `KEYGEN_SIGN_MECHANISM_*` constants.
+     * `mechanism` must be set to one of the `AZIOT_KEYS_SIGN_MECHANISM_*` constants.
      *
-     * If the function returns `KEYGEN_SUCCESS`, then `ok` is set to 0 if the signature is invalid and non-zero if the signature is valid.
+     * If the function returns `AZIOT_KEYS_SUCCESS`, then `ok` is set to 0 if the signature is invalid and non-zero if the signature is valid.
      *
      * # Errors
      *
-     * - `KEYGEN_ERROR_INVALID_PARAMETER`:
+     * - `AZIOT_KEYS_ERROR_INVALID_PARAMETER`:
      *   - `id` is NULL.
      *   - The key specified by `id` does not exist.
      *   - `mechanism` is not a valid parameter type for the key specified by `id`.
      *
-     * - `KEYGEN_ERROR_EXTERNAL`
+     * - `AZIOT_KEYS_ERROR_EXTERNAL`
      */
-    KEYGEN_ERROR (*verify)(const char *id, KEYGEN_SIGN_MECHANISM mechanism, const void *parameters, const unsigned char *digest, uintptr_t digest_len, const unsigned char *signature, uintptr_t signature_len, int *ok);
-    KEYGEN_ERROR (*encrypt)(const char *id, KEYGEN_ENCRYPT_MECHANISM mechanism, const void *parameters, const unsigned char *plaintext, uintptr_t plaintext_len, unsigned char *ciphertext, uintptr_t *ciphertext_len);
-    KEYGEN_ERROR (*decrypt)(const char *id, KEYGEN_ENCRYPT_MECHANISM mechanism, const void *parameters, const unsigned char *ciphertext, uintptr_t ciphertext_len, unsigned char *plaintext, uintptr_t *plaintext_len);
-} KEYGEN_FUNCTION_LIST_2_0_0_0;
+    AZIOT_KEYS_STATUS (*verify)(const char *id, AZIOT_KEYS_SIGN_MECHANISM mechanism, const void *parameters, const unsigned char *digest, uintptr_t digest_len, const unsigned char *signature, uintptr_t signature_len, int *ok);
+    AZIOT_KEYS_STATUS (*encrypt)(const char *id, AZIOT_KEYS_ENCRYPT_MECHANISM mechanism, const void *parameters, const unsigned char *plaintext, uintptr_t plaintext_len, unsigned char *ciphertext, uintptr_t *ciphertext_len);
+    AZIOT_KEYS_STATUS (*decrypt)(const char *id, AZIOT_KEYS_ENCRYPT_MECHANISM mechanism, const void *parameters, const unsigned char *ciphertext, uintptr_t ciphertext_len, unsigned char *plaintext, uintptr_t *plaintext_len);
+} AZIOT_KEYS_FUNCTION_LIST_2_0_0_0;
 
 /**
- * Holds parameters for a sign operation with the [`KEYGEN_SIGN_MECHANISM_DERIVED`] mechanism.
+ * Holds parameters for a sign operation with the [`AZIOT_KEYS_SIGN_MECHANISM_DERIVED`] mechanism.
  */
 typedef struct {
     const unsigned char *derivation_data;
     uintptr_t derivation_data_len;
-    KEYGEN_SIGN_MECHANISM mechanism;
+    AZIOT_KEYS_SIGN_MECHANISM mechanism;
     const void *parameters;
-} KEYGEN_SIGN_DERIVED_PARAMETERS;
+} AZIOT_KEYS_SIGN_DERIVED_PARAMETERS;
 
 /**
- * Holds parameters for an encrypt operation with the [`KEYGEN_ENCRYPT_MECHANISM_AEAD`] mechanism.
+ * Holds parameters for an encrypt operation with the [`AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD`] mechanism.
  */
 typedef struct {
     const unsigned char *iv;
     uintptr_t iv_len;
     const unsigned char *aad;
     uintptr_t aad_len;
-} KEYGEN_ENCRYPT_AEAD_PARAMETERS;
+} AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS;
 
 /**
- * Holds parameters for an encrypt operation with the [`KEYGEN_ENCRYPT_MECHANISM_DERIVED`] mechanism.
+ * Holds parameters for an encrypt operation with the [`AZIOT_KEYS_ENCRYPT_MECHANISM_DERIVED`] mechanism.
  */
 typedef struct {
     const unsigned char *derivation_data;
     uintptr_t derivation_data_len;
-    KEYGEN_ENCRYPT_MECHANISM mechanism;
+    AZIOT_KEYS_ENCRYPT_MECHANISM mechanism;
     const void *parameters;
-} KEYGEN_ENCRYPT_DERIVED_PARAMETERS;
+} AZIOT_KEYS_ENCRYPT_DERIVED_PARAMETERS;
 
-typedef unsigned int KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM;
+typedef unsigned int AZIOT_KEYS_KEY_PAIR_PARAMETER_ALGORITHM;
 
 /**
  * AEAD mechanism, like AES-256-GCM.
  */
-#define KEYGEN_ENCRYPT_MECHANISM_AEAD 1
+#define AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD 1
 
 /**
- * Encrypt with a derived key. The `parameters` parameter must be set to a `KEYGEN_ENCRYPT_DERIVED_PARAMETERS` value.
+ * Encrypt with a derived key. The `parameters` parameter must be set to a `AZIOT_KEYS_ENCRYPT_DERIVED_PARAMETERS` value.
  */
-#define KEYGEN_ENCRYPT_MECHANISM_DERIVED 4
+#define AZIOT_KEYS_ENCRYPT_MECHANISM_DERIVED 4
 
 /**
  * RSA with no padding. Padding will have been performed by the caller.
  */
-#define KEYGEN_ENCRYPT_MECHANISM_RSA_NO_PADDING 3
+#define AZIOT_KEYS_ENCRYPT_MECHANISM_RSA_NO_PADDING 3
 
 /**
  * RSA with PKCS1 padding.
  */
-#define KEYGEN_ENCRYPT_MECHANISM_RSA_PKCS1 2
+#define AZIOT_KEYS_ENCRYPT_MECHANISM_RSA_PKCS1 2
 
 /**
  * The library encountered an error with an external resource, such as an I/O error or RPC error.
  */
-#define KEYGEN_ERROR_EXTERNAL 3
+#define AZIOT_KEYS_ERROR_EXTERNAL 3
 
 /**
  * The library encountered an unrecoverable error. The process should exit as soon as possible.
  */
-#define KEYGEN_ERROR_FATAL 1
+#define AZIOT_KEYS_ERROR_FATAL 1
 
 /**
  * The operation failed because a parameter has an invalid value.
  */
-#define KEYGEN_ERROR_INVALID_PARAMETER 2
+#define AZIOT_KEYS_ERROR_INVALID_PARAMETER 2
 
-#define KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM_EC 1
+#define AZIOT_KEYS_KEY_PAIR_PARAMETER_ALGORITHM_EC 1
 
-#define KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM_RSA 2
+#define AZIOT_KEYS_KEY_PAIR_PARAMETER_ALGORITHM_RSA 2
 
 /**
  * Used as the parameter type with `get_key_pair_parameter` to get the key algorithm.
  *
- * The value returned by `get_key_pair_parameter` will be one of the `KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM_*` constants.
+ * The value returned by `get_key_pair_parameter` will be one of the `AZIOT_KEYS_KEY_PAIR_PARAMETER_ALGORITHM_*` constants.
  */
-#define KEYGEN_KEY_PAIR_PARAMETER_TYPE_ALGORITHM 1
+#define AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_ALGORITHM 1
 
 /**
  * Used as the parameter type with `get_key_pair_parameter` to get the curve OID of an EC key.
  *
  * The value returned by `get_key_pair_parameter` will be a byte buffer containing a DER-encoded OID.
  */
-#define KEYGEN_KEY_PAIR_PARAMETER_TYPE_EC_CURVE_OID 2
+#define AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_EC_CURVE_OID 2
 
 /**
  * Used as the parameter type with `get_key_pair_parameter` to get the point of an EC key.
  *
  * The value returned by `get_key_pair_parameter` will be a byte buffer containing a DER-encoded octet string in RFC 5490 format.
  */
-#define KEYGEN_KEY_PAIR_PARAMETER_TYPE_EC_POINT 3
+#define AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_EC_POINT 3
 
 /**
  * Used as the parameter type with `get_key_pair_parameter` to get the exponent of an RSA key.
  *
  * The value returned by `get_key_pair_parameter` will be a byte buffer holding a big-endian bignum.
  */
-#define KEYGEN_KEY_PAIR_PARAMETER_TYPE_RSA_EXPONENT 5
+#define AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_RSA_EXPONENT 5
 
 /**
  * Used as the parameter type with `get_key_pair_parameter` to get the modulus of an RSA key.
  *
  * The value returned by `get_key_pair_parameter` will be a byte buffer holding a big-endian bignum.
  */
-#define KEYGEN_KEY_PAIR_PARAMETER_TYPE_RSA_MODULUS 4
+#define AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_RSA_MODULUS 4
 
 /**
- * Sign with a derived key. The `parameters` parameter must be set to a `KEYGEN_SIGN_DERIVED_PARAMETERS` value.
+ * Sign with a derived key. The `parameters` parameter must be set to a `AZIOT_KEYS_SIGN_DERIVED_PARAMETERS` value.
  */
-#define KEYGEN_SIGN_MECHANISM_DERIVED 3
+#define AZIOT_KEYS_SIGN_MECHANISM_DERIVED 3
 
 /**
  * ECDSA
  */
-#define KEYGEN_SIGN_MECHANISM_ECDSA 1
+#define AZIOT_KEYS_SIGN_MECHANISM_ECDSA 1
 
 /**
  * HMAC-SHA256
  */
-#define KEYGEN_SIGN_MECHANISM_HMAC_SHA256 2
+#define AZIOT_KEYS_SIGN_MECHANISM_HMAC_SHA256 2
 
 /**
  * The operation succeeded.
  */
-#define KEYGEN_SUCCESS 0
+#define AZIOT_KEYS_SUCCESS 0
 
 /**
  * Version 2.0.0.0
  */
-#define KEYGEN_VERSION_2_0_0_0 33554432
+#define AZIOT_KEYS_VERSION_2_0_0_0 33554432
 
 
 /**
@@ -301,12 +301,12 @@ typedef unsigned int KEYGEN_KEY_PAIR_PARAMETER_ALGORITHM;
  *
  * # Errors
  *
- * - `KEYGEN_ERROR_INVALID_PARAMETER`:
+ * - `AZIOT_KEYS_ERROR_INVALID_PARAMETER`:
  *   - `version` is not recognized by this implementation.
  *   - `pfunction_list` is NULL.
  */
-KEYGEN_ERROR KEYGEN_get_function_list(KEYGEN_VERSION version,
-                                      const KEYGEN_FUNCTION_LIST **pfunction_list);
+AZIOT_KEYS_STATUS aziot_keys_get_function_list(AZIOT_KEYS_VERSION version,
+                                               const AZIOT_KEYS_FUNCTION_LIST **pfunction_list);
 
 
 

--- a/key/aziot-keys/cbindgen.prelude.h
+++ b/key/aziot-keys/cbindgen.prelude.h
@@ -6,12 +6,12 @@
  *
  * # API conventions
  *
- * All functions return an `unsigned int` to indicate success or failure. See the [`KEYGEN_ERROR`] type's docs for details about these constants.
+ * All functions return an `unsigned int` to indicate success or failure. See the [`AZIOT_KEYS_STATUS`] type's docs for details about these constants.
  *
- * The only function exported by this library is [`KEYGEN_get_function_list`]. Call this function to get the version of the API
+ * The only function exported by this library is [`aziot_keys_get_function_list`]. Call this function to get the version of the API
  * that this library exports, as well as the function pointers to the key operations. See its docs for more details.
  *
- * All calls to [`KEYGEN_get_function_list`] or any function in [`KEYGEN_FUNCTION_LIST`] are serialized, ie a function will not be called
+ * All calls to [`aziot_keys_get_function_list`] or any function in [`AZIOT_KEYS_FUNCTION_LIST`] are serialized, ie a function will not be called
  * while another function is running. However, it is not guaranteed that all function calls will be made from the same operating system thread.
  * Thus, implementations do not need to worry about locking to prevent concurrent access, but should also not store data in thread-local storage.
  */

--- a/key/aziot-keys/src/key.rs
+++ b/key/aziot-keys/src/key.rs
@@ -3,7 +3,7 @@
 pub(crate) unsafe extern "C" fn create_key_if_not_exists(
 	id: *const std::os::raw::c_char,
 	length: usize,
-) -> crate::KEYGEN_ERROR {
+) -> crate::AZIOT_KEYS_STATUS {
 	crate::r#catch(|| {
 		let id = {
 			if id.is_null() {
@@ -32,7 +32,7 @@ pub(crate) unsafe extern "C" fn create_key_if_not_exists(
 
 pub(crate) unsafe extern "C" fn load_key(
 	id: *const std::os::raw::c_char,
-) -> crate::KEYGEN_ERROR {
+) -> crate::AZIOT_KEYS_STATUS {
 	crate::r#catch(|| {
 		let id = {
 			if id.is_null() {
@@ -57,7 +57,7 @@ pub(crate) unsafe extern "C" fn import_key(
 	id: *const std::os::raw::c_char,
 	bytes: *const u8,
 	bytes_len: usize,
-) -> crate::KEYGEN_ERROR {
+) -> crate::AZIOT_KEYS_STATUS {
 	crate::r#catch(|| {
 		let id = {
 			if id.is_null() {
@@ -91,7 +91,7 @@ pub(crate) unsafe extern "C" fn derive_key(
 	derivation_data_len: usize,
 	derived_key: *mut std::os::raw::c_uchar,
 	derived_key_len: *mut usize,
-) -> crate::KEYGEN_ERROR {
+) -> crate::AZIOT_KEYS_STATUS {
 	crate::r#catch(|| {
 		let base_id = {
 			if base_id.is_null() {
@@ -139,10 +139,10 @@ pub(crate) unsafe extern "C" fn derive_key(
 
 pub(crate) unsafe fn sign(
 	locations: &[crate::implementation::Location],
-	mechanism: crate::KEYGEN_SIGN_MECHANISM,
+	mechanism: crate::AZIOT_KEYS_SIGN_MECHANISM,
 	parameters: *const std::ffi::c_void,
 	digest: &[u8],
-) -> Result<(usize, Vec<u8>), crate::KEYGEN_ERROR> {
+) -> Result<(usize, Vec<u8>), crate::AZIOT_KEYS_STATUS> {
 	use hmac::{Mac, NewMac};
 
 	let key = match load_inner(locations)? {
@@ -151,14 +151,14 @@ pub(crate) unsafe fn sign(
 	};
 
 	let (key, mechanism, _) =
-		if mechanism == crate::KEYGEN_SIGN_MECHANISM_DERIVED {
+		if mechanism == crate::AZIOT_KEYS_SIGN_MECHANISM_DERIVED {
 			derive_key_for_sign(&key, parameters)?
 		}
 		else {
 			(key, mechanism, parameters)
 		};
 
-	if mechanism != crate::KEYGEN_SIGN_MECHANISM_HMAC_SHA256 {
+	if mechanism != crate::AZIOT_KEYS_SIGN_MECHANISM_HMAC_SHA256 {
 		return Err(crate::implementation::err_invalid_parameter("mechanism", "unrecognized value"));
 	}
 
@@ -175,7 +175,7 @@ pub(crate) unsafe fn verify(
 	locations: &[crate::implementation::Location],
 	digest: &[u8],
 	signature: &[u8],
-) -> Result<bool, crate::KEYGEN_ERROR> {
+) -> Result<bool, crate::AZIOT_KEYS_STATUS> {
 	use hmac::{Mac, NewMac};
 
 	let key = match load_inner(locations)? {
@@ -201,24 +201,24 @@ pub(crate) unsafe fn verify(
 
 pub(crate) unsafe fn encrypt(
 	locations: &[crate::implementation::Location],
-	mechanism: crate::KEYGEN_ENCRYPT_MECHANISM,
+	mechanism: crate::AZIOT_KEYS_ENCRYPT_MECHANISM,
 	parameters: *const std::ffi::c_void,
 	plaintext: &[u8],
-) -> Result<(usize, Vec<u8>), crate::KEYGEN_ERROR> {
+) -> Result<(usize, Vec<u8>), crate::AZIOT_KEYS_STATUS> {
 	let key = match load_inner(locations)? {
 		Some(key) => key,
 		None => return Err(crate::implementation::err_invalid_parameter("id", "key not found")),
 	};
 
 	let (key, mechanism, parameters) =
-		if mechanism == crate::KEYGEN_ENCRYPT_MECHANISM_DERIVED {
+		if mechanism == crate::AZIOT_KEYS_ENCRYPT_MECHANISM_DERIVED {
 			derive_key_for_encrypt(&key, parameters)?
 		}
 		else {
 			(key, mechanism, parameters)
 		};
 
-	if mechanism != crate::KEYGEN_ENCRYPT_MECHANISM_AEAD {
+	if mechanism != crate::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD {
 		return Err(crate::implementation::err_invalid_parameter("mechanism", "unrecognized value"));
 	}
 
@@ -227,7 +227,7 @@ pub(crate) unsafe fn encrypt(
 			return Err(crate::implementation::err_invalid_parameter("parameters", "expected non-NULL"));
 		}
 
-		let parameters = parameters as *const crate::KEYGEN_ENCRYPT_AEAD_PARAMETERS;
+		let parameters = parameters as *const crate::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS;
 		let parameters = &*parameters;
 
 		let iv = std::slice::from_raw_parts(parameters.iv, parameters.iv_len);
@@ -248,24 +248,24 @@ pub(crate) unsafe fn encrypt(
 
 pub(crate) unsafe fn decrypt(
 	locations: &[crate::implementation::Location],
-	mechanism: crate::KEYGEN_ENCRYPT_MECHANISM,
+	mechanism: crate::AZIOT_KEYS_ENCRYPT_MECHANISM,
 	parameters: *const std::ffi::c_void,
 	ciphertext: &[u8],
-) -> Result<(usize, Vec<u8>), crate::KEYGEN_ERROR> {
+) -> Result<(usize, Vec<u8>), crate::AZIOT_KEYS_STATUS> {
 	let key = match load_inner(locations)? {
 		Some(key) => key,
 		None => return Err(crate::implementation::err_invalid_parameter("id", "key not found")),
 	};
 
 	let (key, mechanism, parameters) =
-		if mechanism == crate::KEYGEN_ENCRYPT_MECHANISM_DERIVED {
+		if mechanism == crate::AZIOT_KEYS_ENCRYPT_MECHANISM_DERIVED {
 			derive_key_for_encrypt(&key, parameters)?
 		}
 		else {
 			(key, mechanism, parameters)
 		};
 
-	if mechanism != crate::KEYGEN_ENCRYPT_MECHANISM_AEAD {
+	if mechanism != crate::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD {
 		return Err(crate::implementation::err_invalid_parameter("mechanism", "unrecognized value"));
 	}
 
@@ -274,7 +274,7 @@ pub(crate) unsafe fn decrypt(
 			return Err(crate::implementation::err_invalid_parameter("parameters", "expected non-NULL"));
 		}
 
-		let parameters = parameters as *const crate::KEYGEN_ENCRYPT_AEAD_PARAMETERS;
+		let parameters = parameters as *const crate::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS;
 		let parameters = &*parameters;
 
 		let iv = std::slice::from_raw_parts(parameters.iv, parameters.iv_len);
@@ -299,7 +299,7 @@ pub(crate) unsafe fn decrypt(
 	Ok((plaintext.len(), plaintext))
 }
 
-fn load_inner(locations: &[crate::implementation::Location]) -> Result<Option<Vec<u8>>, crate::KEYGEN_ERROR> {
+fn load_inner(locations: &[crate::implementation::Location]) -> Result<Option<Vec<u8>>, crate::AZIOT_KEYS_STATUS> {
 	for location in locations {
 		match location {
 			crate::implementation::Location::Filesystem(path) => match std::fs::read(path) {
@@ -316,7 +316,7 @@ fn load_inner(locations: &[crate::implementation::Location]) -> Result<Option<Ve
 	Err(crate::implementation::err_external("no valid location for symmetric key"))
 }
 
-fn create_inner(locations: &[crate::implementation::Location], bytes: &[u8]) -> Result<(), crate::KEYGEN_ERROR> {
+fn create_inner(locations: &[crate::implementation::Location], bytes: &[u8]) -> Result<(), crate::AZIOT_KEYS_STATUS> {
 	for location in locations {
 		match location {
 			crate::implementation::Location::Filesystem(path) => {
@@ -335,12 +335,12 @@ fn create_inner(locations: &[crate::implementation::Location], bytes: &[u8]) -> 
 unsafe fn derive_key_for_sign(
 	key: &[u8],
 	parameters: *const std::ffi::c_void,
-) -> Result<(Vec<u8>, crate::KEYGEN_SIGN_MECHANISM, *const std::ffi::c_void), crate::KEYGEN_ERROR> {
+) -> Result<(Vec<u8>, crate::AZIOT_KEYS_SIGN_MECHANISM, *const std::ffi::c_void), crate::AZIOT_KEYS_STATUS> {
 	if parameters.is_null() {
 		return Err(crate::implementation::err_invalid_parameter("parameters", "expected non-NULL"));
 	}
 
-	let parameters = parameters as *const crate::KEYGEN_SIGN_DERIVED_PARAMETERS;
+	let parameters = parameters as *const crate::AZIOT_KEYS_SIGN_DERIVED_PARAMETERS;
 	let parameters = &*parameters;
 
 	let signature = derive_key_common(key, parameters.derivation_data, parameters.derivation_data_len)?;
@@ -351,12 +351,12 @@ unsafe fn derive_key_for_sign(
 unsafe fn derive_key_for_encrypt(
 	key: &[u8],
 	parameters: *const std::ffi::c_void,
-) -> Result<(Vec<u8>, crate::KEYGEN_ENCRYPT_MECHANISM, *const std::ffi::c_void), crate::KEYGEN_ERROR> {
+) -> Result<(Vec<u8>, crate::AZIOT_KEYS_ENCRYPT_MECHANISM, *const std::ffi::c_void), crate::AZIOT_KEYS_STATUS> {
 	if parameters.is_null() {
 		return Err(crate::implementation::err_invalid_parameter("parameters", "expected non-NULL"));
 	}
 
-	let parameters = parameters as *const crate::KEYGEN_ENCRYPT_DERIVED_PARAMETERS;
+	let parameters = parameters as *const crate::AZIOT_KEYS_ENCRYPT_DERIVED_PARAMETERS;
 	let parameters = &*parameters;
 
 	let signature = derive_key_common(key, parameters.derivation_data, parameters.derivation_data_len)?;
@@ -368,7 +368,7 @@ unsafe fn derive_key_common(
 	key: &[u8],
 	derivation_data: *const std::os::raw::c_uchar,
 	derivation_data_len: usize,
-) -> Result<Vec<u8>, crate::KEYGEN_ERROR> {
+) -> Result<Vec<u8>, crate::AZIOT_KEYS_STATUS> {
 	use hmac::{Mac, NewMac};
 
 	if derivation_data.is_null() {

--- a/openssl-build/Cargo.toml
+++ b/openssl-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openssl-build"
 version = "0.1.0"
 license = "MIT"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/openssl-sys2/Cargo.toml
+++ b/openssl-sys2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openssl-sys2"
 version = "0.1.0"
 license = "MIT"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 build = "build/main.rs"
 

--- a/openssl2/Cargo.toml
+++ b/openssl2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openssl2"
 version = "0.1.0"
 license = "MIT"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 build = "build/main.rs"
 

--- a/pkcs11/pkcs11-openssl-engine/Cargo.toml
+++ b/pkcs11/pkcs11-openssl-engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pkcs11-openssl-engine"
 version = "0.1.0"
 license = "MIT"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 build = "build/main.rs"
 

--- a/pkcs11/pkcs11-sys/Cargo.toml
+++ b/pkcs11/pkcs11-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pkcs11-sys"
 version = "0.1.0"
 license = "MIT"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]

--- a/pkcs11/pkcs11-test/Cargo.toml
+++ b/pkcs11/pkcs11-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pkcs11-test"
 version = "0.1.0"
 license = "MIT"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 

--- a/pkcs11/pkcs11/Cargo.toml
+++ b/pkcs11/pkcs11/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pkcs11"
 version = "0.1.0"
 license = "MIT"
-authors = ["Arnav Singh <arsing@microsoft.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 


### PR DESCRIPTION
4c6a200f6f92592d2c3560349c19d7421a042b6d renamed many things as part of
renaming libiothsm-keygen to libaziot-keys, but forgot the names of
the exported items. This commit finishes the job.

One special case is `KEYGEN_get_function_list` - it was renamed not to
`AZIOT_KEYS_get_function_list` but to `aziot_keys_get_function_list`.
The upper-case prefix was incorrect for function names.

One more related change in this commit is to stop compiling
the `cbindgen_unused_` functions into the final libaziot-keys cdylib.
These fns are a hack to get cbindgen to emit structs that are otherwise
not referenced by any function. But before this change, these functions would
still end up being compiled into the final binary.