### PR TITLE
Restore logging of internal errors (and all other errors) in the HTTP servers.

### DIFF
--- a/key/aziot-keyd/src/http/mod.rs
+++ b/key/aziot-keyd/src/http/mod.rs
@@ -31,15 +31,24 @@ http_common::make_server! {
 }
 
 fn to_http_error(err: &aziot_keyd::Error) -> http_common::server::Error {
+	let error_message = http_common::server::error_to_message(err);
+
+	// TODO: When we get distributed tracing, associate these logs with the tracing ID.
+	for line in error_message.split('\n') {
+		eprintln!("!!! {}", line);
+	}
+
 	match err {
+		// Do not use error_message because we don't want to leak internal errors to the client.
+		// Just return the top-level error, ie "internal error"
 		aziot_keyd::Error::Internal(_) => http_common::server::Error {
 			status_code: hyper::StatusCode::INTERNAL_SERVER_ERROR,
-			message: err.to_string().into(), // Do not use http_common::server::error_to_message for Error::Internal because we don't want to leak internal errors
+			message: err.to_string().into(),
 		},
 
-		err @ aziot_keyd::Error::InvalidParameter(_) => http_common::server::Error {
+		aziot_keyd::Error::InvalidParameter(_) => http_common::server::Error {
 			status_code: hyper::StatusCode::BAD_REQUEST,
-			message: http_common::server::error_to_message(err).into(),
+			message: error_message.into(),
 		},
 	}
 }


### PR DESCRIPTION
Internal errors aren't returned to the caller and ought to be logged to
the server console. This was inconsistently implemented before -
only for aziot-certd - and even that was lost in
294e9aa099ad47b47be91e360288d757b4a61b05

This commit brings back the logging for internal errors and also logs
non-internal errors, and does so for all three of aziot-keyd, -certd and
-identityd.