### PR TITLE
Ensure aziot-keys is built before aziot-keyd.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ version = "0.1.0"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
+ "aziot-keys",
  "backtrace",
  "base64",
  "futures-util",

--- a/key/aziot-keyd/Cargo.toml
+++ b/key/aziot-keyd/Cargo.toml
@@ -23,4 +23,5 @@ url = "2"
 
 aziot-key-common = { path = "../aziot-key-common" }
 aziot-key-common-http = { path = "../aziot-key-common-http" }
+aziot-keys = { path = "../aziot-keys" }
 http-common = { path = "../../http-common" }


### PR DESCRIPTION
aziot-keyd requires aziot-keys to have been built first so that the linker
can link it in. But before this change this was not guaranteed to happen.

This went unnoticed until now because the parallel build would usually finish
building aziot-keys before it got around to linking aziot-keyd.
But Micah happened to have a machine that ended up linking aziot-keyd first
and complained about having no `libaziot_keys.so` to link to.