### PR TITLE
Add local identity to create_identity

### DIFF
--- a/docs/identity-service.md
+++ b/docs/identity-service.md
@@ -188,15 +188,31 @@ The `type` query parameter specifies the identity type to return. Accepted value
 
 `POST /identities/modules?api-version=2020-09-01`
 
-#### Request
+#### Request (Module identity)
 ```json
 {
   "type": "aziot",
-  "name": "module01",
-  "deviceId": "device01",
-  "managedBy": "edgeruntime"
+  "moduleId": "module01"
 }
 ```
+
+#### Request (Local identity)
+```json
+{
+  "type": "local",
+  "moduleId": "module01",
+  "localIdOpts": {
+    "type": "x509",
+    "attributes": "server"
+  }
+}
+```
+
+`localIdOpts` is an optional field that can be used to specify configuration of the issued local identity. It contains the following fields:
+- `type` - Type of local identity. Currently, only `x509` is supported.
+- `attributes` - Attributes of the X.509 local identity certificate. May be either `client` or `server`.
+
+If `localIdOpts` is not specified, the default `{"type": "x509", "attributes": "client"}` will be used.
 
 #### Response (SAS case)
 
@@ -232,6 +248,23 @@ The `type` query parameter specifies the identity type to return. Accepted value
         "type": "x509",
         "keyHandle": "string",
         "certId": "string"
+    }
+  }
+}
+```
+
+#### Response (Local identity)
+
+```json
+{
+  "type": "local",
+  "spec":
+  {
+    "moduleId": "module01",
+    "auth": {
+        "privateKey": "private key bytes",
+        "certificate": "certificate bytes",
+        "expiration": "yyyy-mm-ddThh:mm:ss+00:00"
     }
   }
 }
@@ -292,7 +325,7 @@ The `type` query parameter specifies the identity type to return. Accepted value
   "type": "local",
   "spec":
   {
-    "moduleId": "myhub.net",
+    "moduleId": "module01",
     "auth": {
         "privateKey": "private key bytes",
         "certificate": "certificate bytes",

--- a/identity/aziot-identity-common-http/src/lib.rs
+++ b/identity/aziot-identity-common-http/src/lib.rs
@@ -51,11 +51,19 @@ pub mod get_device_identity {
 
 pub mod create_module_identity {
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub enum CreateModuleOpts {
+        LocalIdOpts(aziot_identity_common::LocalIdOpts),
+    }
+
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
     pub struct Request {
         #[serde(rename = "type")]
         pub id_type: String,
         #[serde(rename = "moduleId")]
         pub module_id: String,
+        #[serde(flatten)]
+        pub opts: Option<CreateModuleOpts>,
     }
 
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/identity/aziot-identity-common/src/lib.rs
+++ b/identity/aziot-identity-common/src/lib.rs
@@ -39,6 +39,20 @@ pub struct LocalIdSpec {
     pub auth: LocalAuthenticationInfo,
 }
 
+/// Options for a single local identity.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "type")]
+pub enum LocalIdOpts {
+    /// Options valid when local identities are X.509 credentials. Currently the only
+    /// supported credential type, but may change in the future.
+    #[serde(rename = "x509")]
+    X509 {
+        /// Whether the X.509 certificate is a TLS client or server certificate.
+        #[serde(default)]
+        attributes: LocalIdAttr,
+    },
+}
+
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct LocalAuthenticationInfo {
     #[serde(rename = "privateKey")]

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -33,7 +33,7 @@ pub struct Principal {
     pub id_type: Option<Vec<aziot_identity_common::IdType>>,
 
     /// Options for this principal's local identity.
-    pub localid: Option<LocalIdOpts>,
+    pub localid: Option<aziot_identity_common::LocalIdOpts>,
 }
 
 #[derive(
@@ -48,20 +48,6 @@ pub type Credentials = Uid;
 pub struct LocalId {
     /// Identifier for a group of local identity certificates, suffixed to the common name.
     pub domain: String,
-}
-
-/// Options for a single local identity.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(tag = "type")]
-pub enum LocalIdOpts {
-    /// Options valid when local identities are X.509 credentials. Currently the only
-    /// supported credential type, but may change in the future.
-    #[serde(rename = "x509")]
-    X509 {
-        /// Whether the X.509 certificate is a TLS client or server certificate.
-        #[serde(default)]
-        attributes: aziot_identity_common::LocalIdAttr,
-    },
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
+++ b/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
@@ -82,7 +82,7 @@ impl http_common::server::Route for Route {
         };
 
         let identity = match api
-            .create_identity(auth_id, Some(&body.id_type), &body.module_id)
+            .create_identity(auth_id, Some(&body.id_type), &body.module_id, body.opts)
             .await
         {
             Ok(id) => id,

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -33,7 +33,7 @@ const ID_TYPE_AZIOT: &str = "aziot";
 const ID_TYPE_LOCAL: &str = "local";
 
 macro_rules! match_id_type {
-    ($id_type:ident { $( $type:ident => $action:expr ,)+ }) => {
+    ($id_type:ident { $( $type:ident => $action:block ,)+ }) => {
         if let Some(id_type) = $id_type {
             match id_type {
                 $(
@@ -286,8 +286,8 @@ impl Api {
         }
 
         match_id_type!(id_type {
-            ID_TYPE_AZIOT => self.id_manager.get_module_identity(module_id).await,
-            ID_TYPE_LOCAL => self.issue_local_identity(module_id).await,
+            ID_TYPE_AZIOT => { self.id_manager.get_module_identity(module_id).await },
+            ID_TYPE_LOCAL => { self.issue_local_identity(module_id).await },
         })
     }
 
@@ -304,7 +304,7 @@ impl Api {
         }
 
         match_id_type!(id_type {
-            ID_TYPE_AZIOT => self.id_manager.get_module_identities().await,
+            ID_TYPE_AZIOT => { self.id_manager.get_module_identities().await },
         })
     }
 
@@ -328,6 +328,7 @@ impl Api {
         auth_id: auth::AuthId,
         id_type: Option<&str>,
         module_id: &str,
+        opts: Option<aziot_identity_common_http::create_module_identity::CreateModuleOpts>,
     ) -> Result<aziot_identity_common::Identity, Error> {
         if !self.authorizer.authorize(auth::Operation {
             auth_id,
@@ -337,7 +338,7 @@ impl Api {
         }
 
         match_id_type!( id_type {
-            ID_TYPE_AZIOT => self.id_manager.create_module_identity(module_id).await,
+            ID_TYPE_AZIOT => { self.id_manager.create_module_identity(module_id).await },
         })
     }
 
@@ -355,7 +356,7 @@ impl Api {
         }
 
         match_id_type!(id_type {
-            ID_TYPE_AZIOT => self.id_manager.update_module_identity(module_id).await,
+            ID_TYPE_AZIOT => { self.id_manager.update_module_identity(module_id).await },
         })
     }
 
@@ -373,7 +374,7 @@ impl Api {
         }
 
         match_id_type!(id_type {
-            ID_TYPE_AZIOT => self.id_manager.delete_module_identity(module_id).await,
+            ID_TYPE_AZIOT => { self.id_manager.delete_module_identity(module_id).await },
         })
     }
 

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -287,7 +287,20 @@ impl Api {
 
         match_id_type!(id_type {
             ID_TYPE_AZIOT => { self.id_manager.get_module_identity(module_id).await },
-            ID_TYPE_LOCAL => { self.issue_local_identity(module_id).await },
+            ID_TYPE_LOCAL => {
+                // Callers of this API must have a local identity specified in the principals list.
+                match self
+                    .local_identities
+                    .get(&aziot_identity_common::ModuleId(module_id.to_owned())) {
+                    Some(opts) => self.issue_local_identity(module_id, opts).await,
+                    None => Err(
+                        Error::invalid_parameter(
+                            "moduleId",
+                            format!("local identity for {} doesn't exist", module_id)
+                        )
+                    ),
+                }
+            },
         })
     }
 
@@ -339,6 +352,27 @@ impl Api {
 
         match_id_type!( id_type {
             ID_TYPE_AZIOT => { self.id_manager.create_module_identity(module_id).await },
+            ID_TYPE_LOCAL => {
+                if self.local_identities
+                    .get(&aziot_identity_common::ModuleId(module_id.to_owned()))
+                    .is_some() {
+                    // Don't create a local identity for a module in the principals list.
+                    Err(Error::invalid_parameter(
+                        "moduleId",
+                        format!("local identity for {} already exists", module_id)
+                    ))
+                } else {
+                    let opts = opts.map(|opts| {
+                        match opts {
+                            aziot_identity_common_http::create_module_identity::CreateModuleOpts::LocalIdOpts(opts) => opts,
+                            // Currently, the only supported opts variant is LocalIdOpts.
+                            // But if more variants are added in the future, they should be rejected here.
+                        }
+                    });
+
+                    self.issue_local_identity(module_id, &opts).await
+                }
+            },
         })
     }
 
@@ -586,6 +620,7 @@ impl Api {
     async fn issue_local_identity(
         &self,
         module_id: &str,
+        opts: &Option<aziot_identity_common::LocalIdOpts>,
     ) -> Result<aziot_identity_common::Identity, Error> {
         let localid = self.settings.localid.as_ref().ok_or_else(|| {
             Error::Internal(InternalError::BadSettings(std::io::Error::new(
@@ -594,81 +629,59 @@ impl Api {
             )))
         })?;
 
-        let local_identity =
-            match self
-                .local_identities
-                .get(&aziot_identity_common::ModuleId(module_id.to_owned()))
-            {
-                None => {
-                    return Err(Error::invalid_parameter(
-                        "module_id",
-                        format!("no local identity found for {}", module_id),
-                    ))
-                }
-                Some(opts) => {
-                    let attributes = opts.as_ref().map_or(
+        let local_identity = {
+            let attributes =
+                opts.as_ref()
+                    .map_or(
                         aziot_identity_common::LocalIdAttr::default(),
                         |opts| match opts {
                             aziot_identity_common::LocalIdOpts::X509 { attributes } => *attributes,
                         },
                     );
 
-                    // Generate new private key for local identity.
-                    let rsa = openssl::rsa::Rsa::generate(2048).map_err(|err| {
-                        Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                    })?;
-                    let private_key = openssl::pkey::PKey::from_rsa(rsa).map_err(|err| {
-                        Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                    })?;
-                    let private_key_pem =
-                        private_key.private_key_to_pem_pkcs8().map_err(|err| {
-                            Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                        })?;
-                    let private_key_pem =
-                        std::string::String::from_utf8(private_key_pem).map_err(|err| {
-                            Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                        })?;
-                    let public_key = private_key.public_key_to_pem().map_err(|err| {
-                        Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                    })?;
-                    let public_key = openssl::pkey::PKey::public_key_from_pem(&public_key)
-                        .map_err(|err| {
-                            Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                        })?;
+            // Generate new private key for local identity.
+            let rsa = openssl::rsa::Rsa::generate(2048)
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
+            let private_key = openssl::pkey::PKey::from_rsa(rsa)
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
+            let private_key_pem = private_key
+                .private_key_to_pem_pkcs8()
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
+            let private_key_pem = std::string::String::from_utf8(private_key_pem)
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
+            let public_key = private_key
+                .public_key_to_pem()
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
+            let public_key = openssl::pkey::PKey::public_key_from_pem(&public_key)
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
 
-                    // Create local identity CSR.
-                    let subject = format!(
-                        "{}.{}.{}",
-                        module_id, self.settings.hostname, localid.domain
-                    );
-                    let csr = create_csr(&subject, &public_key, &private_key, Some(attributes))
-                        .map_err(|err| {
-                            Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                        })?;
-                    let certificate = self
-                        .cert_client
-                        .create_cert(&module_id, &csr, None)
-                        .await
-                        .map_err(|err| {
-                            Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                        })?;
-                    let certificate = String::from_utf8(certificate).map_err(|err| {
-                        Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                    })?;
+            // Create local identity CSR.
+            let subject = format!(
+                "{}.{}.{}",
+                module_id, self.settings.hostname, localid.domain
+            );
+            let csr = create_csr(&subject, &public_key, &private_key, Some(attributes))
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
+            let certificate = self
+                .cert_client
+                .create_cert(&module_id, &csr, None)
+                .await
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
+            let certificate = String::from_utf8(certificate)
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
 
-                    // Parse certificate expiration time.
-                    let expiration = get_cert_expiration(&certificate)?;
+            // Parse certificate expiration time.
+            let expiration = get_cert_expiration(&certificate)?;
 
-                    aziot_identity_common::Identity::Local(aziot_identity_common::LocalIdSpec {
-                        module_id: module_id.to_owned(),
-                        auth: aziot_identity_common::LocalAuthenticationInfo {
-                            private_key: private_key_pem,
-                            certificate,
-                            expiration,
-                        },
-                    })
-                }
-            };
+            aziot_identity_common::Identity::Local(aziot_identity_common::LocalIdSpec {
+                module_id: module_id.to_owned(),
+                auth: aziot_identity_common::LocalAuthenticationInfo {
+                    private_key: private_key_pem,
+                    certificate,
+                    expiration,
+                },
+            })
+        };
 
         Ok(local_identity)
     }


### PR DESCRIPTION
Adds local identities to the create_identity API.

```
POST /identities/modules?api-version=2020-09-01

{
  "type": "local",
  "moduleId": "module01",
  "localIdOpts": {
    "type": "x509",
    "attributes": "server"
  }
}
```