### PR TITLE
Add type parameter to IS APIs

### DIFF
--- a/docs/identity-service.md
+++ b/docs/identity-service.md
@@ -238,10 +238,10 @@ The returned `auth.keyHandle` value is meant to be used with the [Keys Service](
 
 ### Get IoT module identity information
 
-`GET /identities/modules/{module-id}?api-version=2020-09-01[&type={type}]`
+`GET /identities/modules/{module-id}?api-version=2020-09-01&type={type}`
 
-The optional `type` query parameter specifies the identity type to return. Accepted values are:
-- `aziot`: Module identity. This is the default if type is not specified.
+The `type` query parameter specifies the identity type to return. Accepted values are:
+- `aziot`: Module identity.
 - `local`: Local identity.
 
 #### Response (SAS case)
@@ -301,9 +301,59 @@ The optional `type` query parameter specifies the identity type to return. Accep
 
 ---
 
+### Update IoT module identity
+
+`PUT /identities/modules/{module-id}?api-version=2020-09-01&type={type}`
+
+The `type` query parameter specifies the identity type to return. Accepted values are:
+- `aziot`: Module identity.
+
+#### Response (SAS case)
+```json
+{
+  "type": "aziot",
+  "spec":
+  {
+    "hubName": "myhub.net",
+    "deviceId": "device01",
+    "moduleId": "module01",
+    "genId": "12345",
+    "auth": {
+        "type": "sas",
+        "keyHandle": "string"
+   }
+  }
+}
+```
+
+#### Response (X.509 case)
+
+```json
+{
+  "type": "aziot",
+  "spec":
+  {
+    "hubName": "myhub.net",
+    "deviceId": "device01",
+    "moduleId": "module01",
+    "genId": "12345",
+    "auth": {
+        "type": "x509",
+        "keyHandle": "string",
+        "certId": "string"
+    }
+  }
+}
+```
+
+---
+
 ### Delete IoT module identity
 
-`DELETE /identities/modules/{module-id}?api-version=2020-09-01`
+`DELETE /identities/modules/{module-id}?api-version=2020-09-01&type={type}`
+
+The `type` query parameter specifies the identity type to return. Accepted values are:
+- `aziot`: Module identity.
 
 #### Response
 

--- a/docs/identity-service.md
+++ b/docs/identity-service.md
@@ -131,7 +131,10 @@ The returned `auth.keyHandle` value is meant to be used with the [Keys Service](
 ---
 
 ### List IoT Module Identities
-`GET /identities/modules?api-version=2020-09-01`
+`GET /identities/modules?api-version=2020-09-01&type={type}`
+
+The `type` query parameter specifies the identity type to return. Accepted values are:
+- `aziot`: Module identity.
 
 #### Response (SAS case)
 ```json

--- a/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
+++ b/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
@@ -23,7 +23,7 @@ impl http_common::server::Route for Route {
         }
 
         let id_type: Option<String> = query.iter().find_map(|q| {
-            if q.0.to_lowercase() == "type" {
+            if q.0 == "type" {
                 Some(q.1.to_string())
             } else {
                 None
@@ -51,7 +51,7 @@ impl http_common::server::Route for Route {
         };
 
         //TODO: get uid from UDS
-        let identities = match api.get_identities(auth_id, self.id_type).await {
+        let identities = match api.get_identities(auth_id, self.id_type.as_deref()).await {
             Ok(v) => v,
             Err(err) => return Err(super::to_http_error(&err)),
         };
@@ -81,7 +81,7 @@ impl http_common::server::Route for Route {
 
         //TODO: get uid from UDS
         let identity = match api
-            .create_identity(auth_id, Some(body.id_type), &body.module_id)
+            .create_identity(auth_id, Some(&body.id_type), &body.module_id)
             .await
         {
             Ok(id) => id,

--- a/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
+++ b/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
@@ -2,6 +2,7 @@
 
 pub(super) struct Route {
     api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    id_type: Option<String>,
 }
 
 #[async_trait::async_trait]
@@ -15,14 +16,23 @@ impl http_common::server::Route for Route {
     fn from_uri(
         service: &Self::Service,
         path: &str,
-        _query: &[(std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>)],
+        query: &[(std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>)],
     ) -> Option<Self> {
         if path != "/identities/modules" {
             return None;
         }
 
+        let id_type: Option<String> = query.iter().find_map(|q| {
+            if q.0.to_lowercase() == "type" {
+                Some(q.1.to_string())
+            } else {
+                None
+            }
+        });
+
         Some(Route {
             api: service.api.clone(),
+            id_type,
         })
     }
 
@@ -41,7 +51,7 @@ impl http_common::server::Route for Route {
         };
 
         //TODO: get uid from UDS
-        let identities = match api.get_identities(auth_id, "aziot").await {
+        let identities = match api.get_identities(auth_id, self.id_type).await {
             Ok(v) => v,
             Err(err) => return Err(super::to_http_error(&err)),
         };
@@ -71,7 +81,7 @@ impl http_common::server::Route for Route {
 
         //TODO: get uid from UDS
         let identity = match api
-            .create_identity(auth_id, &body.id_type, &body.module_id)
+            .create_identity(auth_id, Some(body.id_type), &body.module_id)
             .await
         {
             Ok(id) => id,

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -63,7 +63,10 @@ impl http_common::server::Route for Route {
         };
 
         //TODO: get uid from UDS
-        match api.delete_identity(auth_id, "aziot", &self.module_id).await {
+        match api
+            .delete_identity(auth_id, self.id_type, &self.module_id)
+            .await
+        {
             Ok(()) => (),
             Err(err) => return Err(super::to_http_error(&err)),
         }
@@ -118,7 +121,10 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
 
-        let identity = match api.update_identity(auth_id, "aziot", &self.module_id).await {
+        let identity = match api
+            .update_identity(auth_id, self.id_type, &self.module_id)
+            .await
+        {
             Ok(v) => v,
             Err(err) => return Err(super::to_http_error(&err)),
         };

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -33,7 +33,7 @@ impl http_common::server::Route for Route {
             .ok()?;
 
         let id_type: Option<String> = query.iter().find_map(|q| {
-            if q.0.to_lowercase() == "type" {
+            if q.0 == "type" {
                 Some(q.1.to_string())
             } else {
                 None
@@ -64,7 +64,7 @@ impl http_common::server::Route for Route {
 
         //TODO: get uid from UDS
         match api
-            .delete_identity(auth_id, self.id_type, &self.module_id)
+            .delete_identity(auth_id, self.id_type.as_deref(), &self.module_id)
             .await
         {
             Ok(()) => (),
@@ -87,7 +87,7 @@ impl http_common::server::Route for Route {
 
         //TODO: get uid from UDS
         let identity = match api
-            .get_identity(auth_id, self.id_type, &self.module_id)
+            .get_identity(auth_id, self.id_type.as_deref(), &self.module_id)
             .await
         {
             Ok(v) => v,
@@ -122,7 +122,7 @@ impl http_common::server::Route for Route {
         };
 
         let identity = match api
-            .update_identity(auth_id, self.id_type, &self.module_id)
+            .update_identity(auth_id, self.id_type.as_deref(), &self.module_id)
             .await
         {
             Ok(v) => v,

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -28,6 +28,27 @@ const DPS_ASSIGNMENT_RETRY_INTERVAL_SECS: u64 = 10;
 /// This is the number of seconds to wait for DPS to complete assignment to a hub
 const DPS_ASSIGNMENT_TIMEOUT_SECS: u64 = 120;
 
+/// URI query parameter that identifies module identity type.
+const ID_TYPE_AZIOT: &str = "aziot";
+
+/// URI query parameter that identifies local identity type.
+const ID_TYPE_LOCAL: &str = "local";
+
+macro_rules! match_id_type {
+    ($id_type:ident, $(($type:ident, $action:expr)),+) => {
+        if let Some(id_type) = $id_type {
+            match id_type.as_str() {
+                $(
+                    $type => $action,
+                )+
+                _ => Err(Error::invalid_parameter("id_type", "invalid id_type")),
+            }
+        } else {
+            Err(Error::invalid_parameter("id_type", "missing id_type"))
+        }
+    };
+}
+
 pub async fn main(
     settings: settings::Settings,
 ) -> Result<(http_common::Connector, http::Service), Box<dyn std::error::Error>> {
@@ -213,14 +234,14 @@ impl Api {
             return Err(Error::Authorization);
         }
 
-        // If id_type is not provided, return module identity.
-        let id_type = id_type.unwrap_or_else(|| "aziot".to_owned());
-
-        match id_type.as_str() {
-            "aziot" => self.id_manager.get_module_identity(module_id).await,
-            "local" => self.issue_local_identity(module_id).await,
-            _ => Err(Error::invalid_parameter("id_type", "invalid id_type")),
-        }
+        match_id_type!(
+            id_type,
+            (
+                ID_TYPE_AZIOT,
+                self.id_manager.get_module_identity(module_id).await
+            ),
+            (ID_TYPE_LOCAL, self.issue_local_identity(module_id).await)
+        )
     }
 
     pub async fn get_identities(
@@ -277,7 +298,7 @@ impl Api {
     pub async fn update_identity(
         &self,
         auth_id: auth::AuthId,
-        _idtype: &str,
+        id_type: Option<String>,
         module_id: &str,
     ) -> Result<aziot_identity_common::Identity, Error> {
         if !self.authorizer.authorize(auth::Operation {
@@ -287,14 +308,19 @@ impl Api {
             return Err(Error::Authorization);
         }
 
-        //TODO: match identity type based on uid configuration and create and get identity from appropriate identity manager (Hub or local)
-        self.id_manager.update_module_identity(module_id).await
+        match_id_type!(
+            id_type,
+            (
+                ID_TYPE_AZIOT,
+                self.id_manager.update_module_identity(module_id).await
+            )
+        )
     }
 
     pub async fn delete_identity(
         &self,
         auth_id: auth::AuthId,
-        _idtype: &str,
+        id_type: Option<String>,
         module_id: &str,
     ) -> Result<(), Error> {
         if !self.authorizer.authorize(auth::Operation {
@@ -304,8 +330,13 @@ impl Api {
             return Err(Error::Authorization);
         }
 
-        //TODO: match identity type based on uid configuration and create and get identity from appropriate identity manager (Hub or local)
-        self.id_manager.delete_module_identity(module_id).await
+        match_id_type!(
+            id_type,
+            (
+                ID_TYPE_AZIOT,
+                self.id_manager.delete_module_identity(module_id).await
+            )
+        )
     }
 
     pub async fn get_trust_bundle(

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -35,7 +35,7 @@ const ID_TYPE_AZIOT: &str = "aziot";
 const ID_TYPE_LOCAL: &str = "local";
 
 macro_rules! match_id_type {
-    ($id_type:ident, $(($type:ident, $action:expr)),+) => {
+    ($id_type:ident { $( $type:ident => $action:expr ,)+ }) => {
         if let Some(id_type) = $id_type {
             match id_type {
                 $(
@@ -234,14 +234,10 @@ impl Api {
             return Err(Error::Authorization);
         }
 
-        match_id_type!(
-            id_type,
-            (
-                ID_TYPE_AZIOT,
-                self.id_manager.get_module_identity(module_id).await
-            ),
-            (ID_TYPE_LOCAL, self.issue_local_identity(module_id).await)
-        )
+        match_id_type!(id_type {
+            ID_TYPE_AZIOT => self.id_manager.get_module_identity(module_id).await,
+            ID_TYPE_LOCAL => self.issue_local_identity(module_id).await,
+        })
     }
 
     pub async fn get_identities(
@@ -256,10 +252,9 @@ impl Api {
             return Err(Error::Authorization);
         }
 
-        match_id_type!(
-            id_type,
-            (ID_TYPE_AZIOT, self.id_manager.get_module_identities().await)
-        )
+        match_id_type!(id_type {
+            ID_TYPE_AZIOT => self.id_manager.get_module_identities().await,
+        })
     }
 
     pub async fn get_device_identity(
@@ -290,13 +285,9 @@ impl Api {
             return Err(Error::Authorization);
         }
 
-        match_id_type!(
-            id_type,
-            (
-                ID_TYPE_AZIOT,
-                self.id_manager.create_module_identity(module_id).await
-            )
-        )
+        match_id_type!( id_type {
+            ID_TYPE_AZIOT => self.id_manager.create_module_identity(module_id).await,
+        })
     }
 
     pub async fn update_identity(
@@ -312,13 +303,9 @@ impl Api {
             return Err(Error::Authorization);
         }
 
-        match_id_type!(
-            id_type,
-            (
-                ID_TYPE_AZIOT,
-                self.id_manager.update_module_identity(module_id).await
-            )
-        )
+        match_id_type!(id_type {
+            ID_TYPE_AZIOT => self.id_manager.update_module_identity(module_id).await,
+        })
     }
 
     pub async fn delete_identity(
@@ -334,13 +321,9 @@ impl Api {
             return Err(Error::Authorization);
         }
 
-        match_id_type!(
-            id_type,
-            (
-                ID_TYPE_AZIOT,
-                self.id_manager.delete_module_identity(module_id).await
-            )
-        )
+        match_id_type!(id_type {
+            ID_TYPE_AZIOT => self.id_manager.delete_module_identity(module_id).await,
+        })
     }
 
     pub async fn get_trust_bundle(

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -41,7 +41,7 @@ macro_rules! match_id_type {
                 $(
                     $type => $action,
                 )+
-                _ => Err(Error::invalid_parameter("type", format!("invalid type {}", id_type))),
+                _ => Err(Error::invalid_parameter("type", format!("invalid type: {}", id_type))),
             }
         } else {
             Err(Error::invalid_parameter("type", "missing parameter"))

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -37,7 +37,7 @@ const ID_TYPE_LOCAL: &str = "local";
 macro_rules! match_id_type {
     ($id_type:ident, $(($type:ident, $action:expr)),+) => {
         if let Some(id_type) = $id_type {
-            match id_type.as_str() {
+            match id_type {
                 $(
                     $type => $action,
                 )+
@@ -224,7 +224,7 @@ impl Api {
     pub async fn get_identity(
         &self,
         auth_id: auth::AuthId,
-        id_type: Option<String>,
+        id_type: Option<&str>,
         module_id: &str,
     ) -> Result<aziot_identity_common::Identity, Error> {
         if !self.authorizer.authorize(auth::Operation {
@@ -247,7 +247,7 @@ impl Api {
     pub async fn get_identities(
         &self,
         auth_id: auth::AuthId,
-        id_type: Option<String>,
+        id_type: Option<&str>,
     ) -> Result<Vec<aziot_identity_common::Identity>, Error> {
         if !self.authorizer.authorize(auth::Operation {
             auth_id,
@@ -280,7 +280,7 @@ impl Api {
     pub async fn create_identity(
         &self,
         auth_id: auth::AuthId,
-        id_type: Option<String>,
+        id_type: Option<&str>,
         module_id: &str,
     ) -> Result<aziot_identity_common::Identity, Error> {
         if !self.authorizer.authorize(auth::Operation {
@@ -302,7 +302,7 @@ impl Api {
     pub async fn update_identity(
         &self,
         auth_id: auth::AuthId,
-        id_type: Option<String>,
+        id_type: Option<&str>,
         module_id: &str,
     ) -> Result<aziot_identity_common::Identity, Error> {
         if !self.authorizer.authorize(auth::Operation {
@@ -324,7 +324,7 @@ impl Api {
     pub async fn delete_identity(
         &self,
         auth_id: auth::AuthId,
-        id_type: Option<String>,
+        id_type: Option<&str>,
         module_id: &str,
     ) -> Result<(), Error> {
         if !self.authorizer.authorize(auth::Operation {


### PR DESCRIPTION
Adds the required query parameter `type` to IS API calls.

The *Get module identity* call (`GET /identities/modules/{module-id}`) accepts both `type=aziot` and `type=local`. All other APIs only accept `type=aziot`.