### PR TITLE
Add basic E2E test workflows.

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -46,5 +46,6 @@ jobs:
         AZURE_USERNAME: "${{ secrets.AZURE_USERNAME }}"
         AZURE_PASSWORD: "${{ secrets.AZURE_PASSWORD }}"
         AZURE_RESOURCE_GROUP_NAME: "${{ secrets.AZURE_RESOURCE_GROUP_NAME }}"
+        AZURE_LOCATION: "${{ secrets.AZURE_LOCATION }}"
 
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -1,0 +1,50 @@
+# Used to run the E2E tests against a branch of your choice from the github.com UI.
+#
+# Note that the workflow file is always used from main, even when running against a different branch.
+#
+# DEVNOTE: Keep in sync with e2e-tests-scheduled.yaml
+
+name: 'e2e-tests-manual'
+
+on:
+  'workflow_dispatch':
+    inputs:
+      branch:
+        default: 'main'
+
+jobs:
+  e2e-tests:
+    runs-on: 'ubuntu-18.04'
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os:
+        - 'centos:7'
+        - 'debian:9'
+        - 'debian:10'
+        - 'ubuntu:18.04'
+        - 'ubuntu:20.04'
+        test_name:
+        - 'manual-symmetric-key'
+
+    steps:
+    - uses: 'actions/checkout@v1'
+      with:
+        ref: "${{ github.events.input.branch }}"
+
+    - name: 'Run'
+      run: |
+        ./ci/e2e-tests.sh ${{ matrix.test_name }}
+      env:
+        BRANCH: "${{ github.events.input.branch }}"
+
+        OS: "${{ matrix.os }}"
+
+        AZURE_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
+        AZURE_USERNAME: "${{ secrets.AZURE_USERNAME }}"
+        AZURE_PASSWORD: "${{ secrets.AZURE_PASSWORD }}"
+        AZURE_RESOURCE_GROUP_NAME: "${{ secrets.AZURE_RESOURCE_GROUP_NAME }}"
+
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -49,5 +49,6 @@ jobs:
         AZURE_USERNAME: "${{ secrets.AZURE_USERNAME }}"
         AZURE_PASSWORD: "${{ secrets.AZURE_PASSWORD }}"
         AZURE_RESOURCE_GROUP_NAME: "${{ secrets.AZURE_RESOURCE_GROUP_NAME }}"
+        AZURE_LOCATION: "${{ secrets.AZURE_LOCATION }}"
 
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -1,0 +1,53 @@
+# Runs the E2E tests against a set of branches every day.
+#
+# Note that the workflow file is always used from main, even when running against a different branch.
+#
+# DEVNOTE: Keep in sync with e2e-tests-manual.yaml
+
+name: 'e2e-tests-scheduled'
+
+on:
+  schedule:
+  - cron: '0 1 * * *'
+
+jobs:
+  e2e-tests:
+    if: 'github.repository == "Azure/iot-identity-service"'
+
+    runs-on: 'ubuntu-18.04'
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        branch:
+        - 'main'
+
+        os:
+        - 'centos:7'
+        - 'debian:9'
+        - 'debian:10'
+        - 'ubuntu:18.04'
+        - 'ubuntu:20.04'
+        test_name:
+        - 'manual-symmetric-key'
+
+    steps:
+    - uses: 'actions/checkout@v1'
+      with:
+        ref: "${{ matrix.branch }}"
+
+    - name: 'Run'
+      run: |
+        ./ci/e2e-tests.sh ${{ matrix.test_name }}
+      env:
+        BRANCH: "${{ matrix.branch }}"
+
+        OS: "${{ matrix.os }}"
+
+        AZURE_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
+        AZURE_USERNAME: "${{ secrets.AZURE_USERNAME }}"
+        AZURE_PASSWORD: "${{ secrets.AZURE_PASSWORD }}"
+        AZURE_RESOURCE_GROUP_NAME: "${{ secrets.AZURE_RESOURCE_GROUP_NAME }}"
+
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   e2e-tests:
-    if: 'github.repository == "Azure/iot-identity-service"'
+    if: "github.repository == 'Azure/iot-identity-service'"
 
     runs-on: 'ubuntu-18.04'
 

--- a/aziotd/src/logging.rs
+++ b/aziotd/src/logging.rs
@@ -1,10 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-// use std::env;
-// use std::io::Write;
-
-// use log::{Level, LevelFilter};
-
 const LOG_LEVEL_ENV_VAR: &str = "AZIOT_LOG";
 
 pub(crate) fn init() {

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -183,7 +183,7 @@ where
                 }
 
                 let patch_path = entry.path();
-                if patch_path.extension().and_then(std::ffi::OsStr::to_str) != Some(".toml") {
+                if patch_path.extension().and_then(std::ffi::OsStr::to_str) != Some("toml") {
                     continue;
                 }
 

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -149,7 +149,7 @@ echo "Run ID: $run_id" >&2
 
 # Temp directory used as scratch space to store the downloaded package from GitHub
 # and the config files for the package that are scp'd to the test VM.
-working_directory="iot-identity-service-e2e-tests-$run_id.XXXXXXXXXX"
+working_directory="iot-identity-service-e2e-tests-$run_id"
 echo "Working directory: $working_directory" >&2
 mkdir -p "$working_directory"
 cd "$working_directory"

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -149,7 +149,7 @@ echo "Run ID: $run_id" >&2
 
 # Temp directory used as scratch space to store the downloaded package from GitHub
 # and the config files for the package that are scp'd to the test VM.
-working_directory="iot-identity-service-e2e-tests-$run_id"
+working_directory="iot-identity-service-e2e-tests-${run_id//:/-}"
 echo "Working directory: $working_directory" >&2
 mkdir -p "$working_directory"
 cd "$working_directory"
@@ -176,6 +176,9 @@ echo 'Logging in to Azure...' >&2
     "--password=$AZURE_PASSWORD"
 echo 'Logged in to Azure' >&2
 
+if [ -n "${AZURE_LOCATION:-}" ]; then
+    az configure --defaults "location=$AZURE_LOCATION"
+fi
 
 # VM image as taken by `az vm create` is specified as `$publisher:$offer:$sku:$version`
 #

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -1,0 +1,615 @@
+#!/bin/bash
+
+# Usage:
+#
+# e2e-tests.sh <test_name>
+#
+# See /docs/dev/e2e-tests.md for details of some env vars that need to be defined.
+#
+# <test_name>:
+#     manual-symmetric-key
+
+set -euo pipefail
+
+
+get_package() {
+    if [ -n "${PACKAGE:-}" ]; then
+        echo "Using package specified by PACKAGE" >&2
+        printf '%s\n' "$PACKAGE"
+        return
+    fi
+
+    # The download-artifact does not have a way to download artifacts from other workflows.
+    # Ref: https://github.com/actions/download-artifact/issues/3
+    #
+    # So instead we use the GitHub API ourselves.
+    #
+    # It would be nice to use the v4 graphql API and get the artifact URL in one shot,
+    # but it doesn't appear to support artifacts.
+
+    github_curl() {
+        if [ -n "${GITHUB_PAT:-}" ]; then
+            curl --user "$GITHUB_PAT" "$@"
+        elif [ -n "${GITHUB_TOKEN:-}" ]; then
+            curl --header "authorization: Bearer $GITHUB_TOKEN" "$@"
+        else
+            echo 'Neither PACKAGE nor GITHUB_PAT nor GITHUB_TOKEN have been set.' >&2
+            exit 1
+        fi
+    }
+
+    # Get workflow runs for this branch and pick the latest one (the first one).
+    # From that, get the artifacts URL.
+    #
+    # Ref: https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs
+    echo "Getting latest workflow run's artifacts URL..." >&2
+    artifacts_url="$(
+        github_curl -L \
+            -H 'accept: application/vnd.github.v3+json' \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/workflows/packages.yaml/runs?branch=$BRANCH&event=push&status=success" |
+            jq -r '.workflow_runs[0].artifacts_url'
+    )"
+    if [ "$artifacts_url" = 'null' ]; then
+        echo "No successfully-concluded packages workflow found for branch $BRANCH" >&2
+        exit 1
+    fi
+    echo "Artifacts URL: $artifacts_url" >&2
+
+    case "$OS" in
+        'centos:7')
+            artifact_name='centos-7'
+            ;;
+
+        'debian:9')
+            artifact_name='debian-9-slim'
+            ;;
+
+        'debian:10')
+            artifact_name='debian-10-slim'
+            ;;
+
+        'ubuntu:18.04')
+            artifact_name='ubuntu-18.04'
+            ;;
+
+        'ubuntu:20.04')
+            artifact_name='ubuntu-20.04'
+            ;;
+
+        *)
+            echo "Unsupported OS $OS" >&2
+            exit 1
+    esac
+    artifact_name="packages_${artifact_name}_amd64"
+
+    echo 'Getting artifact download URL...' >&2
+    artifact_download_url="$(
+        github_curl -L \
+            -H 'accept: application/vnd.github.v3+json' \
+            "$artifacts_url" |
+            jq \
+                --arg artifact_name "$artifact_name" \
+                -r \
+                '.artifacts[] | select(.name == $artifact_name) | .archive_download_url'
+    )"
+    if [ -z "$artifact_download_url" ]; then
+        echo "Could not find artifact for OS $OS" >&2
+        exit 1
+    fi
+    echo "Artifact download URL: $artifact_download_url" >&2
+
+    echo 'Downloading artifact...' >&2
+    github_curl -L \
+        -o package.zip \
+        "$artifact_download_url"
+    echo 'Downloaded artifact' >&2
+
+
+    echo 'Extracting package...' >&2
+    case "$OS" in
+        'centos:7')
+            unzip -j package.zip 'centos7/amd64/aziot-identity-service-*.x86_64.rpm' -x '*-debuginfo-*.rpm' '*-devel-*.rpm' >&2
+            printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
+            ;;
+
+        'debian:9')
+            unzip -j package.zip 'debian9/amd64/aziot-identity-service_*_amd64.deb' >&2
+            printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
+            ;;
+
+        'debian:10')
+            unzip -j package.zip 'debian10/amd64/aziot-identity-service_*_amd64.deb' >&2
+            printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
+            ;;
+
+        'ubuntu:18.04')
+            unzip -j package.zip 'ubuntu1804/amd64/aziot-identity-service_*_amd64.deb' >&2
+            printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
+            ;;
+
+        'ubuntu:20.04')
+            unzip -j package.zip 'ubuntu2004/amd64/aziot-identity-service_*_amd64.deb' >&2
+            printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
+            ;;
+
+        *)
+            echo "Unsupported OS $OS" >&2
+            exit 1
+    esac
+    echo 'Extracted package' >&2
+}
+
+
+test_name="$1"
+
+
+run_id="$OS:$GITHUB_RUN_ID:$GITHUB_RUN_NUMBER:$test_name"
+echo "Run ID: $run_id" >&2
+
+
+# Temp directory used as scratch space to store the downloaded package from GitHub
+# and the config files for the package that are scp'd to the test VM.
+rm -rf /tmp/iot-identity-service-e2e-tests
+mkdir -p /tmp/iot-identity-service-e2e-tests
+cd /tmp/iot-identity-service-e2e-tests
+
+
+package="$(get_package)"
+echo "Using package at [$package]" >&2
+if ! [ -f "$package" ]; then
+    echo 'Could not find package file' >&2
+    exit 1
+fi
+
+
+echo 'Installing and updating azure-iot extension...' >&2
+az extension add --name azure-iot
+az extension update --name azure-iot
+echo 'Installed and updated azure-iot extension' >&2
+
+
+echo 'Logging in to Azure...' >&2
+>/dev/null az login --service-principal \
+    --tenant "$AZURE_TENANT_ID" \
+    --username "$AZURE_USERNAME" \
+    "--password=$AZURE_PASSWORD"
+echo 'Logged in to Azure' >&2
+
+
+# VM image as taken by `az vm create` is specified as `$publisher:$offer:$sku:$version`
+#
+# Commented-out commands show how to query the SKU and version if needed to update.
+# When possible, use the SKU that has a `-gen2` suffix so that it creates a Gen 2 VM instead of a Gen 1 VM.
+# (The VM generation is determined by the SKU.)
+#
+# `--publisher` and `--offer` are useful to filter server-side. But they filter as substrings and return many irrelevant matches,
+# so the commands also filter for exact matches using `--query`. `--sku` is left as a substring match so that the query doesn't have to
+# give a specific minor version.
+#
+# Choice of publisher is determined by
+# https://docs.microsoft.com/en-us/troubleshoot/azure/cloud-services/support-linux-open-source-technology
+case "$OS" in
+    'centos:7')
+        # az vm image list --all \
+        #     --publisher 'OpenLogic' --offer 'CentOS' --sku '7' \
+        #     --query "[?publisher == 'OpenLogic' && offer == 'CentOS'].{ sku: sku, version: version }" --output table
+        vm_image='OpenLogic:CentOS:7_8-gen2:7.8.2020100701'
+        ;;
+
+    'debian:9')
+        # az vm image list --all \
+        #     --publisher 'credativ' --offer 'Debian' --sku '9' \
+        #     --query "[?publisher == 'credativ' && offer == 'Debian'].{ sku: sku, version: version }" --output table
+        vm_image='credativ:Debian:9:9.20200722.0'
+        ;;
+
+    'debian:10')
+        # Not listed on the docs.microsoft.com page, but credativ doesn't publish Debian 10 images.
+        #
+        # az vm image list --all \
+        #     --publisher 'Debian' --offer 'debian-10' --sku '10' \
+        #     --query "[?publisher == 'Debian' && offer == 'debian-10'].{ sku: sku, version: version }" --output table
+        vm_image='Debian:debian-10:10-gen2:0.20201023.432'
+        ;;
+
+    'ubuntu:18.04')
+        # az vm image list --all \
+        #     --publisher 'Canonical' --offer 'UbuntuServer' --sku '18' \
+        #     --query "[?publisher == 'Canonical' && offer == 'UbuntuServer'].{ sku: sku, version: version }" --output table
+        vm_image='Canonical:UbuntuServer:18_04-lts-gen2:18.04.202010140'
+        ;;
+
+    'ubuntu:20.04')
+        # Different offer because UbuntuServer offer does not have 20.04 yet.
+        #
+        # Ref: https://github.com/Azure/azure-cli/issues/13320#issuecomment-649867249
+        #
+        # az vm image list --all \
+        #     --publisher 'Canonical' --offer '0001-com-ubuntu-server-focal' --sku '20' \
+        #     --query "[?publisher == 'Canonical' && offer == '0001-com-ubuntu-server-focal'].{ sku: sku, version: version }" --output table
+        vm_image='Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202010260'
+        ;;
+
+    *)
+        echo "Unsupported OS $OS" >&2
+        exit 1
+esac
+
+
+echo 'Generating ssh key...' >&2
+# https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys#supported-ssh-key-formats
+ssh-keygen -t rsa -b 4096 -f vm-ssh-key -N ''
+echo 'Generated ssh key' >&2
+
+
+common_resource_name="${run_id//:/-}"
+common_resource_name="${common_resource_name//./-}"
+resource_tag="run_id=$run_id"
+
+
+# `az resource list` has `--tag` to filter, but it cannot be combined with `--resource-group`,
+# so query with `--resource-group` and filter for tags client-side.
+#
+# Also, sometimes deleting resources fails because `az resource delete` doesn't respect inter-resource dependencies.
+# So keep trying it in a loop as long as there are still resources that match.
+trap "
+    set +eo pipefail
+
+    rm -f package.zip vm-ssh-key vm-ssh-key.pub *.deb *.rpm
+
+    echo 'Deleting resources...' >&2
+    while :; do \
+        ids=\"\$(
+            az resource list --resource-group '$AZURE_RESOURCE_GROUP_NAME' |
+                jq -r '.[] | select(.tags.run_id == \"$run_id\").id'
+        )\"
+        if [ -z \"\$ids\" ]; then
+            break
+        else
+            <<< \"\$ids\" xargs az resource delete --ids >/dev/null
+        fi
+
+        sleep 1
+        echo 'Retrying...' >&2
+    done
+
+    if [ -n \"\${vm_os_disk:-}\" ]; then
+        az resource delete --ids \"\$vm_os_disk\"
+    fi
+
+    echo 'Deleted resources' >&2
+" EXIT
+
+
+# Creating an IoT Hub is slow, so parallelize it with prepping the VM.
+
+(
+    echo 'Creating IoT Hub...' >&2
+    iot_hub_resource_id="$(
+        az iot hub create \
+            --resource-group "$AZURE_RESOURCE_GROUP_NAME" \
+            --name "$common_resource_name" \
+            --sku 'S1' --unit 1 --partition-count 2 \
+            --query 'id' --output tsv
+    )"
+    # `az iot hub create` doesn't have `--tags`, so tag it manually.
+    #
+    # Ref: https://github.com/Azure/azure-cli/issues/13497
+    >/dev/null az resource tag \
+        --ids "$iot_hub_resource_id" \
+        --tags "$resource_tag"
+    echo 'Created IoT Hub' >&2
+
+
+    case "$test_name" in
+        'manual-symmetric-key')
+            echo 'Creating IoT device...' >&2
+            iot_device_id="$common_resource_name-01"
+            manual_symmetric_key="$(
+                az iot hub device-identity create \
+                    --hub-name "$common_resource_name" \
+                    --device-id "$iot_device_id" \
+                    --auth-method 'shared_private_key' \
+                    --query 'authentication.symmetricKey.primaryKey' --output tsv
+            )"
+            echo 'Created IoT device' >&2
+
+            echo 'Generating config files...' >&2
+
+            >keyd.toml cat <<-EOF
+[aziot_keys]
+homedir_path = "/var/lib/aziot/keyd"
+
+[preloaded_keys]
+device-id = "file:///var/secrets/aziot/keyd/device-id"
+EOF
+
+            >certd.toml cat <<-EOF
+homedir_path = "/var/lib/aziot/certd"
+
+[cert_issuance]
+
+[preloaded_certs]
+EOF
+
+            >identityd.toml cat <<-EOF
+hostname = "$common_resource_name"
+homedir = "/var/lib/aziot/identityd"
+
+[provisioning]
+dynamic_reprovisioning = true
+source = "manual"
+iothub_hostname = "$common_resource_name.azure-devices.net"
+device_id = "$iot_device_id"
+
+[provisioning.authentication]
+method = "sas"
+device_id_pk = "device-id"
+EOF
+
+            >device-id base64 -d <<< "$manual_symmetric_key"
+
+            echo 'Generated config files' >&2
+            ;;
+
+        *)
+            echo "Unsupported test $1" >&2
+            exit 1
+    esac
+
+    >testmodule.toml cat <<-EOF
+[[principal]]
+uid = 1000
+name = "testmodule"
+idtype = ["module"]
+EOF
+) &
+
+
+echo 'Creating NSG...' >&2
+nsg_id="$(
+    az network nsg create \
+        --resource-group "$AZURE_RESOURCE_GROUP_NAME" \
+        --name "$common_resource_name" \
+        --tags "$resource_tag" \
+        --query 'id' --output tsv
+)"
+echo 'Created NSG' >&2
+
+echo 'Querying public IP...' >&2
+self_ip="$(curl -L 'https://ipinfo.io/ip')"
+echo 'Queried public IP' >&2
+
+echo 'Creating allow-ssh rule in NSG...' >&2
+>/dev/null az network nsg rule create \
+    --resource-group "$AZURE_RESOURCE_GROUP_NAME" \
+    --nsg-name "$common_resource_name" \
+    --name 'ssh' \
+    --priority 1000 \
+    --access 'Allow' --direction 'Inbound' --protocol 'Tcp' \
+    --destination-port-ranges '22' \
+    --source-address-prefixes "$self_ip/32"
+echo 'Created allow-ssh rule in NSG' >&2
+
+
+echo 'Creating VM...' >&2
+vm_id="$(
+    </dev/null az vm create \
+        --resource-group "$AZURE_RESOURCE_GROUP_NAME" \
+        --name "$common_resource_name" \
+        --image "$vm_image" \
+        --size 'Standard_B1s' \
+        --admin-username 'aziot' \
+        --authentication-type 'ssh' \
+        --ssh-key-values "$PWD/vm-ssh-key.pub" \
+        --nsg "$nsg_id" \
+        --vnet-name "$common_resource_name" \
+        --enable-agent 'false' \
+        --tags "$resource_tag" \
+        --query 'id' --output tsv
+)"
+vm="$(az vm show --ids "$vm_id" --show-details)"
+vm_public_ip="$(<<< "$vm" jq -r '.publicIps')"
+# Get this ID explicitly so that the exit trap can delete it explicitly.
+# `az resource list` apparently is cached by ARM and often doesn't return the disk,
+# so it would end up not being deleted by the exit trap if the trap just relied on `az resource list`.
+vm_os_disk="$(<<< "$vm" jq -r '.storageProfile.osDisk.managedDisk.id')"
+echo 'Created VM' >&2
+
+echo 'Waiting for VM to respond to ssh...' >&2
+for retry in {0..60}; do
+    sleep 10
+    if timeout 5 ssh -o StrictHostKeyChecking=no -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" echo 'VM is up' >&2; then
+        echo $?
+        break
+    else
+        echo $?
+    fi
+
+    sleep 1
+done
+if ! ssh -o StrictHostKeyChecking=no -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" echo 'VM is up' >&2; then
+    echo 'VM did not come up in time.' >&2
+    exit 1
+fi
+
+
+echo 'Updating VM...' >&2
+case "$OS" in
+    centos:*)
+        ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
+            set -euxo pipefail
+
+            sudo yum -y update
+
+            # The test needs jq
+            sudo yum -y install epel-release
+        '
+        ;;
+
+    debian:*|ubuntu:*)
+        ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
+            set -euxo pipefail
+
+            sudo apt-get update -y
+            sudo apt-get upgrade -y
+        '
+        ;;
+
+    *)
+        echo "Unsupported OS $OS" >&2
+        exit 1
+        ;;
+esac
+echo 'Updated VM' >&2
+
+echo 'Rebooting VM...' >&2
+ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" 'sudo reboot' || :
+echo 'Rebooted VM' >&2
+
+echo 'Waiting for VM to respond to ssh...' >&2
+for retry in {0..60}; do
+    sleep 10
+    if timeout 5 ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" echo 'VM is up' >&2; then
+        echo $?
+        break
+    else
+        echo $?
+    fi
+
+    sleep 1
+done
+if ! ssh -o StrictHostKeyChecking=no -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" echo 'VM is up' >&2; then
+    echo 'VM did not come up in time.' >&2
+    exit 1
+fi
+
+
+echo 'Installing package...' >&2
+case "$OS" in
+    centos:*)
+        scp -i "$PWD/vm-ssh-key" "$package" "aziot@$vm_public_ip:/home/aziot/aziot-identity-service.rpm"
+
+        ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
+            set -euxo pipefail
+
+            sudo yum install -y curl jq
+            sudo yum -y install /home/aziot/aziot-identity-service.rpm
+
+            sudo systemctl start aziot-{key,cert,identity}d.socket
+        '
+
+        ;;
+
+    debian:*|ubuntu:*)
+        scp -i "$PWD/vm-ssh-key" "$package" "aziot@$vm_public_ip:/home/aziot/aziot-identity-service.deb"
+
+        ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
+            set -euxo pipefail
+
+            sudo apt-get install -y curl jq
+            sudo apt-get install -y /home/aziot/aziot-identity-service.deb
+        '
+        ;;
+
+    *)
+        echo "Unsupported OS $OS" >&2
+        exit 1
+        ;;
+esac
+echo 'Installed package' >&2
+
+
+echo 'Waiting for IoT Hub to finish being created...' >&2
+wait $(jobs -pr)
+echo 'Created IoT Hub' >&2
+
+
+echo 'Configuring package...' >&2
+
+scp -i "$PWD/vm-ssh-key" *.toml "aziot@$vm_public_ip:/home/aziot/"
+
+ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
+    set -euxo pipefail
+
+    sudo mv /home/aziot/keyd.toml /etc/aziot/keyd/config.toml
+    sudo chown aziotks:aziotks /etc/aziot/keyd/config.toml
+    sudo chmod 0600 /etc/aziot/keyd/config.toml
+
+    sudo mv /home/aziot/certd.toml /etc/aziot/certd/config.toml
+    sudo chown aziotcs:aziotcs /etc/aziot/certd/config.toml
+    sudo chmod 0600 /etc/aziot/certd/config.toml
+
+    sudo mv /home/aziot/identityd.toml /etc/aziot/identityd/config.toml
+    sudo chown aziotid:aziotid /etc/aziot/identityd/config.toml
+    sudo chmod 0600 /etc/aziot/identityd/config.toml
+
+    sudo mv /home/aziot/testmodule.toml /etc/aziot/identityd/config.d/testmodule.toml
+    sudo chown aziotid:aziotid /etc/aziot/identityd/config.d/testmodule.toml
+    sudo chmod 0600 /etc/aziot/identityd/config.d/testmodule.toml
+
+    sudo usermod -aG aziotcs aziot
+    sudo usermod -aG aziotks aziot
+    sudo usermod -aG aziotid aziot
+'
+
+if [ -f device-id ]; then
+    scp -i "$PWD/vm-ssh-key" device-id "aziot@$vm_public_ip:/home/aziot/"
+    ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
+        set -euxo pipefail
+
+        sudo mkdir -p /var/secrets/aziot/keyd
+        sudo chown aziotks:aziotks /var/secrets/aziot/keyd
+        sudo chmod 0700 /var/secrets/aziot/keyd
+
+        sudo mv /home/aziot/device-id /var/secrets/aziot/keyd/device-id
+        sudo chown aziotks:aziotks /var/secrets/aziot/keyd/device-id
+        sudo chmod 0600 /var/secrets/aziot/keyd/device-id
+    '
+fi
+
+echo 'Configured package' >&2
+
+
+echo 'Running test...' >&2
+ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" "
+    set -euxo pipefail
+
+    sudo systemctl enable aziot-identityd
+    sudo systemctl start aziot-identityd
+
+    # \"Starting server...\" implies provisioning is done.
+    #
+    # Use process substitution for the journalctl | grep so that the command exits as soon as it emits one line of output
+    # rather than waiting for the timeout to expire.
+    #
+    # Pipe the output of head through grep so as to exit with non-zero if the head didn't output anything,
+    # ie the inner grep didn't find the expected line.
+    head -n 1 < <(
+        sudo timeout 60 journalctl --unit aziot-identityd --all --follow |
+            tee /dev/stderr |
+            grep --line-buffered 'Starting server\\.\\.\\.'
+    ) |
+        grep -q .
+
+    identity=\"\$(
+        curl --unix-socket /run/aziot/identityd.sock 'http://foo/identities/modules/testmodule?api-version=2020-09-01'
+    )\"
+    printf '%s\n' \"\$identity\" >&2
+
+    if [ \"\$(<<< \"\$identity\" jq -r '.type')\" != 'aziot' ]; then
+        echo 'Expected identity.type to be aziot' >&2
+        exit 1
+    fi
+
+    if [ \"\$(<<< \"\$identity\" jq -r '.spec.hubName')\" != '$common_resource_name.azure-devices.net' ]; then
+        echo 'Expected identity.spec.hubName to be $common_resource_name.azure-devices.net' >&2
+        exit 1
+    fi
+
+    if [ \"\$(<<< \"\$identity\" jq -r '.spec.moduleId')\" != 'testmodule' ]; then
+        echo 'Expected identity.spec.moduleId to be testmodule' >&2
+        exit 1
+    fi
+"
+echo 'Test passed.' >&2

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -149,9 +149,10 @@ echo "Run ID: $run_id" >&2
 
 # Temp directory used as scratch space to store the downloaded package from GitHub
 # and the config files for the package that are scp'd to the test VM.
-rm -rf /tmp/iot-identity-service-e2e-tests
-mkdir -p /tmp/iot-identity-service-e2e-tests
-cd /tmp/iot-identity-service-e2e-tests
+working_directory="iot-identity-service-e2e-tests-$run_id.XXXXXXXXXX"
+echo "Working directory: $working_directory" >&2
+mkdir -p "$working_directory"
+cd "$working_directory"
 
 
 package="$(get_package)"

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -4,7 +4,7 @@
 #
 # e2e-tests.sh <test_name>
 #
-# See /docs/dev/e2e-tests.md for details of some env vars that need to be defined.
+# See https://azure.github.io/iot-identity-service/dev/e2e-tests.html for details of some env vars that need to be defined.
 #
 # <test_name>:
 #     manual-symmetric-key

--- a/contrib/centos/aziot-identity-service.spec
+++ b/contrib/centos/aziot-identity-service.spec
@@ -103,9 +103,21 @@ fi
 
 
 %post
+%systemd_post aziot-certd.socket
+%systemd_post aziot-identityd.socket
+%systemd_post aziot-keyd.socket
+
+
+%preun
+%systemd_preun aziot-certd.socket
+%systemd_preun aziot-identityd.socket
+%systemd_preun aziot-keyd.socket
 
 
 %postun
+%systemd_postun_with_restart aziot-certd.service
+%systemd_postun_with_restart aziot-identityd.service
+%systemd_postun_with_restart aziot-keyd.service
 
 
 %files

--- a/docs/dev/e2e-tests.md
+++ b/docs/dev/e2e-tests.md
@@ -1,0 +1,95 @@
+# End-to-end tests
+
+## Overview
+
+E2E tests are run in a GitHub Actions workflow. Currently the workflow is triggered manually, and takes the branch it should run on as an input.
+
+The workflow then creates Azure resources to run the tests on.
+
+
+## Setup
+
+To run the tests on your own subscription, you need:
+
+- A Github Personal Access Token. This token must have the `repo.public_repo` scope. This is only needed if you want to run the script against the latest build of a packages workflow, as opposed to using a locally-built package file.
+
+- An Azure subscription.
+
+- An Azure resource group. The E2E tests create resources under this RG. The rest of this document assumes the RG is named "iot-identity-service-e2e-tests"
+
+- An Azure service principal. The E2E tests use this SP to create resources. The rest of this document assumes the SP is named "http://iot-identity-service-e2e-tests"
+
+```sh
+set -euo pipefail
+
+AZURE_ACCOUNT="$(az account show)"
+AZURE_SUBSCRIPTION_ID="$(<<< "$AZURE_ACCOUNT" jq --raw-output '.id')"
+
+export AZURE_RESOURCE_GROUP_NAME='iot-identity-service-e2e-tests'
+AZURE_SP_NAME="http://iot-identity-service-e2e-tests"
+
+az group create --name "$AZURE_RESOURCE_GROUP_NAME" --location 'West US 2'
+
+# Save the output of this command. It contains the password for the SP which cannot be obtained later.
+az ad sp create-for-rbac --name "$AZURE_SP_NAME" --skip-assignment
+
+az role assignment create \
+    --assignee "$AZURE_SP_NAME" \
+    --role 'Contributor' \
+    --scope "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/$AZURE_RESOURCE_GROUP_NAME"
+```
+
+If you've never created an IoT Hub under your subscription, you'll need to register the `Microsoft.Devices` Resource Provider. (Make sure to do this while logged in as yourself, not when logged in as the SP, because the SP won't have permissions to do this.)
+
+```sh
+az provider register --namespace 'Microsoft.Devices'
+
+# Wait for it to go from "Registering" to "Registered"
+watch -c -- az provider show --namespace 'Microsoft.Devices' --query 'registrationState' --output tsv
+```
+
+## Run
+
+Set some more env vars for the parameters of the tests, then run the script.
+
+```sh
+mkdir -p /tmp/aziot-e2e
+cd /tmp/aziot-e2e
+
+# When running as a GH action, these env vars come from secrets.
+# Since we're running the script ourselves, we need to set these according to the SP we created in the previous section.
+export AZURE_TENANT_ID='...'
+export AZURE_USERNAME='...'
+export AZURE_PASSWORD='...'
+export AZURE_RESOURCE_GROUP_NAME='iot-identity-service-e2e-tests'
+
+
+# When running as a GH action, GH provides the script with a token that it can use for the GH API.
+# Since we're running the script ourselves, we have the choice of also using the latest package from a packages workflow run,
+# or a locally-build package file.
+#
+# For the former case, we need to give it a PAT instead, along with env vars used for the API requests and to identify the branch
+# to download the package for.
+#
+# The value is of the format "$github_username:$pat"
+export GITHUB_PAT='foobar:1234abcd'
+export GITHUB_API_URL='https://api.github.com'
+export GITHUB_REPOSITORY='Azure/iot-identity-service'
+export BRANCH='main'
+
+# For the latter case, set the PACKAGE env var to the path of the .deb or .rpm instead.
+#
+# export PACKAGE='/path/to/file.deb'
+
+# These are used to ensure the Azure resources don't conflict with other resources in the RG.
+# When running as a GH action, these env vars will be automatically set by GH.
+export GITHUB_RUN_ID='1000'
+export GITHUB_RUN_NUMBER='1'
+
+# One of the supported OSes. The GH action uses a matrix for every supported OS.
+export OS='ubuntu:18.04'
+
+~/src/iot-identity-service/ci/e2e-tests.sh 'manual_symmetric_key'
+```
+
+Note: The script deletes the resources on exit. If you want to keep the resources around for debugging, comment out the `trap ... EXIT` command.

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -5,3 +5,5 @@
 - [Running the services locally](running/index.md)
 
 - [Building the packages](packages.md)
+
+- [End-to-end tests](e2e-tests.md)

--- a/docs/dev/running/aziot-certd.md
+++ b/docs/dev/running/aziot-certd.md
@@ -200,6 +200,8 @@ With this basic file, fill it out depending on what workflow you want to test:
         "est-ca" = "file:///path/to/est/ca/cert.pem"
         ```
 
+1. Create the `/run/aziot` directory if it doesn't already exist, and make sure it's readable and writable by the user you will run the service as.
+
 1. Finally, run the service.
 
     As mentioned at the beginning, if your config file is not saved at `/etc/aziot/certd/config.toml`, set the `AZIOT_CERTD_CONFIG` env var to its actual path.

--- a/docs/dev/running/aziot-identityd.md
+++ b/docs/dev/running/aziot-identityd.md
@@ -147,7 +147,9 @@ The table of principal accounts in Identity Service configuration represents eac
 
 ## Running `aziot-identityd`
 
-Run the following command to launch the Identity Service, setting the path of the `config.toml` file as the `AZIOT_IDENTITYD_CONFIG` env var:
+Create the `/run/aziot` directory if it doesn't already exist, and make sure it's readable and writable by the user you will run the service as.
+
+Then run the following command to launch the Identity Service, setting the path of the `config.toml` file as the `AZIOT_IDENTITYD_CONFIG` env var:
 
 ```sh
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/target/x86_64-unknown-linux-gnu/debug"

--- a/docs/dev/running/aziot-keyd.md
+++ b/docs/dev/running/aziot-keyd.md
@@ -118,6 +118,8 @@ Assuming you're using Microsoft's implementation of `libaziot_keys.so`, start wi
     export TPM2_PKCS11_STORE=/opt/tpm2-pkcs11
     ```
 
+1. Create the `/run/aziot` directory if it doesn't already exist, and make sure it's readable and writable by the user you will run the service as.
+
 1. Run the service, setting the `AZIOT_KEYD_CONFIG` env var if necessary.
 
     ```sh


### PR DESCRIPTION
This commit adds two GH workflows that run an E2E test script against
all supported OSes in dynamically-created Azure VMs against
dynamically-created IoT Hubs. The test installs the latest
aziot-identity-service package, configures the provisioning method according to
the test parameters, registers a single host process module, and asserts that
identityd is able to complete provisioning and the module is able to get
its identity.

One workflow is a scheduled workflow that runs once a day and is only usable on
the Azure/iot-identity-service repo. The other can be triggered manually
via the github.com UI and is primarily meant for forks, so that devs can
run them against their work branches.

The test script can also be run locally instead of in a GH workflow.

The script uses an OS-appropriate package from the latest successful
packages workflow run for the specified git branch. When running locally,
it can be told to use a locally-built package instead.

Currently the setup has the following limitations:

- Only one provisioning method is tested - manual+symmetric-key device identity.
  Manual+X509 and DPS tests will be added later.

- Only the amd64 architecture is tested. Testing other architectures
  cannot be done in Azure VMs and will require our own hosted GH agents on
  arm32v7 and aarch64 hardware.

- PKCS#11 is not tested. PKCS#11 tests using tpm2-pkcs11 with ibmswtpm2 can
  be run on the Azure VMs, and will be done in the future.

Other changes:

- Fix file extension check when merging configs.

- Clarify service docs that `/run/aziot` also needs to exist and be writable.

- Use systemd helpers in RPM spec to handle enabling and restarting.