### PR TITLE
Fix for keyhandle in get device identity API

### DIFF
--- a/ci/iothub-get-twin.sh
+++ b/ci/iothub-get-twin.sh
@@ -239,16 +239,6 @@ fi
 
 case "$auth_type" in
     'sas')
-        if [ -z "$module_id" ]; then
-            # TODO: Bug? For device ID spec, the key handle is actually the key ID.
-            key_id="$(uri_encode "$key_handle")"
-            key_handle="$(
-                curl --unix-socket '/run/aziot/keyd.sock' \
-                    "http://foo/key/$key_id?api-version=2020-09-01" |
-                    jq '.keyHandle' -er
-            )"
-        fi
-
         expiry="$(bc <<< "$(date +%s) + 60 * 60 * 24")"
         signature_data="$(printf '%s\n%s' "$resource_uri" "$expiry" | base64 -w 0)"
         signature="$(

--- a/identity/aziot-identityd/src/error.rs
+++ b/identity/aziot-identityd/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     DeviceNotFound,
     DPSClient(std::io::Error),
     HubClient(std::io::Error),
+    KeyClient(std::io::Error),
     ModuleNotFound,
     Internal(InternalError),
     InvalidParameter(&'static str, Box<dyn std::error::Error + Send + Sync>),
@@ -29,6 +30,7 @@ impl std::fmt::Display for Error {
             Error::DeviceNotFound => f.write_str("device identity not found"),
             Error::DPSClient(_) => f.write_str("DPS client error"),
             Error::HubClient(_) => f.write_str("Hub client error"),
+            Error::KeyClient(_) => f.write_str("Key client error"),
             Error::ModuleNotFound => f.write_str("module identity not found"),
             Error::Internal(_) => f.write_str("internal error"),
             Error::InvalidParameter(name, _) => {
@@ -45,7 +47,7 @@ impl std::error::Error for Error {
             | Error::Authorization
             | Error::DeviceNotFound
             | Error::ModuleNotFound => None,
-            Error::DPSClient(err) | Error::HubClient(err) => Some(err),
+            Error::DPSClient(err) | Error::HubClient(err) | Error::KeyClient(err) => Some(err),
             Error::Internal(err) => Some(err),
             Error::InvalidParameter(_, err) => Some(&**err),
         }

--- a/identity/aziot-identityd/src/http/mod.rs
+++ b/identity/aziot-identityd/src/http/mod.rs
@@ -55,12 +55,12 @@ fn to_http_error(err: &crate::Error) -> http_common::server::Error {
             message: error_message.into(),
         },
 
-        crate::error::Error::DPSClient(_) | crate::error::Error::HubClient(_) => {
-            http_common::server::Error {
-                status_code: hyper::StatusCode::NOT_FOUND,
-                message: error_message.into(),
-            }
-        }
+        crate::error::Error::DPSClient(_)
+        | crate::error::Error::HubClient(_)
+        | crate::error::Error::KeyClient(_) => http_common::server::Error {
+            status_code: hyper::StatusCode::NOT_FOUND,
+            message: error_message.into(),
+        },
 
         crate::error::Error::Authentication | crate::error::Error::Authorization => {
             http_common::server::Error {

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -168,9 +168,7 @@ impl IdentityManager {
                     device_id: aziot_identity_common::DeviceId(device.device_id.clone()),
                     module_id: None,
                     gen_id: None,
-                    auth: Some(aziot_identity_common::AuthenticationInfo::from(
-                        device.credentials.clone(),
-                    )),
+                    auth: Some(self.get_device_identity_key().await?),
                 },
             )),
             None => Err(Error::DeviceNotFound),
@@ -280,6 +278,43 @@ impl IdentityManager {
                     .await
                     .map_err(Error::HubClient)
             }
+            None => Err(Error::DeviceNotFound),
+        }
+    }
+
+    async fn get_device_identity_key(
+        &self,
+    ) -> Result<aziot_identity_common::AuthenticationInfo, Error> {
+        match &self.iot_hub_device {
+            Some(device) => match &device.credentials {
+                aziot_identity_common::Credentials::SharedPrivateKey(key) => {
+                    let key_handle = self
+                        .key_client
+                        .load_key(key.as_str())
+                        .await
+                        .map_err(Error::KeyClient)?;
+                    Ok(aziot_identity_common::AuthenticationInfo {
+                        auth_type: aziot_identity_common::AuthenticationType::Sas,
+                        key_handle: aziot_key_common::KeyHandle(key_handle.0),
+                        cert_id: None,
+                    })
+                }
+                aziot_identity_common::Credentials::X509 {
+                    identity_cert,
+                    identity_pk,
+                } => {
+                    let identity_pk_key_handle = self
+                        .key_client
+                        .load_key_pair(identity_pk.as_str())
+                        .await
+                        .map_err(Error::KeyClient)?;
+                    Ok(aziot_identity_common::AuthenticationInfo {
+                        auth_type: aziot_identity_common::AuthenticationType::X509,
+                        key_handle: aziot_key_common::KeyHandle(identity_pk_key_handle.0),
+                        cert_id: Some(identity_cert.clone()),
+                    })
+                }
+            },
             None => Err(Error::DeviceNotFound),
         }
     }


### PR DESCRIPTION
- Retrieve key handle for SAS or X509 credentials for each `get_device_identity` invocation
- Removed workaround for `/identities/device` API in e2e script (validated locally)