### PR TITLE
Enable Kodiak bot to auto-merge 

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,0 +1,37 @@
+# https://kodiakhq.com/docs/config-reference contains all parameters explained
+version = 1
+
+[update]
+# Update a PR whenever out of date with the base branch. The PR will be updated regardless of 
+# merge requirements (e.g. failing status checks, missing reviews).
+always = false # default: false
+
+# When enabled, Kodiak will only update PRs that have an automerge label. When disabled, any PR.
+require_automerge_label = true # default: true
+
+[merge]
+# Merge method for Kodiak to use.
+method = "squash" # default: "merge"
+
+# Once a PR is merged, delete the branch.
+delete_branch_on_merge = true # default: false
+
+# When enabled, Kodiak will only update PRs that have an automerge label. 
+# When disabled, automatically merge any PR that passes all required checks.
+require_automerge_label = true # default: true
+
+# By default, Kodiak will only act on PRs that have this label.
+automerge_label = "ready-to-merge" # default: "automerge"
+
+[merge.message]
+# use title of PR for merge commit.
+title = "pull_request_title" # default: "github_default"
+
+# use body of PR for merge commit.
+body = "pull_request_body" # default: "github_default"
+
+# Add the pull request author as a coauthor of the merge commit using
+include_pull_request_author = false # default: false
+
+# remove html comments to auto remove PR templates.
+strip_html_comments = true # default: false


### PR DESCRIPTION
Enabling the Kodiak bot to squash and auto-merge. All settings have mimic the Azure/iotedge repo to make it easier for contributors to follow similar labels. 