### PR TITLE
Fix URI for certificate delete requests

### DIFF
--- a/cert/aziot-cert-client-async/src/lib.rs
+++ b/cert/aziot-cert-client-async/src/lib.rs
@@ -178,8 +178,6 @@ async fn request_no_content<TRequest>(
 where
 	TRequest: serde::Serialize,
 {
-	let uri = format!("http://foo{}", uri);
-
 	let req =
 		hyper::Request::builder()
 		.method(method)


### PR DESCRIPTION
The call to `request_no_content` already provides the full formatted URI as the function parameter. Therefore, `request_no_content` should not prepend anything to its uri parameter (this was causing uris to start with "http://foohttp://foo").