### PR TITLE
Build improvements.

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -36,14 +36,12 @@ jobs:
       run: |
         docker run --rm \
           -v "$GITHUB_WORKSPACE:/src" \
-          -e "CONTAINER_OS=$CONTAINER_OS" \
           -e "ARCH=$ARCH" \
           -e "PACKAGE_VERSION=$PACKAGE_VERSION" \
           -e "PACKAGE_RELEASE=$PACKAGE_RELEASE" \
           "${{ matrix.container_os }}" \
           '/src/ci/package.sh'
       env:
-        CONTAINER_OS: "${{ matrix.container_os }}"
         ARCH: "${{ matrix.arch }}"
         PACKAGE_VERSION: '1.1.0'
         PACKAGE_RELEASE: '0'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,12 +33,10 @@ jobs:
       run: |
         docker run --rm \
           -v "$GITHUB_WORKSPACE:/src" \
-          -e "CONTAINER_OS=$CONTAINER_OS" \
           -e "ARCH=$ARCH" \
           "${{ matrix.container_os }}" \
           '/src/ci/test-basic.sh'
       env:
-        CONTAINER_OS: "${{ matrix.container_os }}"
         ARCH: "${{ matrix.arch }}"
     - name: 'Generate artifact properties'
       id: 'generate-artifact-properties'
@@ -122,13 +120,11 @@ jobs:
       run: |
         docker run --rm \
           -v "$GITHUB_WORKSPACE:/src" \
-          -e "CONTAINER_OS=$CONTAINER_OS" \
           -e "ARCH=$ARCH" \
           -e "KEY_TYPE=$KEY_TYPE" \
           "${{ matrix.container_os }}" \
           '/src/ci/test-pkcs11-softhsm.sh'
       env:
-        CONTAINER_OS: "${{ matrix.container_os }}"
         ARCH: "${{ matrix.arch }}"
         KEY_TYPE: "${{ matrix.key_type }}"
 

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -6,22 +6,25 @@
 # modify the contents of /etc/apt. The script is intended to be run inside a container of the corresponding OS, not directly on your machine.
 
 
+OS="$(. /etc/os-release; echo "$ID:$VERSION_ID")"
+
+
 # OS packages
 
-case "$CONTAINER_OS.$ARCH" in
-    'centos:7.amd64')
+case "$OS:$ARCH" in
+    'centos:7:amd64')
         yum install -y epel-release
         yum install -y \
             curl gcc jq make pkgconfig \
             clang llvm-devel openssl-devel
         ;;
 
-    'centos:7.arm32v7'|'centos:7.aarch64')
+    'centos:7:arm32v7'|'centos:7:aarch64')
         echo 'Cross-compilation on CentOS 7 is not supported' >&2
         exit 1
         ;;
 
-    'debian:9-slim.amd64'|'debian:10-slim.amd64'|'ubuntu:18.04.amd64'|'ubuntu:20.04.amd64')
+    'debian:9:amd64'|'debian:10:amd64'|'ubuntu:18.04:amd64'|'ubuntu:20.04:amd64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 
@@ -32,7 +35,7 @@ case "$CONTAINER_OS.$ARCH" in
             libclang1 libssl-dev llvm-dev
         ;;
 
-    'debian:9-slim.arm32v7'|'debian:10-slim.arm32v7')
+    'debian:9:arm32v7'|'debian:10:arm32v7')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 
@@ -44,7 +47,7 @@ case "$CONTAINER_OS.$ARCH" in
             libc-dev libc-dev:armhf libclang1 libssl-dev:armhf llvm-dev
         ;;
 
-    'debian:9-slim.aarch64'|'debian:10-slim.aarch64')
+    'debian:9:aarch64'|'debian:10:aarch64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 
@@ -56,7 +59,7 @@ case "$CONTAINER_OS.$ARCH" in
             libc-dev libc-dev:arm64 libclang1 libssl-dev:arm64 llvm-dev
         ;;
 
-    'ubuntu:18.04.arm32v7'|'ubuntu:20.04.arm32v7')
+    'ubuntu:18.04:arm32v7'|'ubuntu:20.04:arm32v7')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 
@@ -81,7 +84,7 @@ case "$CONTAINER_OS.$ARCH" in
             libc-dev libc-dev:armhf libclang1 libssl-dev:armhf llvm-dev
         ;;
 
-    'ubuntu:18.04.aarch64'|'ubuntu:20.04.aarch64')
+    'ubuntu:18.04:aarch64'|'ubuntu:20.04:aarch64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 
@@ -107,6 +110,7 @@ case "$CONTAINER_OS.$ARCH" in
         ;;
 
     *)
+        echo "Unsupported OS:ARCH $OS:$ARCH" >&2
         exit 1
 esac
 
@@ -150,8 +154,8 @@ case "$ARCH" in
         ;;
 esac
 
-case "$CONTAINER_OS.$ARCH" in
-    debian:*.arm32v7|ubuntu*.arm32v7)
+case "$OS:$ARCH" in
+    debian:*:arm32v7|ubuntu:*:arm32v7)
         mkdir -p ~/.cargo
         echo '[target.armv7-unknown-linux-gnueabihf]' > ~/.cargo/config
         echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
@@ -159,7 +163,7 @@ case "$CONTAINER_OS.$ARCH" in
         export ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_INCLUDE_DIR=/usr/include
         ;;
 
-    debian:*.aarch64|ubuntu*.aarch64)
+    debian:*:aarch64|ubuntu:*:aarch64)
         mkdir -p ~/.cargo
         echo '[target.aarch64-unknown-linux-gnu]' > ~/.cargo/config
         echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config

--- a/ci/install-runtime-deps.sh
+++ b/ci/install-runtime-deps.sh
@@ -2,7 +2,11 @@
 
 # This script is meant to be sourced.
 
-case "$CONTAINER_OS" in
+
+OS="$(. /etc/os-release; echo "$ID:$VERSION_ID")"
+
+
+case "$OS" in
     'centos:7')
         # openssl 1.0
 
@@ -13,7 +17,7 @@ case "$CONTAINER_OS" in
         mkdir -p /var/lib/softhsm/tokens
         ;;
 
-    'debian:9-slim'|'debian:10-slim'|'ubuntu:18.04'|'ubuntu:20.04')
+    'debian:9'|'debian:10'|'ubuntu:18.04'|'ubuntu:20.04')
         # openssl 1.1.0 for Debian 9, 1.1.1 for the others
 
         apt-get update -y
@@ -25,5 +29,6 @@ case "$CONTAINER_OS" in
         ;;
 
     *)
+        echo "Unsupported OS $OS" >&2
         exit 1
 esac

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -10,7 +10,7 @@ cd /src
 mkdir -p packages
 
 
-case "$CONTAINER_OS" in
+case "$OS" in
     'centos:7')
         case "$ARCH" in
             'arm32v7'|'aarch64')
@@ -35,18 +35,18 @@ case "$CONTAINER_OS" in
             "packages/centos7/$ARCH/"
         ;;
 
-    'debian:9-slim'|'debian:10-slim'|'ubuntu:18.04'|'ubuntu:20.04')
+    'debian:9'|'debian:10'|'ubuntu:18.04'|'ubuntu:20.04')
         DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y dh-make dh-systemd
 
         make ARCH="$ARCH" PACKAGE_VERSION="$PACKAGE_VERSION" PACKAGE_RELEASE="$PACKAGE_RELEASE" V=1 deb
 
-        case "$CONTAINER_OS" in
-            'debian:9-slim')
+        case "$OS" in
+            'debian:9')
                 TARGET_DIR="debian9/$ARCH"
                 DBGSYM_EXT='deb'
                 ;;
 
-            'debian:10-slim')
+            'debian:10')
                 TARGET_DIR="debian10/$ARCH"
                 DBGSYM_EXT='deb'
                 ;;
@@ -62,7 +62,7 @@ case "$CONTAINER_OS" in
                 ;;
 
             *)
-                # unreachable
+                echo 'unreachable' >&2
                 exit 1
         esac
 
@@ -92,5 +92,6 @@ case "$CONTAINER_OS" in
         ;;
 
     *)
+        echo "Unsupported OS:ARCH $OS:$ARCH" >&2
         exit 1
 esac

--- a/contrib/third-party-notices.sh
+++ b/contrib/third-party-notices.sh
@@ -19,6 +19,7 @@ case "$ARCH" in
         ;;
 
     *)
+        echo "Unsupported ARCH $ARCH" >&2
         exit 1
         ;;
 esac
@@ -179,6 +180,7 @@ cargo metadata --format-version 1 |
                 ;;
 
             *)
+                echo "$name:$version at $manifest_path has unsupported license $license" >&2
                 exit 1
                 ;;
         esac

--- a/docs/dev/packages.md
+++ b/docs/dev/packages.md
@@ -1,6 +1,6 @@
 # Building the packages
 
-This repository contains three services - `aziot-certd`, `aziot-identityd` and `aziot-keyd` - as well as the `libaziot_keys.so` library. These four components ship in a single distro package named `aziot-identity-service`. The package can be built for a particular distro and a particular architecture by running the `/ci/package.sh` script in a Docker container of that distro, with some environment variables set to identify the distro and the architecture to build the packages for.
+This repository contains three services - `aziot-certd`, `aziot-identityd` and `aziot-keyd` - as well as the `libaziot_keys.so` library. These four components ship in a single distro package named `aziot-identity-service`. The package can be built for a particular distro and a particular architecture by running the `/ci/package.sh` script in a Docker container of that distro, with an environment variable set to identify the architecture to build the packages for.
 
 
 <table>
@@ -8,33 +8,27 @@ This repository contains three services - `aziot-certd`, `aziot-identityd` and `
 <tr>
 <th>Distro</th>
 <th>Docker image</th>
-<th><code>CONTAINER_OS</code> env var</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td>CentOS 7</td>
 <td><code>centos:7</code></td>
-<td><code>centos:7</code></td>
 </tr>
 <tr>
 <td>Debian 9 / Raspbian 9</td>
-<td><code>debian:9-slim</code></td>
 <td><code>debian:9-slim</code></td>
 </tr>
 <tr>
 <td>Debian 10 / Raspbian 10</td>
 <td><code>debian:10-slim</code></td>
-<td><code>debian:10-slim</code></td>
 </tr>
 <tr>
 <td>Ubuntu 18.04</td>
 <td><code>ubuntu:18.04</code></td>
-<td><code>ubuntu:18.04</code></td>
 </tr>
 <tr>
 <td>Ubuntu 20.04</td>
-<td><code>ubuntu:20.04</code></td>
 <td><code>ubuntu:20.04</code></td>
 </tr>
 </tbody>
@@ -73,7 +67,6 @@ For an example to put it all together, let's say you want to build the CentOS 7 
 ```sh
 docker run -it --rm \
 	-v "$(realpath ~/src/iot-identity-service):/src" \
-	-e 'CONTAINER_OS=centos:7' \
 	-e 'ARCH=amd64' \
 	-e 'PACKAGE_VERSION=1.1.0' \
 	-e 'PACKAGE_RELEASE=0' \
@@ -103,7 +96,6 @@ For another example, let's say you want to build the Debian 10 package for ARM32
 ```sh
 docker run -it --rm \
 	-v "$(realpath ~/src/iot-identity-service):/src" \
-	-e 'CONTAINER_OS=debian:10-slim' \
 	-e 'ARCH=arm32v7' \
 	-e 'PACKAGE_VERSION=1.1.0' \
 	-e 'PACKAGE_RELEASE=0' \


### PR DESCRIPTION
- Use a mktemp'd file for cbindgen output rather than creating one in
  the repo directory. This ensures directory mtime isn't updated from
  the temp file, though it doesn't matter at this point since neither make
  nor cargo care about that.

- Detect the OS from /etc/os-release instead of needing the CONTAINER_OS env var
  to be set.

- Consistently print error messages when failing due to unsupported OSes or
  ARCHes, and when a dependency has an unsupported license.