### PR TITLE
Fix for device identity key handle

### DIFF
--- a/ci/iothub-get-twin.sh
+++ b/ci/iothub-get-twin.sh
@@ -239,16 +239,6 @@ fi
 
 case "$auth_type" in
     'sas')
-        if [ -z "$module_id" ]; then
-            # TODO: Bug? For device ID spec, the key handle is actually the key ID.
-            key_id="$(uri_encode "$key_handle")"
-            key_handle="$(
-                curl --unix-socket '/run/aziot/keyd.sock' \
-                    "http://foo/key/$key_id?api-version=2020-09-01" |
-                    jq '.keyHandle' -er
-            )"
-        fi
-
         expiry="$(bc <<< "$(date +%s) + 60 * 60 * 24")"
         signature_data="$(printf '%s\n%s' "$resource_uri" "$expiry" | base64 -w 0)"
         signature="$(

--- a/identity/aziot-hub-client-async/src/lib.rs
+++ b/identity/aziot-hub-client-async/src/lib.rs
@@ -252,16 +252,7 @@ where
         aziot_identity_common::Credentials::X509 {
             identity_cert,
             identity_pk,
-        } => {
-            get_x509_connector(
-                &identity_cert,
-                &identity_pk,
-                key_client,
-                key_engine,
-                cert_client,
-            )
-            .await?
-        }
+        } => get_x509_connector(&identity_cert, &identity_pk, key_engine, cert_client).await?,
     };
 
     let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);
@@ -383,16 +374,7 @@ where
         aziot_identity_common::Credentials::X509 {
             identity_cert,
             identity_pk,
-        } => {
-            get_x509_connector(
-                &identity_cert,
-                &identity_pk,
-                key_client,
-                key_engine,
-                cert_client,
-            )
-            .await?
-        }
+        } => get_x509_connector(&identity_cert, &identity_pk, key_engine, cert_client).await?,
     };
 
     let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);

--- a/identity/aziot-identityd/src/error.rs
+++ b/identity/aziot-identityd/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     DeviceNotFound,
     DPSClient(std::io::Error),
     HubClient(std::io::Error),
+    KeyClient(std::io::Error),
     ModuleNotFound,
     Internal(InternalError),
     InvalidParameter(&'static str, Box<dyn std::error::Error + Send + Sync>),
@@ -29,6 +30,7 @@ impl std::fmt::Display for Error {
             Error::DeviceNotFound => f.write_str("device identity not found"),
             Error::DPSClient(_) => f.write_str("DPS client error"),
             Error::HubClient(_) => f.write_str("Hub client error"),
+            Error::KeyClient(_) => f.write_str("Key client error"),
             Error::ModuleNotFound => f.write_str("module identity not found"),
             Error::Internal(_) => f.write_str("internal error"),
             Error::InvalidParameter(name, _) => {
@@ -45,7 +47,7 @@ impl std::error::Error for Error {
             | Error::Authorization
             | Error::DeviceNotFound
             | Error::ModuleNotFound => None,
-            Error::DPSClient(err) | Error::HubClient(err) => Some(err),
+            Error::DPSClient(err) | Error::HubClient(err) | Error::KeyClient(err) => Some(err),
             Error::Internal(err) => Some(err),
             Error::InvalidParameter(_, err) => Some(&**err),
         }

--- a/identity/aziot-identityd/src/http/mod.rs
+++ b/identity/aziot-identityd/src/http/mod.rs
@@ -55,12 +55,12 @@ fn to_http_error(err: &crate::Error) -> http_common::server::Error {
             message: error_message.into(),
         },
 
-        crate::error::Error::DPSClient(_) | crate::error::Error::HubClient(_) => {
-            http_common::server::Error {
-                status_code: hyper::StatusCode::NOT_FOUND,
-                message: error_message.into(),
-            }
-        }
+        crate::error::Error::DPSClient(_)
+        | crate::error::Error::HubClient(_)
+        | crate::error::Error::KeyClient(_) => http_common::server::Error {
+            status_code: hyper::StatusCode::NOT_FOUND,
+            message: error_message.into(),
+        },
 
         crate::error::Error::Authentication | crate::error::Error::Authorization => {
             http_common::server::Error {


### PR DESCRIPTION
- Device identity symmetric keys were being stored as `key_id`s instead of `key_handle`s on service launch. Now, the `key_id`s are translated into `key_handle`s by calling the Key Service on each provision.  
- Fix for SAS and X509 connector logic to use `key_handle`s
- Removed workaround for `/identities/device` API in e2e script (validated locally)