### PR TITLE
[http-common] Use `async_trait` for http_common::Route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
+name = "async-trait"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +97,7 @@ dependencies = [
 name = "aziot-certd"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "aziot-cert-common-http",
  "aziot-key-client",
  "aziot-key-common",
@@ -195,6 +207,7 @@ dependencies = [
 name = "aziot-identityd"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "aziot-cert-client-async",
  "aziot-cert-common-http",
  "aziot-dps-client-async",
@@ -308,6 +321,7 @@ dependencies = [
 name = "aziot-keyd"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "aziot-key-common",
  "aziot-key-common-http",
  "aziot-keys",
@@ -708,6 +722,7 @@ dependencies = [
 name = "http-common"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64",
  "futures-util",
  "http",

--- a/cert/aziot-certd/Cargo.toml
+++ b/cert/aziot-certd/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 build = "build/main.rs"
 
 [dependencies]
+async-trait = "0.1"
 backtrace = "0.3"
 base64 = "0.12"
 foreign-types-shared = "0.1"

--- a/cert/aziot-certd/src/http/create.rs
+++ b/cert/aziot-certd/src/http/create.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_certd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_cert_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -32,29 +33,27 @@ impl http_common::server::Route for Route {
 
 	type PostBody = aziot_cert_common_http::create_cert::Request;
 	type PostResponse = aziot_cert_common_http::create_cert::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let pem = aziot_certd::Server::create_cert(
-				self.inner,
-				body.cert_id,
-				body.csr.0,
-				body.issuer.map(|aziot_cert_common_http::create_cert::Issuer { cert_id, private_key_handle }| (cert_id, private_key_handle)),
-			).await;
-			let pem = match pem {
-				Ok(pem) => pem,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let pem = aziot_certd::Server::create_cert(
+			self.inner,
+			body.cert_id,
+			body.csr.0,
+			body.issuer.map(|aziot_cert_common_http::create_cert::Issuer { cert_id, private_key_handle }| (cert_id, private_key_handle)),
+		).await;
+		let pem = match pem {
+			Ok(pem) => pem,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_cert_common_http::create_cert::Response {
-				pem: aziot_cert_common_http::Pem(pem),
-			};
-			Ok((hyper::StatusCode::CREATED, Some(res)))
-		})
+		let res = aziot_cert_common_http::create_cert::Response {
+			pem: aziot_cert_common_http::Pem(pem),
+		};
+		Ok((hyper::StatusCode::CREATED, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/cert/aziot-certd/src/http/get_or_delete.rs
+++ b/cert/aziot-certd/src/http/get_or_delete.rs
@@ -11,6 +11,7 @@ pub(super) struct Route {
 	cert_id: String,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_cert_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -36,36 +37,32 @@ impl http_common::server::Route for Route {
 
 	type DeleteBody = serde::de::IgnoredAny;
 	type DeleteResponse = ();
-	fn delete(self, _body: Option<Self::DeleteBody>) -> http_common::server::RouteResponse<Option<Self::DeleteResponse>> {
-		Box::pin(async move {
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+	async fn delete(self, _body: Option<Self::DeleteBody>) -> http_common::server::RouteResponse<Option<Self::DeleteResponse>> {
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			if let Err(err) = inner.delete_cert(&self.cert_id) {
-				return Err(super::to_http_error(&err));
-			}
+		if let Err(err) = inner.delete_cert(&self.cert_id) {
+			return Err(super::to_http_error(&err));
+		}
 
-			Ok((hyper::StatusCode::NO_CONTENT, None))
-		})
+		Ok((hyper::StatusCode::NO_CONTENT, None))
 	}
 
 	type GetResponse = aziot_cert_common_http::get_cert::Response;
-	fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
-		Box::pin(async move {
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+	async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let pem = inner.get_cert(&self.cert_id);
-			let pem = match pem {
-				Ok(pem) => pem,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let pem = inner.get_cert(&self.cert_id);
+		let pem = match pem {
+			Ok(pem) => pem,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_cert_common_http::get_cert::Response {
-				pem: aziot_cert_common_http::Pem(pem),
-			};
-			Ok((hyper::StatusCode::OK, res))
-		})
+		let res = aziot_cert_common_http::get_cert::Response {
+			pem: aziot_cert_common_http::Pem(pem),
+		};
+		Ok((hyper::StatusCode::OK, res))
 	}
 
 	type PostBody = serde::de::IgnoredAny;

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1"
 base64 = "0.12"
 futures-util = "0.3"
 http = "0.2"

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -10,6 +10,7 @@
 	clippy::must_use_candidate,
 	clippy::similar_names,
 	clippy::type_complexity,
+	clippy::too_many_lines,
 )]
 
 mod dynrange;

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -9,8 +9,8 @@
 	clippy::module_name_repetitions,
 	clippy::must_use_candidate,
 	clippy::similar_names,
-	clippy::type_complexity,
 	clippy::too_many_lines,
+	clippy::type_complexity,
 )]
 
 mod dynrange;

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -319,7 +319,11 @@ pub fn json_response(status_code: hyper::StatusCode, body: Option<&impl serde::S
 	res
 }
 
-mod fake_server {
+/// This server is never actually used, but is useful to ensure that the macro
+/// works as expected.
+mod test_server {
+	use crate as http_common;
+
 	#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 	pub enum ApiVersion {
 		FAKE,
@@ -344,24 +348,23 @@ mod fake_server {
 		}
 	}
 
-	use crate as http_common;
 
 	http_common::make_server! {
 		server: Server,
 		api_version: ApiVersion,
 		routes: [
-			fake_route::Route,
+			test_route::Route,
 		],
 	}
 
-	pub(crate) struct Server;
+	pub struct Server;
 
-	mod fake_route {
+	mod test_route {
 		use crate as http_common;
 
 		use super::ApiVersion;
 
-		pub(super) struct Route {}
+		pub(super) struct Route;
 
 		#[async_trait::async_trait]
 		impl http_common::server::Route for Route {
@@ -376,7 +379,7 @@ mod fake_server {
 				_path: &str,
 				_query: &[(std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>)],
 			) -> Option<Self> {
-				Some(Route {})
+				Some(Route)
 			}
 
 			type DeleteBody = serde::de::IgnoredAny;
@@ -390,7 +393,5 @@ mod fake_server {
 			type PutBody = serde::de::IgnoredAny;
 			type PutResponse = ();
 		}
-
 	}
-
 }

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -20,7 +20,6 @@ macro_rules! make_server {
 				std::task::Poll::Ready(Ok(()))
 			}
 
-			#[allow(clippy::too_many_lines)]
 			fn call(&mut self, req: hyper::Request<hyper::Body>) -> Self::Future {
 				fn call_inner(
 					this: &mut $server_ty,
@@ -325,7 +324,7 @@ mod test_server {
 	use crate as http_common;
 
 	#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-	pub enum ApiVersion {
+	enum ApiVersion {
 		FAKE,
 	}
 
@@ -357,7 +356,7 @@ mod test_server {
 		],
 	}
 
-	pub struct Server;
+	struct Server;
 
 	mod test_route {
 		use crate as http_common;

--- a/identity/aziot-identityd/Cargo.toml
+++ b/identity/aziot-identityd/Cargo.toml
@@ -9,6 +9,7 @@ The code used for Identity Service.
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1"
 base64 = "0.12"
 chrono = "0.4"
 clap = "2.31"

--- a/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
+++ b/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_identityd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -29,58 +30,54 @@ impl http_common::server::Route for Route {
 	type DeleteResponse = ();
 
 	type GetResponse = aziot_identity_common_http::get_module_identities::Response;
-	fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
-		Box::pin(async move {
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+	async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let user = aziot_identityd::auth::Uid(0);
-			let auth_id = match inner.authenticator.authenticate(user) {
-				Ok(auth_id) => auth_id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let user = aziot_identityd::auth::Uid(0);
+		let auth_id = match inner.authenticator.authenticate(user) {
+			Ok(auth_id) => auth_id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			//TODO: get uid from UDS
-			let identities = match inner.get_identities(auth_id, "aziot").await {
-				Ok(v) => v,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
-			let res = aziot_identity_common_http::get_module_identities::Response {
-				identities,
-			};
-			Ok((hyper::StatusCode::OK, res))
-		})
+		//TODO: get uid from UDS
+		let identities = match inner.get_identities(auth_id, "aziot").await {
+			Ok(v) => v,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
+		let res = aziot_identity_common_http::get_module_identities::Response {
+			identities,
+		};
+		Ok((hyper::StatusCode::OK, res))
 	}
 
 	type PostBody = aziot_identity_common_http::create_module_identity::Request;
 	type PostResponse = aziot_identity_common_http::create_module_identity::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let user = aziot_identityd::auth::Uid(0);
-			let auth_id = match inner.authenticator.authenticate(user) {
-				Ok(auth_id) => auth_id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let user = aziot_identityd::auth::Uid(0);
+		let auth_id = match inner.authenticator.authenticate(user) {
+			Ok(auth_id) => auth_id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			//TODO: get uid from UDS
-			let identity = match inner.create_identity(auth_id, &body.id_type, &body.module_id).await {
-				Ok(id) => id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		//TODO: get uid from UDS
+		let identity = match inner.create_identity(auth_id, &body.id_type, &body.module_id).await {
+			Ok(id) => id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_identity_common_http::create_module_identity::Response {
-				identity,
-			};
-			Ok((hyper::StatusCode::OK, Some(res)))
-		})
+		let res = aziot_identity_common_http::create_module_identity::Response {
+			identity,
+		};
+		Ok((hyper::StatusCode::OK, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/identity/aziot-identityd/src/http/get_caller_identity.rs
+++ b/identity/aziot-identityd/src/http/get_caller_identity.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_identityd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -29,27 +30,25 @@ impl http_common::server::Route for Route {
 	type DeleteResponse = ();
 
 	type GetResponse = aziot_identity_common_http::get_module_identity::Response;
-	fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
-		Box::pin(async move {
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+	async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let user = aziot_identityd::auth::Uid(0);
-			let auth_id = match inner.authenticator.authenticate(user) {
-				Ok(auth_id) => auth_id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let user = aziot_identityd::auth::Uid(0);
+		let auth_id = match inner.authenticator.authenticate(user) {
+			Ok(auth_id) => auth_id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			//TODO: get uid from UDS
-			let identity = match inner.get_caller_identity(auth_id).await {
-				Ok(v) => v,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
-			let res = aziot_identity_common_http::get_module_identity::Response {
-				identity,
-			};
-			Ok((hyper::StatusCode::OK, res))
-		})
+		//TODO: get uid from UDS
+		let identity = match inner.get_caller_identity(auth_id).await {
+			Ok(v) => v,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
+		let res = aziot_identity_common_http::get_module_identity::Response {
+			identity,
+		};
+		Ok((hyper::StatusCode::OK, res))
 	}
 
 	type PostBody = serde::de::IgnoredAny;

--- a/identity/aziot-identityd/src/http/get_device_identity.rs
+++ b/identity/aziot-identityd/src/http/get_device_identity.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_identityd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -32,32 +33,30 @@ impl http_common::server::Route for Route {
 
 	type PostBody = aziot_identity_common_http::get_device_identity::Request;
 	type PostResponse = aziot_identity_common_http::get_device_identity::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let user = aziot_identityd::auth::Uid(0);
-			let auth_id = match inner.authenticator.authenticate(user) {
-				Ok(auth_id) => auth_id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let user = aziot_identityd::auth::Uid(0);
+		let auth_id = match inner.authenticator.authenticate(user) {
+			Ok(auth_id) => auth_id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			//TODO: get uid from UDS
-			let identity = match inner.get_device_identity(auth_id, &body.id_type).await {
-				Ok(v) => v,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
-			let res = aziot_identity_common_http::get_device_identity::Response {
-				identity,
-			};
-			Ok((hyper::StatusCode::OK, Some(res)))
-		})
+		//TODO: get uid from UDS
+		let identity = match inner.get_device_identity(auth_id, &body.id_type).await {
+			Ok(v) => v,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
+		let res = aziot_identity_common_http::get_device_identity::Response {
+			identity,
+		};
+		Ok((hyper::StatusCode::OK, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/identity/aziot-identityd/src/http/get_trust_bundle.rs
+++ b/identity/aziot-identityd/src/http/get_trust_bundle.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_identityd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -29,28 +30,26 @@ impl http_common::server::Route for Route {
 	type DeleteResponse = ();
 
 	type GetResponse = aziot_identity_common_http::get_trust_bundle::Response;
-	fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
-		Box::pin(async move {
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+	async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let user = aziot_identityd::auth::Uid(0);
-			let auth_id = match inner.authenticator.authenticate(user) {
-				Ok(auth_id) => auth_id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let user = aziot_identityd::auth::Uid(0);
+		let auth_id = match inner.authenticator.authenticate(user) {
+			Ok(auth_id) => auth_id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			//TODO: get uid from UDS
-			let certificate = match inner.get_trust_bundle(auth_id).await {
-				Ok(v) => v,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		//TODO: get uid from UDS
+		let certificate = match inner.get_trust_bundle(auth_id).await {
+			Ok(v) => v,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_identity_common_http::get_trust_bundle::Response {
-				certificate,
-			};
-			Ok((hyper::StatusCode::OK, res))
-		})
+		let res = aziot_identity_common_http::get_trust_bundle::Response {
+			certificate,
+		};
+		Ok((hyper::StatusCode::OK, res))
 	}
 
 	type PostBody = serde::de::IgnoredAny;

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -83,6 +83,7 @@ impl http_common::server::Route for Route {
 
 	type PutBody = serde::de::IgnoredAny;
 	type PutResponse = aziot_identity_common_http::update_module_identity::Response;
+	#[allow(clippy::needless_pass_by_value)]
 	async fn put(self, _body: Self::PutBody) -> http_common::server::RouteResponse<Self::PutResponse> {
 		let mut inner = self.inner.lock().await;
 		let inner = &mut *inner;

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -83,6 +83,11 @@ impl http_common::server::Route for Route {
 
 	type PutBody = serde::de::IgnoredAny;
 	type PutResponse = aziot_identity_common_http::update_module_identity::Response;
+	// clippy fires this lint for the `_body` parameter of the inner fn in the `async-trait` expansion.
+	// It's not clear why clippy does this, especially since it doesn't raise it for other functions
+	// that also ignore their `_body` parameter like `fn delete` above.
+	//
+	// So suppress it manually.
 	#[allow(clippy::needless_pass_by_value)]
 	async fn put(self, _body: Self::PutBody) -> http_common::server::RouteResponse<Self::PutResponse> {
 		let mut inner = self.inner.lock().await;

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -11,6 +11,7 @@ pub(super) struct Route {
 	module_id: String,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -36,49 +37,45 @@ impl http_common::server::Route for Route {
 
 	type DeleteBody = serde::de::IgnoredAny;
 	type DeleteResponse = ();
-	fn delete(self, _body: Option<Self::DeleteBody>) -> http_common::server::RouteResponse<Option<Self::DeleteResponse>> {
-		Box::pin(async move {
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+	async fn delete(self, _body: Option<Self::DeleteBody>) -> http_common::server::RouteResponse<Option<Self::DeleteResponse>> {
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let user = aziot_identityd::auth::Uid(0);
-			let auth_id = match inner.authenticator.authenticate(user) {
-				Ok(auth_id) => auth_id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let user = aziot_identityd::auth::Uid(0);
+		let auth_id = match inner.authenticator.authenticate(user) {
+			Ok(auth_id) => auth_id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			//TODO: get uid from UDS
-			match inner.delete_identity(auth_id, "aziot", &self.module_id).await {
-				Ok(()) => (),
-				Err(err) => return Err(super::to_http_error(&err)),
-			}
+		//TODO: get uid from UDS
+		match inner.delete_identity(auth_id, "aziot", &self.module_id).await {
+			Ok(()) => (),
+			Err(err) => return Err(super::to_http_error(&err)),
+		}
 
-			Ok((hyper::StatusCode::NO_CONTENT, None))
-		})
+		Ok((hyper::StatusCode::NO_CONTENT, None))
 	}
 
 	type GetResponse = aziot_identity_common_http::get_module_identity::Response;
-	fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
-		Box::pin(async move {
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+	async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let user = aziot_identityd::auth::Uid(0);
-			let auth_id = match inner.authenticator.authenticate(user) {
-				Ok(auth_id) => auth_id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let user = aziot_identityd::auth::Uid(0);
+		let auth_id = match inner.authenticator.authenticate(user) {
+			Ok(auth_id) => auth_id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			//TODO: get uid from UDS
-			let identity = match inner.get_identity(auth_id, "aziot", &self.module_id).await {
-				Ok(v) => v,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
-			let res = aziot_identity_common_http::get_module_identity::Response {
-				identity,
-			};
-			Ok((hyper::StatusCode::OK, res))
-		})
+		//TODO: get uid from UDS
+		let identity = match inner.get_identity(auth_id, "aziot", &self.module_id).await {
+			Ok(v) => v,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
+		let res = aziot_identity_common_http::get_module_identity::Response {
+			identity,
+		};
+		Ok((hyper::StatusCode::OK, res))
 	}
 
 	type PostBody = serde::de::IgnoredAny;
@@ -86,25 +83,23 @@ impl http_common::server::Route for Route {
 
 	type PutBody = serde::de::IgnoredAny;
 	type PutResponse = aziot_identity_common_http::update_module_identity::Response;
-	fn put(self, _body: Self::PutBody) -> http_common::server::RouteResponse<Self::PutResponse> {
-		Box::pin(async move {
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+	async fn put(self, _body: Self::PutBody) -> http_common::server::RouteResponse<Self::PutResponse> {
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let user = aziot_identityd::auth::Uid(0);
-			let auth_id = match inner.authenticator.authenticate(user) {
-				Ok(auth_id) => auth_id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let user = aziot_identityd::auth::Uid(0);
+		let auth_id = match inner.authenticator.authenticate(user) {
+			Ok(auth_id) => auth_id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let identity = match inner.update_identity(auth_id, "aziot", &self.module_id).await {
-				Ok(v) => v,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
-			let res = aziot_identity_common_http::update_module_identity::Response {
-				identity,
-			};
-			Ok((hyper::StatusCode::OK, res))
-		})
+		let identity = match inner.update_identity(auth_id, "aziot", &self.module_id).await {
+			Ok(v) => v,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
+		let res = aziot_identity_common_http::update_module_identity::Response {
+			identity,
+		};
+		Ok((hyper::StatusCode::OK, res))
 	}
 }

--- a/identity/aziot-identityd/src/http/reprovision_device.rs
+++ b/identity/aziot-identityd/src/http/reprovision_device.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_identityd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_identity_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -32,25 +33,23 @@ impl http_common::server::Route for Route {
 
 	type PostBody = serde::de::IgnoredAny;
 	type PostResponse = ();
-	fn post(self, _body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+	async fn post(self, _body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let user = aziot_identityd::auth::Uid(0);
-			let auth_id = match inner.authenticator.authenticate(user) {
-				Ok(auth_id) => auth_id,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let user = aziot_identityd::auth::Uid(0);
+		let auth_id = match inner.authenticator.authenticate(user) {
+			Ok(auth_id) => auth_id,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			//TODO: get uid from UDS
-			match inner.reprovision_device(auth_id).await {
-				Ok(()) => (),
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		//TODO: get uid from UDS
+		match inner.reprovision_device(auth_id).await {
+			Ok(()) => (),
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			Ok((hyper::StatusCode::NO_CONTENT, None))
-		})
+		Ok((hyper::StatusCode::NO_CONTENT, None))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/key/aziot-keyd/Cargo.toml
+++ b/key/aziot-keyd/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1"
 backtrace = "0.3"
 base64 = "0.12"
 futures-util = "0.3"

--- a/key/aziot-keyd/src/http/create_derived_key.rs
+++ b/key/aziot-keyd/src/http/create_derived_key.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_keyd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -32,26 +33,24 @@ impl http_common::server::Route for Route {
 
 	type PostBody = aziot_key_common_http::create_derived_key::Request;
 	type PostResponse = aziot_key_common_http::create_derived_key::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let handle = match inner.create_derived_key(&body.base_handle, &body.derivation_data.0) {
-				Ok(handle) => handle,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let handle = match inner.create_derived_key(&body.base_handle, &body.derivation_data.0) {
+			Ok(handle) => handle,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_key_common_http::create_derived_key::Response {
-				handle,
-			};
-			Ok((hyper::StatusCode::OK, Some(res)))
-		})
+		let res = aziot_key_common_http::create_derived_key::Response {
+			handle,
+		};
+		Ok((hyper::StatusCode::OK, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/key/aziot-keyd/src/http/create_key_if_not_exists.rs
+++ b/key/aziot-keyd/src/http/create_key_if_not_exists.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_keyd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -32,42 +33,40 @@ impl http_common::server::Route for Route {
 
 	type PostBody = aziot_key_common_http::create_key_if_not_exists::Request;
 	type PostResponse = aziot_key_common_http::create_key_if_not_exists::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let create_key_value = match (body.generate_key_len, body.import_key_bytes) {
-				(Some(generate_key_len), None) => aziot_key_common::CreateKeyValue::Generate { length: generate_key_len },
+		let create_key_value = match (body.generate_key_len, body.import_key_bytes) {
+			(Some(generate_key_len), None) => aziot_key_common::CreateKeyValue::Generate { length: generate_key_len },
 
-				(None, Some(import_key_bytes)) => aziot_key_common::CreateKeyValue::Import { bytes: import_key_bytes.0 },
+			(None, Some(import_key_bytes)) => aziot_key_common::CreateKeyValue::Import { bytes: import_key_bytes.0 },
 
-				(Some(_), Some(_)) => return Err(http_common::server::Error {
-					status_code: hyper::StatusCode::UNPROCESSABLE_ENTITY,
-					message: "both lengthBytes and keyBytes cannot be specified in the same request".into(),
-				}),
+			(Some(_), Some(_)) => return Err(http_common::server::Error {
+				status_code: hyper::StatusCode::UNPROCESSABLE_ENTITY,
+				message: "both lengthBytes and keyBytes cannot be specified in the same request".into(),
+			}),
 
-				(None, None) => return Err(http_common::server::Error {
-					status_code: hyper::StatusCode::UNPROCESSABLE_ENTITY,
-					message: "one of lengthBytes and keyBytes must be specified in the request".into(),
-				}),
-			};
+			(None, None) => return Err(http_common::server::Error {
+				status_code: hyper::StatusCode::UNPROCESSABLE_ENTITY,
+				message: "one of lengthBytes and keyBytes must be specified in the request".into(),
+			}),
+		};
 
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let handle = match inner.create_key_if_not_exists(&body.id, create_key_value) {
-				Ok(handle) => handle,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let handle = match inner.create_key_if_not_exists(&body.id, create_key_value) {
+			Ok(handle) => handle,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_key_common_http::create_key_if_not_exists::Response {
-				handle,
-			};
-			Ok((hyper::StatusCode::OK, Some(res)))
-		})
+		let res = aziot_key_common_http::create_key_if_not_exists::Response {
+			handle,
+		};
+		Ok((hyper::StatusCode::OK, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/key/aziot-keyd/src/http/create_key_pair_if_not_exists.rs
+++ b/key/aziot-keyd/src/http/create_key_pair_if_not_exists.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_keyd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -32,26 +33,24 @@ impl http_common::server::Route for Route {
 
 	type PostBody = aziot_key_common_http::create_key_pair_if_not_exists::Request;
 	type PostResponse = aziot_key_common_http::create_key_pair_if_not_exists::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let handle = match inner.create_key_pair_if_not_exists(&body.id, body.preferred_algorithms.as_deref()) {
-				Ok(handle) => handle,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let handle = match inner.create_key_pair_if_not_exists(&body.id, body.preferred_algorithms.as_deref()) {
+			Ok(handle) => handle,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_key_common_http::create_key_pair_if_not_exists::Response {
-				handle,
-			};
-			Ok((hyper::StatusCode::OK, Some(res)))
-		})
+		let res = aziot_key_common_http::create_key_pair_if_not_exists::Response {
+			handle,
+		};
+		Ok((hyper::StatusCode::OK, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/key/aziot-keyd/src/http/decrypt.rs
+++ b/key/aziot-keyd/src/http/decrypt.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_keyd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -32,34 +33,32 @@ impl http_common::server::Route for Route {
 
 	type PostBody = aziot_key_common_http::decrypt::Request;
 	type PostResponse = aziot_key_common_http::decrypt::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let mechanism = match body.parameters {
-				aziot_key_common_http::encrypt::Parameters::Aead { iv, aad } => aziot_key_common::EncryptMechanism::Aead { iv: iv.0, aad: aad.0 },
+		let mechanism = match body.parameters {
+			aziot_key_common_http::encrypt::Parameters::Aead { iv, aad } => aziot_key_common::EncryptMechanism::Aead { iv: iv.0, aad: aad.0 },
 
-				aziot_key_common_http::encrypt::Parameters::RsaPkcs1 => aziot_key_common::EncryptMechanism::RsaPkcs1,
+			aziot_key_common_http::encrypt::Parameters::RsaPkcs1 => aziot_key_common::EncryptMechanism::RsaPkcs1,
 
-				aziot_key_common_http::encrypt::Parameters::RsaNoPadding => aziot_key_common::EncryptMechanism::RsaNoPadding,
-			};
+			aziot_key_common_http::encrypt::Parameters::RsaNoPadding => aziot_key_common::EncryptMechanism::RsaNoPadding,
+		};
 
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let plaintext = match inner.decrypt(&body.key_handle, mechanism, &body.ciphertext.0) {
-				Ok(plaintext) => plaintext,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let plaintext = match inner.decrypt(&body.key_handle, mechanism, &body.ciphertext.0) {
+			Ok(plaintext) => plaintext,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_key_common_http::decrypt::Response {
-				plaintext: http_common::ByteString(plaintext),
-			};
-			Ok((hyper::StatusCode::OK, Some(res)))
-		})
+		let res = aziot_key_common_http::decrypt::Response {
+			plaintext: http_common::ByteString(plaintext),
+		};
+		Ok((hyper::StatusCode::OK, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/key/aziot-keyd/src/http/encrypt.rs
+++ b/key/aziot-keyd/src/http/encrypt.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_keyd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -32,34 +33,32 @@ impl http_common::server::Route for Route {
 
 	type PostBody = aziot_key_common_http::encrypt::Request;
 	type PostResponse = aziot_key_common_http::encrypt::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let mechanism = match body.parameters {
-				aziot_key_common_http::encrypt::Parameters::Aead { iv, aad } => aziot_key_common::EncryptMechanism::Aead { iv: iv.0, aad: aad.0 },
+		let mechanism = match body.parameters {
+			aziot_key_common_http::encrypt::Parameters::Aead { iv, aad } => aziot_key_common::EncryptMechanism::Aead { iv: iv.0, aad: aad.0 },
 
-				aziot_key_common_http::encrypt::Parameters::RsaPkcs1 => aziot_key_common::EncryptMechanism::RsaPkcs1,
+			aziot_key_common_http::encrypt::Parameters::RsaPkcs1 => aziot_key_common::EncryptMechanism::RsaPkcs1,
 
-				aziot_key_common_http::encrypt::Parameters::RsaNoPadding => aziot_key_common::EncryptMechanism::RsaNoPadding,
-			};
+			aziot_key_common_http::encrypt::Parameters::RsaNoPadding => aziot_key_common::EncryptMechanism::RsaNoPadding,
+		};
 
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let ciphertext = match inner.encrypt(&body.key_handle, mechanism, &body.plaintext.0) {
-				Ok(ciphertext) => ciphertext,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let ciphertext = match inner.encrypt(&body.key_handle, mechanism, &body.plaintext.0) {
+			Ok(ciphertext) => ciphertext,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_key_common_http::encrypt::Response {
-				ciphertext: http_common::ByteString(ciphertext),
-			};
-			Ok((hyper::StatusCode::OK, Some(res)))
-		})
+		let res = aziot_key_common_http::encrypt::Response {
+			ciphertext: http_common::ByteString(ciphertext),
+		};
+		Ok((hyper::StatusCode::OK, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
+++ b/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
@@ -11,6 +11,7 @@ pub(super) struct Route {
 	parameter_name: String,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -41,26 +42,24 @@ impl http_common::server::Route for Route {
 
 	type PostBody = aziot_key_common_http::get_key_pair_public_parameter::Request;
 	type PostResponse = aziot_key_common_http::get_key_pair_public_parameter::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let parameter_value = match inner.get_key_pair_public_parameter(&body.key_handle, &self.parameter_name) {
-				Ok(parameter_value) => parameter_value,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let parameter_value = match inner.get_key_pair_public_parameter(&body.key_handle, &self.parameter_name) {
+			Ok(parameter_value) => parameter_value,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_key_common_http::get_key_pair_public_parameter::Response {
-				value: parameter_value,
-			};
-			Ok((hyper::StatusCode::OK, Some(res)))
-		})
+		let res = aziot_key_common_http::get_key_pair_public_parameter::Response {
+			value: parameter_value,
+		};
+		Ok((hyper::StatusCode::OK, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;

--- a/key/aziot-keyd/src/http/sign.rs
+++ b/key/aziot-keyd/src/http/sign.rs
@@ -4,6 +4,7 @@ pub(super) struct Route {
 	inner: std::sync::Arc<futures_util::lock::Mutex<aziot_keyd::Server>>,
 }
 
+#[async_trait::async_trait]
 impl http_common::server::Route for Route {
 	type ApiVersion = aziot_key_common_http::ApiVersion;
 	fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
@@ -32,32 +33,30 @@ impl http_common::server::Route for Route {
 
 	type PostBody = aziot_key_common_http::sign::Request;
 	type PostResponse = aziot_key_common_http::sign::Response;
-	fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
-		Box::pin(async move {
-			let body = body.ok_or_else(|| http_common::server::Error {
-				status_code: http::StatusCode::BAD_REQUEST,
-				message: "missing request body".into(),
-			})?;
+	async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+		let body = body.ok_or_else(|| http_common::server::Error {
+			status_code: http::StatusCode::BAD_REQUEST,
+			message: "missing request body".into(),
+		})?;
 
-			let (mechanism, digest) = match body.parameters {
-				aziot_key_common_http::sign::Parameters::Ecdsa { digest } => (aziot_key_common::SignMechanism::Ecdsa, digest),
+		let (mechanism, digest) = match body.parameters {
+			aziot_key_common_http::sign::Parameters::Ecdsa { digest } => (aziot_key_common::SignMechanism::Ecdsa, digest),
 
-				aziot_key_common_http::sign::Parameters::HmacSha256 { message } => (aziot_key_common::SignMechanism::HmacSha256, message),
-			};
+			aziot_key_common_http::sign::Parameters::HmacSha256 { message } => (aziot_key_common::SignMechanism::HmacSha256, message),
+		};
 
-			let mut inner = self.inner.lock().await;
-			let inner = &mut *inner;
+		let mut inner = self.inner.lock().await;
+		let inner = &mut *inner;
 
-			let signature = match inner.sign(&body.key_handle, mechanism, &digest.0) {
-				Ok(signature) => signature,
-				Err(err) => return Err(super::to_http_error(&err)),
-			};
+		let signature = match inner.sign(&body.key_handle, mechanism, &digest.0) {
+			Ok(signature) => signature,
+			Err(err) => return Err(super::to_http_error(&err)),
+		};
 
-			let res = aziot_key_common_http::sign::Response {
-				signature: http_common::ByteString(signature),
-			};
-			Ok((hyper::StatusCode::OK, Some(res)))
-		})
+		let res = aziot_key_common_http::sign::Response {
+			signature: http_common::ByteString(signature),
+		};
+		Ok((hyper::StatusCode::OK, Some(res)))
 	}
 
 	type PutBody = serde::de::IgnoredAny;


### PR DESCRIPTION
[`async_trait`](https://docs.rs/async-trait/0.1.41/async_trait/) is basically just some syntactic sugar over explicitly returning Pinned Boxed Futures syntax.

It's not a particularly heavy dependency, and really helps cut-down on the boilerplate required to define a route.

Don't be alarmed by the line number diff, it's mostly just whitespace removal :sweat_smile: 