### PR TITLE
Disable hard warnings + rustfmt during local dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
     This is enforced by `make test-release`.
 
-    When developing locally, consider using `make test` instead, which does not enforcing rustfmt code formatting.
+    Make sure to run `make test-release` before pushing to your remote so that you run all the checks that CI would run, as `make test` does not enforce rustfmt!
 
 1. Every crate root must enable the major lint groups and warnings-as-errors:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,16 +20,22 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
     - Rust: `// Copyright (c) Microsoft. All rights reserved.`
     - C: `/* Copyright (c) Microsoft. All rights reserved. */`
 
-    This is enforced by `make test`
+    This is enforced by `make test`.
+
+1. Rust code must be formatted with `rustfmt`
+
+    This is enforced by `make test-release`.
+
+    When developing locally, consider using `make test` instead, which does not enforcing rustfmt code formatting.
 
 1. Every crate root must enable the major lint groups and warnings-as-errors:
 
     ```rust
-    #![deny(rust_2018_idioms, warnings)]
-    #![deny(clippy::all, clippy::pedantic)]
+    #![deny(rust_2018_idioms)]
+    #![warn(clippy::all, clippy::pedantic)]
     ```
 
-    This is enforced by `make test`
+    This is enforced by `make test`.
 
     A crate root is any file that is the entrypoint of a crate. This includes `lib.rs`, `main.rs`, `build.rs` (build scripts), `tests/*.rs` (integration tests) and `examples/*.rs` (examples).
 
@@ -37,13 +43,13 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
     - `rust_2018_idioms`: This lint group fires for code that could be written in a better style in Edition 2018. For example, it enforces that `extern crate` statements are not used, and that trait objects are written like `dyn Trait` instead of just `Trait`.
 
-    - `warnings`: Denying this lint group converts all warnings to errors.
-
     - `clippy::all`: This lint group contains the mostly-uncontroversial clippy lints.
 
-    - `clippy::pedantic`: This lint group contains more subjective clippy lints. While some of these lints are overly pedantic and okay to `allow` (see below), there are some lints in this group that are useful, so we prefer to `deny` this group by default.
+    - `clippy::pedantic`: This lint group contains more subjective clippy lints. While some of these lints are overly pedantic and okay to `allow` (see below), there are some lints in this group that are useful, so we prefer to `warn` this group by default.
 
-    In general, if any of the above lint groups raises an error, it should be fixed by modifying the code to satisfy the lint. However, there are some lints that it is acceptable to `allow`. The list below enumerates these lints. Note that it is okay to `allow` these lints at the crate level with `#![allow(...)]`, rather than at the smallest scope where the lint was raised with `#[allow(...)]`, unless indicated otherwise.
+    When running in CI, the `make test-release` target is used, and all warnings are treated as errors.
+
+    In general, if any of the above lint groups raises an error/warning, it should be fixed by modifying the code to satisfy the lint. However, there are some lints that it is acceptable to `allow`. The list below enumerates these lints. Note that it is okay to `allow` these lints at the crate level with `#![allow(...)]`, rather than at the smallest scope where the lint was raised with `#[allow(...)]`, unless indicated otherwise.
 
     1. `clippy::default_trait_access`: This lint fires for code that uses `Default::default()` and suggests using `ConcreteType::default()`. However, in most cases, there is no benefit to naming the `ConcreteType` explicitly because it doesn't matter which type's default is being used, and it can create more noise from having to `use path::to::ConcreteType` than to leave it unnamed.
 

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,6 @@ target/openapi-schema-validated:
 	touch target/openapi-schema-validated
 
 
-test-release: export RUSTFLAGS += -D warnings
 test-release: CLIPPY_FLAGS = -D warnings -D clippy::all -D clippy::pedantic
 test-release: test
 	$(CARGO) fmt --all -- --check

--- a/aziot/src/main.rs
+++ b/aziot/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_unit_value,

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -5,8 +5,8 @@
 //! this one aziotd binary. The aziotd binary looks at its command-line args to figure out
 //! which service it's being invoked as, and runs the code of that service accordingly.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::default_trait_access, clippy::let_unit_value)]
 
 mod error;

--- a/cert/aziot-cert-client-async/src/lib.rs
+++ b/cert/aziot-cert-client-async/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,

--- a/cert/aziot-cert-common-http/src/lib.rs
+++ b/cert/aziot-cert-common-http/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ApiVersion {

--- a/cert/aziot-cert-common/src/lib.rs
+++ b/cert/aziot-cert-common/src/lib.rs
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]

--- a/cert/aziot-certd/build/main.rs
+++ b/cert/aziot-certd/build/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
     let mut build = openssl_build::get_c_compiler();

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,

--- a/ci/test-basic.sh
+++ b/ci/test-basic.sh
@@ -6,4 +6,4 @@ cd /src
 
 . ./ci/install-build-deps.sh
 
-make V=1 test
+make V=1 test-release

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,

--- a/identity/aziot-dps-client-async/src/lib.rs
+++ b/identity/aziot-dps-client-async/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,

--- a/identity/aziot-hub-client-async/src/lib.rs
+++ b/identity/aziot-hub-client-async/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,

--- a/identity/aziot-identity-common-http/src/lib.rs
+++ b/identity/aziot-identity-common-http/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ApiVersion {

--- a/identity/aziot-identity-common/src/lib.rs
+++ b/identity/aziot-identity-common/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct DeviceId(pub String);

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,

--- a/iotedged/src/main.rs
+++ b/iotedged/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,

--- a/key/aziot-key-client-async/src/lib.rs
+++ b/key/aziot-key-client-async/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,

--- a/key/aziot-key-client/src/lib.rs
+++ b/key/aziot-key-client/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::let_and_return,
     clippy::missing_errors_doc,

--- a/key/aziot-key-common-http/src/lib.rs
+++ b/key/aziot-key-common-http/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ApiVersion {

--- a/key/aziot-key-common/src/lib.rs
+++ b/key/aziot-key-common/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct KeyHandle(pub String);

--- a/key/aziot-key-openssl-engine-shared/build/main.rs
+++ b/key/aziot-key-openssl-engine-shared/build/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
     openssl_build::define_version_number_cfg();

--- a/key/aziot-key-openssl-engine-shared/src/lib.rs
+++ b/key/aziot-key-openssl-engine-shared/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
 	clippy::doc_markdown, // clippy wants "IoT" in a code fence
 )]

--- a/key/aziot-key-openssl-engine/build/main.rs
+++ b/key/aziot-key-openssl-engine/build/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
     openssl_build::define_version_number_cfg();

--- a/key/aziot-key-openssl-engine/src/lib.rs
+++ b/key/aziot-key-openssl-engine/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
 	clippy::doc_markdown, // clippy wants "IoT" in a code fence
 	clippy::let_and_return,

--- a/key/aziot-keyd/build.rs
+++ b/key/aziot-keyd/build.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
     println!("cargo:rustc-link-lib=aziot_keys");

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,

--- a/key/aziot-keys-common/src/lib.rs
+++ b/key/aziot-keys-common/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 /// This crate exists to hold any types that need to be shared between aziot-keys and the other crates,
 /// so that aziot-keys does not have to be compiled as an rlib.

--- a/key/aziot-keys/src/lib.rs
+++ b/key/aziot-keys/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
 	non_camel_case_types,
 	clippy::default_trait_access,

--- a/openssl-build/src/lib.rs
+++ b/openssl-build/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::must_use_candidate)]
 
 /// Emits `ossl110` and `ossl111` cfgs based on the version of openssl.

--- a/openssl-sys2/build/main.rs
+++ b/openssl-sys2/build/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
     openssl_build::define_version_number_cfg();

--- a/openssl-sys2/src/lib.rs
+++ b/openssl-sys2/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(non_camel_case_types)]
 
 mod asn1;

--- a/openssl2/build/main.rs
+++ b/openssl2/build/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
     openssl_build::define_version_number_cfg();

--- a/openssl2/src/lib.rs
+++ b/openssl2/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::missing_errors_doc,

--- a/pkcs11/pkcs11-openssl-engine/build/main.rs
+++ b/pkcs11/pkcs11-openssl-engine/build/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
     openssl_build::define_version_number_cfg();

--- a/pkcs11/pkcs11-openssl-engine/src/lib.rs
+++ b/pkcs11/pkcs11-openssl-engine/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::let_and_return,
     clippy::missing_errors_doc,

--- a/pkcs11/pkcs11-sys/src/lib.rs
+++ b/pkcs11/pkcs11-sys/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     non_camel_case_types,
     non_snake_case,

--- a/pkcs11/pkcs11-test/build.rs
+++ b/pkcs11/pkcs11-test/build.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
     openssl_build::define_version_number_cfg();

--- a/pkcs11/pkcs11-test/src/main.rs
+++ b/pkcs11/pkcs11-test/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
     clippy::let_unit_value,

--- a/pkcs11/pkcs11/build.rs
+++ b/pkcs11/pkcs11/build.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
     openssl_build::define_version_number_cfg();

--- a/pkcs11/pkcs11/src/lib.rs
+++ b/pkcs11/pkcs11/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(rust_2018_idioms, warnings)]
-#![deny(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     non_snake_case,
     clippy::default_trait_access,


### PR DESCRIPTION
This PR replaces the `#![deny(warnings, clippy::all, clippy::pedantic)]` directives with `#![warn(clippy::all, clippy::pedantic)]` + passing `-D warning -D clippy::pedantic -D clippy::all` when running in the CI.

The reasoning for this is outlined in https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md, but TL;DR, it gives developers the option to leave some warnings in the code while testing new changes, while nonetheless enforcing warning-free code in commits. 

The Makefile has been modified to include a new target `test-release`. This target depends on the `test` target, while also setting the corresponding `-D` flags as well. Additionally, the `rustfmt` check has been moved into the `test-release` target, giving developers the option to only run `rustfmt` once it's time to push a commit.