### PR TITLE
DPS refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,10 +146,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "aziot-cloud-client-async-common"
+version = "0.1.0"
+dependencies = [
+ "aziot-cert-client-async",
+ "aziot-key-client-async",
+ "aziot-key-common",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-common",
+ "hyper",
+ "hyper-openssl",
+ "log",
+ "openssl",
+ "openssl2",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "aziot-dps-client-async"
 version = "0.1.0"
 dependencies = [
  "aziot-cert-client-async",
+ "aziot-cloud-client-async-common",
  "aziot-key-client",
  "aziot-key-client-async",
  "aziot-key-common",
@@ -157,6 +183,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
+ "futures-util",
  "http",
  "http-common",
  "hyper",
@@ -177,6 +204,7 @@ version = "0.1.0"
 dependencies = [
  "aziot-cert-client-async",
  "aziot-cert-common-http",
+ "aziot-cloud-client-async-common",
  "aziot-identity-common",
  "aziot-key-client",
  "aziot-key-client-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 
 	"http-common",
 
+	"identity/aziot-cloud-client-async-common",
 	"identity/aziot-dps-client-async",
 	"identity/aziot-hub-client-async",
 	"identity/aziot-identity-common",

--- a/identity/aziot-cloud-client-async-common/Cargo.toml
+++ b/identity/aziot-cloud-client-async-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "aziot-dps-client-async"
+name = "aziot-cloud-client-async-common"
 version = "0.1.0"
-authors = ["Rajeev Massand <massand@gmail.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 publish = false
 
@@ -22,10 +22,7 @@ futures-util = "0.3"
 url = "2"
 
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }
-aziot-cloud-client-async-common = { path = "../aziot-cloud-client-async-common" }
-aziot-key-client = { path = "../../key/aziot-key-client" }
 aziot-key-client-async = { path = "../../key/aziot-key-client-async" }
 aziot-key-common = { path = "../../key/aziot-key-common" }
-aziot-key-openssl-engine = { path = "../../key/aziot-key-openssl-engine" }
 http-common = { path = "../../http-common" }
 openssl2 = { path = "../../openssl2" }

--- a/identity/aziot-cloud-client-async-common/src/lib.rs
+++ b/identity/aziot-cloud-client-async-common/src/lib.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::let_and_return, clippy::missing_errors_doc)]
+
+use std::io;
+
+pub const ENCODE_SET: &percent_encoding::AsciiSet = &http_common::PATH_SEGMENT_ENCODE_SET.add(b'=');
+
+pub async fn get_sas_connector(
+    audience: &str,
+    key_handle: &str,
+    key_client: &aziot_key_client_async::Client,
+) -> io::Result<(
+    hyper_openssl::HttpsConnector<hyper::client::HttpConnector>,
+    String,
+)> {
+    let key_handle = key_client.load_key(key_handle).await?;
+
+    let token = {
+        let expiry = chrono::Utc::now()
+            + chrono::Duration::from_std(std::time::Duration::from_secs(30))
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let expiry = expiry.timestamp().to_string();
+
+        let resource_uri =
+            percent_encoding::percent_encode(audience.to_lowercase().as_bytes(), ENCODE_SET)
+                .to_string();
+        let sig_data = format!("{}\n{}", &resource_uri, expiry);
+
+        let signature = key_client
+            .sign(
+                &key_handle,
+                aziot_key_common::SignMechanism::HmacSha256,
+                sig_data.as_bytes(),
+            )
+            .await?;
+
+        let signature = base64::encode(&signature);
+
+        let token = url::form_urlencoded::Serializer::new(format!("sr={}", resource_uri))
+            .append_pair("sig", &signature)
+            .append_pair("se", &expiry)
+            .finish();
+        token
+    };
+
+    let token = format!("SharedAccessSignature {}", token);
+
+    let tls_connector = hyper_openssl::HttpsConnector::new()?;
+    Ok((tls_connector, token))
+}
+
+pub async fn get_x509_connector(
+    identity_cert: &str,
+    identity_pk: &str,
+    key_client: &aziot_key_client_async::Client,
+    key_engine: &mut openssl2::FunctionalEngineRef,
+    cert_client: &aziot_cert_client_async::Client,
+) -> io::Result<hyper_openssl::HttpsConnector<hyper::client::HttpConnector>> {
+    let connector = {
+        let mut tls_connector =
+            openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls())?;
+
+        let device_id_private_key = {
+            let device_id_key_handle = key_client.load_key_pair(&identity_pk).await?;
+            let device_id_key_handle = std::ffi::CString::new(device_id_key_handle.0)?;
+            let device_id_private_key = key_engine
+                .load_private_key(&device_id_key_handle)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            device_id_private_key
+        };
+        tls_connector.set_private_key(&device_id_private_key)?;
+
+        let mut device_id_certs = {
+            let device_id_certs = cert_client.get_cert(&identity_cert).await?;
+            let device_id_certs =
+                openssl::x509::X509::stack_from_pem(&device_id_certs)?.into_iter();
+            device_id_certs
+        };
+        let client_cert = device_id_certs.next().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "device identity cert not found")
+        })?;
+        tls_connector.set_certificate(&client_cert)?;
+        for cert in device_id_certs {
+            tls_connector.add_extra_chain_cert(cert)?;
+        }
+
+        let mut http_connector = hyper::client::HttpConnector::new();
+        http_connector.enforce_http(false);
+        let tls_connector =
+            hyper_openssl::HttpsConnector::with_connector(http_connector, tls_connector)?;
+        tls_connector
+    };
+    Ok(connector)
+}

--- a/identity/aziot-dps-client-async/Cargo.toml
+++ b/identity/aziot-dps-client-async/Cargo.toml
@@ -18,6 +18,7 @@ percent-encoding = "2"
 tokio = { version = "0.2", features = ["dns", "macros"] }
 serde = "1"
 serde_json = "1"
+futures-util = "0.3"
 url = "2"
 
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }

--- a/identity/aziot-dps-client-async/src/lib.rs
+++ b/identity/aziot-dps-client-async/src/lib.rs
@@ -13,323 +13,339 @@
     clippy::type_complexity
 )]
 
+use std::sync::Arc;
+
 pub mod model;
 
 pub const DPS_ENCODE_SET: &percent_encoding::AsciiSet =
     &http_common::PATH_SEGMENT_ENCODE_SET.add(b'=');
 
-pub async fn register(
-    uri: &str,
-    scope_id: &str,
-    registration_id: &str,
-    sas_key: Option<String>,
-    identity_cert: Option<String>,
-    identity_pk: Option<String>,
-    key_client: &aziot_key_client_async::Client,
-    key_engine: &mut openssl2::FunctionalEngineRef,
-    cert_client: &aziot_cert_client_async::Client,
-) -> Result<model::RegistrationOperationStatus, std::io::Error> {
-    let resource_uri = format!(
-        "/{}/registrations/{}/register?api-version=2018-11-01",
-        scope_id, registration_id
-    );
-
-    let body = model::DeviceRegistration {
-        registration_id: Some(registration_id.into()),
-    };
-
-    let res: model::RegistrationOperationStatus = request(
-        uri,
-        scope_id,
-        registration_id,
-        http::Method::PUT,
-        &resource_uri,
-        sas_key,
-        identity_cert,
-        identity_pk,
-        Some(&body),
-        key_client,
-        key_engine,
-        cert_client,
-    )
-    .await?;
-
-    Ok(res)
+pub enum DpsAuthKind {
+    SymmetricKey {
+        sas_key: String,
+    },
+    X509 {
+        identity_cert: String,
+        identity_pk: String,
+    },
 }
 
-pub async fn get_operation_status(
-    uri: &str,
-    scope_id: &str,
-    registration_id: &str,
-    operation_id: &str,
-    sas_key: Option<String>,
-    identity_cert: Option<String>,
-    identity_pk: Option<String>,
-    key_client: &aziot_key_client_async::Client,
-    key_engine: &mut openssl2::FunctionalEngineRef,
-    cert_client: &aziot_cert_client_async::Client,
-) -> Result<model::RegistrationOperationStatus, std::io::Error> {
-    let resource_uri = format!(
-        "/{}/registrations/{}/operations/{}?api-version=2018-11-01",
-        scope_id, registration_id, operation_id
-    );
+pub struct Client {
+    global_endpoint: String,
+    scope_id: String,
 
-    let res: model::RegistrationOperationStatus = request::<(), _>(
-        uri,
-        scope_id,
-        registration_id,
-        http::Method::GET,
-        &resource_uri,
-        sas_key,
-        identity_cert,
-        identity_pk,
-        None,
-        key_client,
-        key_engine,
-        cert_client,
-    )
-    .await?;
-
-    Ok(res)
+    key_client: Arc<aziot_key_client_async::Client>,
+    key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
+    cert_client: Arc<aziot_cert_client_async::Client>,
 }
 
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
-pub struct Error {
-    #[serde(alias = "Message")]
-    pub message: std::borrow::Cow<'static, str>,
-}
+impl Client {
+    #[must_use]
+    pub fn new(
+        global_endpoint: &str,
+        scope_id: &str,
+        key_client: Arc<aziot_key_client_async::Client>,
+        key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
+        cert_client: Arc<aziot_cert_client_async::Client>,
+    ) -> Self {
+        Client {
+            global_endpoint: global_endpoint.to_owned(),
+            scope_id: scope_id.to_owned(),
 
-async fn request<TRequest, TResponse>(
-    global_endpoint: &str,
-    scope_id: &str,
-    registration_id: &str,
-    method: http::Method,
-    uri: &str,
-    sas_key: Option<String>,
-    identity_cert: Option<String>,
-    identity_pk: Option<String>,
-    body: Option<&TRequest>,
-    key_client: &aziot_key_client_async::Client,
-    key_engine: &mut openssl2::FunctionalEngineRef,
-    cert_client: &aziot_cert_client_async::Client,
-) -> std::io::Result<TResponse>
-where
-    TRequest: serde::Serialize,
-    TResponse: serde::de::DeserializeOwned,
-{
-    let uri = format!("{}{}", global_endpoint, uri);
-
-    let req = hyper::Request::builder().method(method).uri(uri);
-    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let req = if let Some(body) = body {
-        let body = serde_json::to_vec(body)
-            .expect("serializing request body to JSON cannot fail")
-            .into();
-        req.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        req.body(hyper::Body::default())
-    };
-
-    let mut req = req.expect("cannot fail to create hyper request");
-
-    let connector = if let Some(key) = sas_key.clone() {
-        let (connector, token) =
-            get_sas_connector(scope_id.into(), registration_id.into(), key, key_client).await?;
-
-        let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-        req.headers_mut()
-            .append(hyper::header::AUTHORIZATION, authorization_header_value);
-        connector
-    } else {
-        get_x509_connector(
-            identity_cert.expect("device identity certificate not found"),
-            identity_pk.expect("device private key not found"),
             key_client,
             key_engine,
             cert_client,
-        )
-        .await?
-    };
-
-    let client = hyper::Client::builder().build(connector);
-    log::debug!("DPS request {:?}", req);
-
-    let res = client
-        .request(req)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let (
-        http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
-        },
-        body,
-    ) = res.into_parts();
-    log::debug!("DPS response status {:?}", res_status_code);
-    log::debug!("DPS response headers{:?}", headers);
-
-    let mut is_json = false;
-    for (header_name, header_value) in headers {
-        if header_name == Some(hyper::header::CONTENT_TYPE) {
-            let value = header_value
-                .to_str()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            if value.contains("application/json") {
-                is_json = true;
-            }
         }
     }
 
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-    log::debug!("DPS response body {:?}", body);
+    pub async fn register(
+        &self,
+        registration_id: &str,
+        auth_kind: &DpsAuthKind,
+    ) -> Result<model::RegistrationOperationStatus, std::io::Error> {
+        let resource_uri = format!(
+            "/{}/registrations/{}/register?api-version=2018-11-01",
+            self.scope_id, registration_id
+        );
 
-    let res: TResponse = match res_status_code {
-        hyper::StatusCode::OK | hyper::StatusCode::ACCEPTED => {
-            if !is_json {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "malformed HTTP response",
-                ));
-            }
-            let res = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            res
-        }
+        let body = model::DeviceRegistration {
+            registration_id: Some(registration_id.into()),
+        };
 
-        res_status_code
-            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-        {
-            let res: crate::Error = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
-        }
-
-        _ => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "malformed HTTP response",
-            ))
-        }
-    };
-
-    Ok(res)
-}
-
-async fn get_sas_connector(
-    scope_id: String,
-    registration_id: String,
-    key_handle: String,
-    key_client: &aziot_key_client_async::Client,
-) -> Result<
-    (
-        hyper_openssl::HttpsConnector<hyper::client::HttpConnector>,
-        String,
-    ),
-    std::io::Error,
-> {
-    let key_handle = key_client.load_key(&*key_handle).await?;
-
-    let token = {
-        let expiry = chrono::Utc::now()
-            + chrono::Duration::from_std(std::time::Duration::from_secs(30))
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-        let expiry = expiry.timestamp().to_string();
-        let audience = format!("{}/registrations/{}", scope_id, registration_id);
-
-        let resource_uri =
-            percent_encoding::percent_encode(audience.to_lowercase().as_bytes(), DPS_ENCODE_SET)
-                .to_string();
-        let sig_data = format!("{}\n{}", &resource_uri, expiry);
-
-        let signature = key_client
-            .sign(
-                &key_handle,
-                aziot_key_common::SignMechanism::HmacSha256,
-                sig_data.as_bytes(),
+        let res: model::RegistrationOperationStatus = self
+            .request(
+                registration_id,
+                http::Method::PUT,
+                &resource_uri,
+                auth_kind,
+                Some(&body),
             )
+            .await?;
+
+        Ok(res)
+    }
+
+    pub async fn get_operation_status(
+        &self,
+        registration_id: &str,
+        operation_id: &str,
+        auth_kind: &DpsAuthKind,
+    ) -> Result<model::RegistrationOperationStatus, std::io::Error> {
+        let resource_uri = format!(
+            "/{}/registrations/{}/operations/{}?api-version=2018-11-01",
+            self.scope_id, registration_id, operation_id
+        );
+
+        let res: model::RegistrationOperationStatus = self
+            .request::<(), _>(
+                registration_id,
+                http::Method::GET,
+                &resource_uri,
+                auth_kind,
+                None,
+            )
+            .await?;
+
+        Ok(res)
+    }
+
+    async fn request<TRequest, TResponse>(
+        &self,
+        registration_id: &str,
+        method: http::Method,
+        resource_uri: &str,
+        auth_kind: &DpsAuthKind,
+        body: Option<&TRequest>,
+    ) -> std::io::Result<TResponse>
+    where
+        TRequest: serde::Serialize,
+        TResponse: serde::de::DeserializeOwned,
+    {
+        let uri = format!("{}{}", self.global_endpoint, resource_uri);
+
+        let req = hyper::Request::builder().method(method).uri(uri);
+        // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
+        //
+        // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
+        #[allow(clippy::option_if_let_else)]
+        let req = if let Some(body) = body {
+            let body = serde_json::to_vec(body)
+                .expect("serializing request body to JSON cannot fail")
+                .into();
+            req.header(hyper::header::CONTENT_TYPE, "application/json")
+                .body(body)
+        } else {
+            req.body(hyper::Body::default())
+        };
+
+        let mut req = req.expect("cannot fail to create hyper request");
+
+        let connector = match auth_kind {
+            DpsAuthKind::SymmetricKey { sas_key } => {
+                let (connector, token) = self.get_sas_connector(registration_id, &sas_key).await?;
+
+                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                req.headers_mut()
+                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
+                connector
+            }
+            DpsAuthKind::X509 {
+                identity_cert,
+                identity_pk,
+            } => {
+                self.get_x509_connector(&identity_cert, &identity_pk)
+                    .await?
+            }
+        };
+
+        let client = hyper::Client::builder().build(connector);
+        log::debug!("DPS request {:?}", req);
+
+        let res = client
+            .request(req)
             .await
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
 
-        let signature = base64::encode(&signature);
+        let (
+            http::response::Parts {
+                status: res_status_code,
+                headers,
+                ..
+            },
+            body,
+        ) = res.into_parts();
+        log::debug!("DPS response status {:?}", res_status_code);
+        log::debug!("DPS response headers{:?}", headers);
 
-        let token = url::form_urlencoded::Serializer::new(format!("sr={}", resource_uri))
-            .append_pair("sig", &signature)
-            .append_pair("se", &expiry)
-            .finish();
-        token
-    };
-
-    let token = format!("SharedAccessSignature {}", token);
-
-    let tls_connector = hyper_openssl::HttpsConnector::new()
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-    Ok((tls_connector, token))
-}
-
-async fn get_x509_connector(
-    identity_cert: String,
-    identity_pk: String,
-    key_client: &aziot_key_client_async::Client,
-    key_engine: &mut openssl2::FunctionalEngineRef,
-    cert_client: &aziot_cert_client_async::Client,
-) -> Result<hyper_openssl::HttpsConnector<hyper::client::HttpConnector>, std::io::Error> {
-    let connector = {
-        let mut tls_connector = openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls())
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-        let device_id_private_key = {
-            let device_id_key_handle = key_client
-                .load_key_pair(&identity_pk)
-                .await
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            let device_id_key_handle = std::ffi::CString::new(device_id_key_handle.0)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            let device_id_private_key = key_engine
-                .load_private_key(&device_id_key_handle)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            device_id_private_key
-        };
-        tls_connector
-            .set_private_key(&device_id_private_key)
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-        let mut device_id_certs = {
-            let device_id_certs = cert_client
-                .get_cert(&identity_cert)
-                .await
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            let device_id_certs = openssl::x509::X509::stack_from_pem(&device_id_certs)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
-                .into_iter();
-            device_id_certs
-        };
-        let client_cert = device_id_certs.next().ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::Other, "device identity cert not found")
-        })?;
-        tls_connector
-            .set_certificate(&client_cert)
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-        for cert in device_id_certs {
-            tls_connector
-                .add_extra_chain_cert(cert)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+        let mut is_json = false;
+        for (header_name, header_value) in headers {
+            if header_name == Some(hyper::header::CONTENT_TYPE) {
+                let value = header_value
+                    .to_str()
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                if value.contains("application/json") {
+                    is_json = true;
+                }
+            }
         }
 
-        let mut http_connector = hyper::client::HttpConnector::new();
-        http_connector.enforce_http(false);
-        let tls_connector =
-            hyper_openssl::HttpsConnector::with_connector(http_connector, tls_connector)
+        let body = hyper::body::to_bytes(body)
+            .await
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+        log::debug!("DPS response body {:?}", body);
+
+        let res: TResponse = match res_status_code {
+            hyper::StatusCode::OK | hyper::StatusCode::ACCEPTED => {
+                if !is_json {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "malformed HTTP response",
+                    ));
+                }
+                let res = serde_json::from_slice(&body)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                res
+            }
+
+            res_status_code
+                if res_status_code.is_client_error() || res_status_code.is_server_error() =>
+            {
+                #[derive(Debug, serde::Deserialize, serde::Serialize)]
+                pub struct Error {
+                    #[serde(alias = "Message")]
+                    pub message: std::borrow::Cow<'static, str>,
+                }
+
+                let res: Error = serde_json::from_slice(&body)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
+            }
+
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "malformed HTTP response",
+                ))
+            }
+        };
+
+        Ok(res)
+    }
+
+    async fn get_sas_connector(
+        &self,
+        registration_id: &str,
+        key_handle: &str,
+    ) -> Result<
+        (
+            hyper_openssl::HttpsConnector<hyper::client::HttpConnector>,
+            String,
+        ),
+        std::io::Error,
+    > {
+        let key_handle = self.key_client.load_key(key_handle).await?;
+
+        let token = {
+            let expiry = chrono::Utc::now()
+                + chrono::Duration::from_std(std::time::Duration::from_secs(30))
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            let expiry = expiry.timestamp().to_string();
+            let audience = format!("{}/registrations/{}", self.scope_id, registration_id);
+
+            let resource_uri = percent_encoding::percent_encode(
+                audience.to_lowercase().as_bytes(),
+                DPS_ENCODE_SET,
+            )
+            .to_string();
+            let sig_data = format!("{}\n{}", &resource_uri, expiry);
+
+            let signature = self
+                .key_client
+                .sign(
+                    &key_handle,
+                    aziot_key_common::SignMechanism::HmacSha256,
+                    sig_data.as_bytes(),
+                )
+                .await
                 .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-        tls_connector
-    };
-    Ok(connector)
+
+            let signature = base64::encode(&signature);
+
+            let token = url::form_urlencoded::Serializer::new(format!("sr={}", resource_uri))
+                .append_pair("sig", &signature)
+                .append_pair("se", &expiry)
+                .finish();
+            token
+        };
+
+        let token = format!("SharedAccessSignature {}", token);
+
+        let tls_connector = hyper_openssl::HttpsConnector::new()
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+        Ok((tls_connector, token))
+    }
+
+    async fn get_x509_connector(
+        &self,
+        identity_cert: &str,
+        identity_pk: &str,
+    ) -> Result<hyper_openssl::HttpsConnector<hyper::client::HttpConnector>, std::io::Error> {
+        let connector = {
+            let mut tls_connector =
+                openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls())
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+            let device_id_private_key = {
+                let device_id_key_handle = self
+                    .key_client
+                    .load_key_pair(identity_pk)
+                    .await
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                let device_id_key_handle = std::ffi::CString::new(device_id_key_handle.0)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                let device_id_private_key = self
+                    .key_engine
+                    .lock()
+                    .await
+                    .load_private_key(&device_id_key_handle)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                device_id_private_key
+            };
+            tls_connector
+                .set_private_key(&device_id_private_key)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+            let mut device_id_certs = {
+                let device_id_certs = self
+                    .cert_client
+                    .get_cert(identity_cert)
+                    .await
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                let device_id_certs = openssl::x509::X509::stack_from_pem(&device_id_certs)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
+                    .into_iter();
+                device_id_certs
+            };
+            let client_cert = device_id_certs.next().ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::Other, "device identity cert not found")
+            })?;
+            tls_connector
+                .set_certificate(&client_cert)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            for cert in device_id_certs {
+                tls_connector
+                    .add_extra_chain_cert(cert)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            }
+
+            let mut http_connector = hyper::client::HttpConnector::new();
+            http_connector.enforce_http(false);
+            let tls_connector =
+                hyper_openssl::HttpsConnector::with_connector(http_connector, tls_connector)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            tls_connector
+        };
+        Ok(connector)
+    }
 }

--- a/identity/aziot-hub-client-async/Cargo.toml
+++ b/identity/aziot-hub-client-async/Cargo.toml
@@ -20,8 +20,9 @@ serde = "1"
 serde_json = "1"
 url = "2"
 
-aziot-cert-common-http = { path = "../../cert/aziot-cert-common-http" }
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }
+aziot-cert-common-http = { path = "../../cert/aziot-cert-common-http" }
+aziot-cloud-client-async-common = { path = "../aziot-cloud-client-async-common" }
 aziot-identity-common = { path = "../aziot-identity-common" }
 aziot-key-client = { path = "../../key/aziot-key-client" }
 aziot-key-client-async = { path = "../../key/aziot-key-client-async" }

--- a/identity/aziot-identityd/Cargo.toml
+++ b/identity/aziot-identityd/Cargo.toml
@@ -28,8 +28,8 @@ tokio = { version = "0.2", features = ["time"] }
 toml = "0.5"
 url = { version = "2.0", features = ["serde"] }
 
-aziot-cert-common-http = { path = "../../cert/aziot-cert-common-http" }
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }
+aziot-cert-common-http = { path = "../../cert/aziot-cert-common-http" }
 aziot-dps-client-async = { path = "../aziot-dps-client-async" }
 aziot-hub-client-async = { path = "../aziot-hub-client-async" }
 aziot-identity-common = { path = "../aziot-identity-common" }

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -466,11 +466,6 @@ impl Api {
                 );
 
                 let device = match attestation {
-                    settings::DpsAttestationMethod::TPM { registration_id } => {
-                        let _ = registration_id;
-                        log::warn!("DPS-TPM provisioning is unimplemented!");
-                        return Err(Error::DeviceNotFound);
-                    }
                     settings::DpsAttestationMethod::SymmetricKey {
                         registration_id,
                         symmetric_key,

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -450,6 +450,66 @@ impl Api {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn dps_get_registered_device(
+        &mut self,
+        credential: aziot_identity_common::Credentials,
+        global_endpoint: &str,
+        scope_id: &str,
+        registration_id: &str,
+        operation_id: &str,
+        symmetric_key: Option<String>,
+        identity_cert: Option<String>,
+        identity_pk: Option<String>,
+    ) -> Result<aziot_identity_common::IoTHubDevice, Error> {
+        let mut retry_count =
+            (DPS_ASSIGNMENT_TIMEOUT_SECS / DPS_ASSIGNMENT_RETRY_INTERVAL_SECS) + 1;
+        loop {
+            if retry_count == 0 {
+                return Err(Error::DeviceNotFound);
+            }
+            retry_count -= 1;
+
+            let credential_clone = credential.clone();
+            let reg_status = {
+                let mut key_engine = self.key_engine.lock().await;
+                aziot_dps_client_async::get_operation_status(
+                    global_endpoint,
+                    &scope_id,
+                    &registration_id,
+                    &operation_id,
+                    symmetric_key.clone(),
+                    identity_cert.clone(),
+                    identity_pk.clone(),
+                    &self.key_client,
+                    &mut *key_engine,
+                    &self.cert_client,
+                )
+                .await
+                .map_err(Error::DPSClient)?
+            };
+
+            let status = reg_status.status.ok_or(Error::DeviceNotFound)?;
+            if !status.eq_ignore_ascii_case("assigning") {
+                let mut state = reg_status.registration_state.ok_or(Error::DeviceNotFound)?;
+                let iothub_hostname = state.assigned_hub.get_or_insert("".into());
+                let device_id = state.device_id.get_or_insert("".into());
+                let device = aziot_identity_common::IoTHubDevice {
+                    iothub_hostname: iothub_hostname.clone(),
+                    device_id: device_id.clone(),
+                    credentials: credential_clone,
+                };
+
+                break Ok(device);
+            }
+
+            tokio::time::delay_for(tokio::time::Duration::from_secs(
+                DPS_ASSIGNMENT_RETRY_INTERVAL_SECS,
+            ))
+            .await;
+        }
+    }
+
     pub async fn provision_device(
         &mut self,
     ) -> Result<aziot_identity_common::ProvisioningStatus, Error> {
@@ -494,11 +554,16 @@ impl Api {
                 attestation,
             } => {
                 let device = match attestation {
+                    settings::DpsAttestationMethod::TPM { registration_id } => {
+                        let _ = registration_id;
+                        log::warn!("DPS-TPM provisioning is unimplemented!");
+                        return Err(Error::DeviceNotFound);
+                    }
                     settings::DpsAttestationMethod::SymmetricKey {
                         registration_id,
                         symmetric_key,
                     } => {
-                        let result = {
+                        let operation = {
                             let mut key_engine = self.key_engine.lock().await;
                             aziot_dps_client_async::register(
                                 global_endpoint.as_str(),
@@ -512,80 +577,26 @@ impl Api {
                                 &self.cert_client,
                             )
                             .await
-                        };
-                        let device = match result {
-                            Ok(operation) => {
-                                let mut retry_count = (DPS_ASSIGNMENT_TIMEOUT_SECS
-                                    / DPS_ASSIGNMENT_RETRY_INTERVAL_SECS)
-                                    + 1;
-                                let credential =
-                                    aziot_identity_common::Credentials::SharedPrivateKey(
-                                        symmetric_key.clone(),
-                                    );
-                                loop {
-                                    if retry_count == 0 {
-                                        return Err(Error::DeviceNotFound);
-                                    }
-                                    let credential_clone = credential.clone();
-                                    let result = {
-                                        let mut key_engine = self.key_engine.lock().await;
-                                        aziot_dps_client_async::get_operation_status(
-                                            global_endpoint.as_str(),
-                                            &scope_id,
-                                            &registration_id,
-                                            &operation.operation_id,
-                                            Some(symmetric_key.clone()),
-                                            None,
-                                            None,
-                                            &self.key_client,
-                                            &mut *key_engine,
-                                            &self.cert_client,
-                                        )
-                                        .await
-                                    };
-
-                                    match result {
-                                        Ok(reg_status) => {
-                                            match reg_status.status {
-                                                Some(status) => {
-                                                    if !status.eq_ignore_ascii_case("assigning") {
-                                                        let mut state = reg_status
-                                                            .registration_state
-                                                            .ok_or(Error::DeviceNotFound)?;
-                                                        let iothub_hostname = state
-                                                            .assigned_hub
-                                                            .get_or_insert("".into());
-                                                        let device_id = state
-                                                            .device_id
-                                                            .get_or_insert("".into());
-                                                        let device =
-                                                            aziot_identity_common::IoTHubDevice {
-                                                                iothub_hostname: iothub_hostname
-                                                                    .clone(),
-                                                                device_id: device_id.clone(),
-                                                                credentials: credential_clone,
-                                                            };
-
-                                                        break device;
-                                                    }
-                                                }
-                                                None => return Err(Error::DeviceNotFound),
-                                            };
-                                        }
-                                        Err(err) => return Err(Error::DPSClient(err)),
-                                    }
-                                    retry_count -= 1;
-                                    tokio::time::delay_for(tokio::time::Duration::from_secs(
-                                        DPS_ASSIGNMENT_RETRY_INTERVAL_SECS,
-                                    ))
-                                    .await;
-                                }
-                            }
-                            Err(err) => return Err(Error::DPSClient(err)),
+                            .map_err(Error::DPSClient)?
                         };
 
-                        self.id_manager.set_device(&device);
-                        aziot_identity_common::ProvisioningStatus::Provisioned(device)
+                        let credential = aziot_identity_common::Credentials::SharedPrivateKey(
+                            symmetric_key.clone(),
+                        );
+
+                        let device = self
+                            .dps_get_registered_device(
+                                credential,
+                                global_endpoint.as_str(),
+                                &scope_id,
+                                &registration_id,
+                                &operation.operation_id,
+                                Some(symmetric_key),
+                                None,
+                                None,
+                            )
+                            .await?;
+                        device
                     }
                     settings::DpsAttestationMethod::X509 {
                         registration_id,
@@ -600,7 +611,7 @@ impl Api {
                         )
                         .await?;
 
-                        let result = {
+                        let operation = {
                             let mut key_engine = self.key_engine.lock().await;
                             aziot_dps_client_async::register(
                                 global_endpoint.as_str(),
@@ -614,84 +625,31 @@ impl Api {
                                 &self.cert_client,
                             )
                             .await
+                            .map_err(Error::DPSClient)?
                         };
 
-                        let device = match result {
-                            Ok(operation) => {
-                                let mut retry_count = (DPS_ASSIGNMENT_TIMEOUT_SECS
-                                    / DPS_ASSIGNMENT_RETRY_INTERVAL_SECS)
-                                    + 1;
-                                let credential = aziot_identity_common::Credentials::X509 {
-                                    identity_cert: identity_cert.clone(),
-                                    identity_pk: identity_pk.clone(),
-                                };
-                                loop {
-                                    if retry_count == 0 {
-                                        return Err(Error::DeviceNotFound);
-                                    }
-                                    let credential_clone = credential.clone();
-                                    let result = {
-                                        let mut key_engine = self.key_engine.lock().await;
-                                        aziot_dps_client_async::get_operation_status(
-                                            global_endpoint.as_str(),
-                                            &scope_id,
-                                            &registration_id,
-                                            &operation.operation_id,
-                                            None,
-                                            Some(identity_cert.clone()),
-                                            Some(identity_pk.clone()),
-                                            &self.key_client,
-                                            &mut *key_engine,
-                                            &self.cert_client,
-                                        )
-                                        .await
-                                    };
-
-                                    match result {
-                                        Ok(reg_status) => {
-                                            match reg_status.status {
-                                                Some(status) => {
-                                                    if !status.eq_ignore_ascii_case("assigning") {
-                                                        let mut state = reg_status
-                                                            .registration_state
-                                                            .ok_or(Error::DeviceNotFound)?;
-                                                        let iothub_hostname = state
-                                                            .assigned_hub
-                                                            .get_or_insert("".into());
-                                                        let device_id = state
-                                                            .device_id
-                                                            .get_or_insert("".into());
-                                                        let device =
-                                                            aziot_identity_common::IoTHubDevice {
-                                                                iothub_hostname: iothub_hostname
-                                                                    .clone(),
-                                                                device_id: device_id.clone(),
-                                                                credentials: credential_clone,
-                                                            };
-
-                                                        break device;
-                                                    }
-                                                }
-                                                None => return Err(Error::DeviceNotFound),
-                                            };
-                                        }
-                                        Err(_) => return Err(Error::DeviceNotFound),
-                                    }
-                                    retry_count -= 1;
-                                    tokio::time::delay_for(tokio::time::Duration::from_secs(
-                                        DPS_ASSIGNMENT_RETRY_INTERVAL_SECS,
-                                    ))
-                                    .await;
-                                }
-                            }
-                            Err(_) => return Err(Error::DeviceNotFound),
+                        let credential = aziot_identity_common::Credentials::X509 {
+                            identity_cert: identity_cert.clone(),
+                            identity_pk: identity_pk.clone(),
                         };
 
-                        self.id_manager.set_device(&device);
-                        aziot_identity_common::ProvisioningStatus::Provisioned(device)
+                        let device = self
+                            .dps_get_registered_device(
+                                credential,
+                                global_endpoint.as_str(),
+                                &scope_id,
+                                &registration_id,
+                                &operation.operation_id,
+                                None,
+                                Some(identity_cert.clone()),
+                                Some(identity_pk.clone()),
+                            )
+                            .await?;
+                        device
                     }
                 };
-                device
+                self.id_manager.set_device(&device);
+                aziot_identity_common::ProvisioningStatus::Provisioned(device)
             }
             settings::ProvisioningType::None => {
                 log::info!("Skipping provisioning with IoT Hub.");

--- a/identity/aziot-identityd/src/settings.rs
+++ b/identity/aziot-identityd/src/settings.rs
@@ -165,6 +165,9 @@ pub enum DpsAttestationMethod {
         identity_cert: String,
         identity_pk: String,
     },
+    TPM {
+        registration_id: String,
+    },
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/identity/aziot-identityd/src/settings.rs
+++ b/identity/aziot-identityd/src/settings.rs
@@ -175,9 +175,6 @@ pub enum DpsAttestationMethod {
         identity_cert: String,
         identity_pk: String,
     },
-    TPM {
-        registration_id: String,
-    },
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
While working on TPM provisioning, I noticed that the DPS provisioning code use some refactoring. 
Some notable changes so far:

- Extracts the DPS registration polling into a separate attestation-method agnostic helper function.
- Refactors the DPS client from a series of standalone methods into a proper `Client` struct.
- Use an enum to encapsulate X509 and Symmetric Key specific parameters, reducing the number of Option unwraps/expects.

Aside from a small modification to the identityd config + a stubbed code path, this PR doesn't actually include any substantial DPS-TPM code, as it requires the `tpmd` infrastructure that only exists on my local branch.

I wanted to open this as a separate PR to get some early feedback on these changes, and to hopefully get some pointers on what I should expect once I add TPM provisioning into the mix (i.e: did I accidentally over-abstract).