### PR TITLE
[http-common] use DynRangeBounds for ApiVersion

### DIFF
--- a/cert/aziot-cert-common-http/src/lib.rs
+++ b/cert/aziot-cert-common-http/src/lib.rs
@@ -6,14 +6,12 @@
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ApiVersion {
 	V2020_09_01,
-	Max,
 }
 
 impl std::fmt::Display for ApiVersion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.write_str(match self {
 			ApiVersion::V2020_09_01 => "2020-09-01",
-			ApiVersion::Max => "MAX",
 		})
 	}
 }

--- a/cert/aziot-certd/src/http/create.rs
+++ b/cert/aziot-certd/src/http/create.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_cert_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_cert_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_cert_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/cert/aziot-certd/src/http/create.rs
+++ b/cert/aziot-certd/src/http/create.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_cert_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_cert_common_http::ApiVersion::V2020_09_01)..(aziot_cert_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_cert_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/cert/aziot-certd/src/http/get_or_delete.rs
+++ b/cert/aziot-certd/src/http/get_or_delete.rs
@@ -13,8 +13,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_cert_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_cert_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_cert_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/cert/aziot-certd/src/http/get_or_delete.rs
+++ b/cert/aziot-certd/src/http/get_or_delete.rs
@@ -13,8 +13,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_cert_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_cert_common_http::ApiVersion::V2020_09_01)..(aziot_cert_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_cert_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/cert/aziot-certd/src/http/import.rs
+++ b/cert/aziot-certd/src/http/import.rs
@@ -13,8 +13,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_cert_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_cert_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_cert_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/cert/aziot-certd/src/http/import.rs
+++ b/cert/aziot-certd/src/http/import.rs
@@ -13,8 +13,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_cert_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_cert_common_http::ApiVersion::V2020_09_01)..(aziot_cert_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_cert_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/http-common/src/dynrange.rs
+++ b/http-common/src/dynrange.rs
@@ -1,0 +1,42 @@
+use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+
+/// An object-safe version of `std::ops::RangeBounds`.
+pub trait DynRangeBounds<T>
+where
+    T: std::cmp::PartialOrd,
+{
+    fn contains(&self, item: &T) -> bool;
+}
+
+impl<T> DynRangeBounds<T> for Box<dyn DynRangeBounds<T>>
+where
+    T: std::cmp::PartialOrd,
+{
+    fn contains(&self, item: &T) -> bool {
+        (**self).contains(item)
+    }
+}
+
+macro_rules! impl_dynrange {
+    ($($range:ident),*) => {$(
+        impl<T> DynRangeBounds<T> for $range<T>
+            where T: std::cmp::PartialOrd
+        {
+            fn contains(&self, item: &T) -> bool {
+               $range::contains(self, item)
+            }
+        }
+    )*};
+}
+
+impl_dynrange!(Range, RangeFrom, RangeTo, RangeToInclusive, RangeInclusive);
+
+// RangeFull doesn't have a generic parameter associated with it.
+impl<T> DynRangeBounds<T> for RangeFull
+where
+    T: std::cmp::PartialOrd,
+{
+    fn contains(&self, _item: &T) -> bool {
+        true
+    }
+}

--- a/http-common/src/dynrange.rs
+++ b/http-common/src/dynrange.rs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+
 use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 /// An object-safe version of `std::ops::RangeBounds`.

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -12,6 +12,9 @@
 	clippy::type_complexity,
 )]
 
+mod dynrange;
+pub use dynrange::DynRangeBounds;
+
 mod connector;
 pub use connector::{Connector, ConnectorError, Stream};
 #[cfg(feature = "tokio02")]

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use crate::DynRangeBounds;
+
 #[macro_export]
 macro_rules! make_server {
 	(
@@ -211,8 +213,8 @@ macro_rules! make_server {
 
 // DEVNOTE: Set *Body assoc type to `serde::de::IgnoredAny` if the corresponding method isn't overridden.
 pub trait Route: Sized {
-	type ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion>;
+	type ApiVersion: std::cmp::PartialOrd;
+	fn api_version() -> Box<dyn DynRangeBounds<Self::ApiVersion>>;
 
 	type Server;
 	fn from_uri(

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -214,7 +214,7 @@ macro_rules! make_server {
 // DEVNOTE: Set *Body assoc type to `serde::de::IgnoredAny` if the corresponding method isn't overridden.
 pub trait Route: Sized {
 	type ApiVersion: std::cmp::PartialOrd;
-	fn api_version() -> Box<dyn DynRangeBounds<Self::ApiVersion>>;
+	fn api_version() -> &'static dyn DynRangeBounds<Self::ApiVersion>;
 
 	type Server;
 	fn from_uri(

--- a/identity/aziot-identity-common-http/src/lib.rs
+++ b/identity/aziot-identity-common-http/src/lib.rs
@@ -6,14 +6,12 @@
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ApiVersion {
 	V2020_09_01,
-	Max,
 }
 
 impl std::fmt::Display for ApiVersion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.write_str(match self {
 			ApiVersion::V2020_09_01 => "2020-09-01",
-			ApiVersion::Max => "MAX",
 		})
 	}
 }

--- a/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
+++ b/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
+++ b/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_identity_common_http::ApiVersion::V2020_09_01)..(aziot_identity_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/get_caller_identity.rs
+++ b/identity/aziot-identityd/src/http/get_caller_identity.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/get_caller_identity.rs
+++ b/identity/aziot-identityd/src/http/get_caller_identity.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_identity_common_http::ApiVersion::V2020_09_01)..(aziot_identity_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/get_device_identity.rs
+++ b/identity/aziot-identityd/src/http/get_device_identity.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/get_device_identity.rs
+++ b/identity/aziot-identityd/src/http/get_device_identity.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_identity_common_http::ApiVersion::V2020_09_01)..(aziot_identity_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/get_trust_bundle.rs
+++ b/identity/aziot-identityd/src/http/get_trust_bundle.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/get_trust_bundle.rs
+++ b/identity/aziot-identityd/src/http/get_trust_bundle.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_identity_common_http::ApiVersion::V2020_09_01)..(aziot_identity_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -13,8 +13,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_identity_common_http::ApiVersion::V2020_09_01)..(aziot_identity_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -13,8 +13,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/reprovision_device.rs
+++ b/identity/aziot-identityd/src/http/reprovision_device.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/identity/aziot-identityd/src/http/reprovision_device.rs
+++ b/identity/aziot-identityd/src/http/reprovision_device.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_identity_common_http::ApiVersion::V2020_09_01)..(aziot_identity_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_identity_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-key-common-http/src/lib.rs
+++ b/key/aziot-key-common-http/src/lib.rs
@@ -6,14 +6,12 @@
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ApiVersion {
 	V2020_09_01,
-	Max,
 }
 
 impl std::fmt::Display for ApiVersion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.write_str(match self {
 			ApiVersion::V2020_09_01 => "2020-09-01",
-			ApiVersion::Max => "MAX",
 		})
 	}
 }

--- a/key/aziot-keyd/src/http/create_derived_key.rs
+++ b/key/aziot-keyd/src/http/create_derived_key.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_key_common_http::ApiVersion::V2020_09_01)..(aziot_key_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/create_derived_key.rs
+++ b/key/aziot-keyd/src/http/create_derived_key.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/create_key_if_not_exists.rs
+++ b/key/aziot-keyd/src/http/create_key_if_not_exists.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_key_common_http::ApiVersion::V2020_09_01)..(aziot_key_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/create_key_if_not_exists.rs
+++ b/key/aziot-keyd/src/http/create_key_if_not_exists.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/create_key_pair_if_not_exists.rs
+++ b/key/aziot-keyd/src/http/create_key_pair_if_not_exists.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_key_common_http::ApiVersion::V2020_09_01)..(aziot_key_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/create_key_pair_if_not_exists.rs
+++ b/key/aziot-keyd/src/http/create_key_pair_if_not_exists.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/decrypt.rs
+++ b/key/aziot-keyd/src/http/decrypt.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_key_common_http::ApiVersion::V2020_09_01)..(aziot_key_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/decrypt.rs
+++ b/key/aziot-keyd/src/http/decrypt.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/encrypt.rs
+++ b/key/aziot-keyd/src/http/encrypt.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_key_common_http::ApiVersion::V2020_09_01)..(aziot_key_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/encrypt.rs
+++ b/key/aziot-keyd/src/http/encrypt.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/export_derived_key.rs
+++ b/key/aziot-keyd/src/http/export_derived_key.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_key_common_http::ApiVersion::V2020_09_01)..(aziot_key_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/export_derived_key.rs
+++ b/key/aziot-keyd/src/http/export_derived_key.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
+++ b/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
@@ -13,8 +13,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_key_common_http::ApiVersion::V2020_09_01)..(aziot_key_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
+++ b/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
@@ -13,8 +13,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/load.rs
+++ b/key/aziot-keyd/src/http/load.rs
@@ -14,8 +14,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/load.rs
+++ b/key/aziot-keyd/src/http/load.rs
@@ -14,8 +14,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_key_common_http::ApiVersion::V2020_09_01)..(aziot_key_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;
@@ -28,7 +28,7 @@ impl http_common::server::Route for Route {
 
 		let type_ = &captures["type"];
 		let type_ = percent_encoding::percent_decode_str(type_).decode_utf8().ok()?;
-	
+
 		let key_id = &captures["keyId"];
 		let key_id = percent_encoding::percent_decode_str(key_id).decode_utf8().ok()?;
 

--- a/key/aziot-keyd/src/http/sign.rs
+++ b/key/aziot-keyd/src/http/sign.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> std::ops::Range<Self::ApiVersion> {
-		(aziot_key_common_http::ApiVersion::V2020_09_01)..(aziot_key_common_http::ApiVersion::Max)
+	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
+		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;

--- a/key/aziot-keyd/src/http/sign.rs
+++ b/key/aziot-keyd/src/http/sign.rs
@@ -6,8 +6,8 @@ pub(super) struct Route {
 
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
-	fn api_version() -> Box<dyn http_common::DynRangeBounds<Self::ApiVersion>> {
-		Box::new((aziot_key_common_http::ApiVersion::V2020_09_01)..)
+	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+		&((aziot_key_common_http::ApiVersion::V2020_09_01)..)
 	}
 
 	type Server = super::Server;


### PR DESCRIPTION
This PR removes the need to have a dummy "MAX" API Version, and allows us to use the standard Rust range syntax (albeit through a `&'static dyn` trait object)