### PR TITLE
Fixes for aziot-key-openssl-engine-shared

### DIFF
--- a/key/aziot-key-openssl-engine/build/engine.c
+++ b/key/aziot-key-openssl-engine/build/engine.c
@@ -22,10 +22,15 @@ int aziot_key_dupf_engine_ex_data(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from
 #else
 int aziot_key_dupf_engine_ex_data(CRYPTO_EX_DATA *to, CRYPTO_EX_DATA *from, void *from_d, int idx, long argl, void *argp);
 #endif
-void aziot_key_freef_engine_ex_data(void* parent, void* ptr, CRYPTO_EX_DATA* ad, int idx, long argl, void* argp);
 
 int aziot_key_get_engine_ex_index() {
-	return ENGINE_get_ex_new_index(0, NULL, NULL, aziot_key_dupf_engine_ex_data, aziot_key_freef_engine_ex_data);
+	/* This engine might be loaded using the dynamic engine (if it's being used as aziot-key-openssl-engine-shared).
+	 * In that case, we don't want to use freef to free the Engine ex data, because freef will run after the dynamic engine has
+	 * already unloaded the engine library, which means the function freef points to will also have been unloaded.
+	 *
+	 * Instead, this engine uses the ENGINE_destroy hook to clean up its ex data.
+	 */
+	return ENGINE_get_ex_new_index(0, NULL, NULL, aziot_key_dupf_engine_ex_data, NULL);
 }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L

--- a/key/aziot-key-openssl-engine/src/engine.rs
+++ b/key/aziot-key-openssl-engine/src/engine.rs
@@ -40,7 +40,10 @@ impl Engine {
 
     pub(super) unsafe fn register(
         e: *mut openssl_sys::ENGINE,
-        init: Option<openssl_sys2::ENGINE_GEN_INT_FUNC_PTR>,
+        init_and_destroy: Option<(
+            openssl_sys2::ENGINE_GEN_INT_FUNC_PTR,
+            openssl_sys2::ENGINE_GEN_INT_FUNC_PTR,
+        )>,
     ) -> Result<(), openssl2::Error> {
         openssl2::openssl_returns_1(openssl_sys2::ENGINE_set_id(
             e,
@@ -57,8 +60,9 @@ impl Engine {
             .as_ptr(),
         ))?;
 
-        if let Some(init) = init {
+        if let Some((init, destroy)) = init_and_destroy {
             openssl2::openssl_returns_1(openssl_sys2::ENGINE_set_init_function(e, init))?;
+            openssl2::openssl_returns_1(openssl_sys2::ENGINE_set_destroy_function(e, destroy))?;
         }
 
         openssl2::openssl_returns_1(openssl_sys2::ENGINE_set_load_privkey_function(
@@ -89,10 +93,25 @@ impl Engine {
         crate::ex_data::set(e, engine)?;
         Ok(())
     }
+
+    pub(super) unsafe fn destroy(e: *mut openssl_sys::ENGINE) -> Result<(), openssl2::Error> {
+        let ex_index = <openssl_sys::ENGINE as crate::ex_data::HasExData<Engine>>::index().as_raw();
+
+        let ex_data: *const Engine = openssl2::openssl_returns_nonnull(
+            (<openssl_sys::ENGINE as openssl2::ExDataAccessors>::GET_FN)(e, ex_index),
+        )? as _;
+        if !ex_data.is_null() {
+            // Restore the Arc and then drop it.
+            let ex_data = std::sync::Arc::from_raw(ex_data);
+            drop(ex_data);
+        }
+
+        Ok(())
+    }
 }
 
-impl crate::ex_data::HasExData<crate::engine::Engine> for openssl_sys::ENGINE {
-    unsafe fn index() -> openssl::ex_data::Index<Self, crate::engine::Engine> {
+impl crate::ex_data::HasExData<Engine> for openssl_sys::ENGINE {
+    unsafe fn index() -> openssl::ex_data::Index<Self, Engine> {
         crate::ex_data::ex_indices().engine
     }
 }
@@ -107,21 +126,8 @@ unsafe extern "C" fn aziot_key_dupf_engine_ex_data(
     _argl: std::os::raw::c_long,
     _argp: *mut std::ffi::c_void,
 ) -> std::os::raw::c_int {
-    crate::ex_data::dup::<openssl_sys::ENGINE, crate::engine::Engine>(from_d, idx);
+    crate::ex_data::dup::<openssl_sys::ENGINE, Engine>(from_d, idx);
     1
-}
-
-#[no_mangle]
-#[allow(clippy::similar_names)]
-unsafe extern "C" fn aziot_key_freef_engine_ex_data(
-    _parent: *mut std::ffi::c_void,
-    ptr: *mut std::ffi::c_void,
-    _ad: *mut openssl_sys::CRYPTO_EX_DATA,
-    idx: std::os::raw::c_int,
-    _argl: std::os::raw::c_long,
-    _argp: *mut std::ffi::c_void,
-) {
-    crate::ex_data::free::<openssl_sys::ENGINE, crate::engine::Engine>(ptr, idx);
 }
 
 unsafe extern "C" fn engine_load_privkey(

--- a/key/aziot-key-openssl-engine/src/engine.rs
+++ b/key/aziot-key-openssl-engine/src/engine.rs
@@ -80,7 +80,10 @@ impl Engine {
             openssl_sys2::ENGINE_FLAGS_BY_ID_COPY,
         ))?;
 
-        openssl2::openssl_returns_1(openssl_sys2::ENGINE_add(e))?;
+        if init_and_destroy.is_none() {
+            // ENGINE_add should not be called for dynamic engines because the dynamic loader does it.
+            openssl2::openssl_returns_1(openssl_sys2::ENGINE_add(e))?;
+        }
 
         Ok(())
     }

--- a/key/aziot-key-openssl-engine/src/lib.rs
+++ b/key/aziot-key-openssl-engine/src/lib.rs
@@ -46,8 +46,9 @@ pub fn load(
 pub unsafe fn register(
     e: *mut openssl_sys::ENGINE,
     init: openssl_sys2::ENGINE_GEN_INT_FUNC_PTR,
+    destroy: openssl_sys2::ENGINE_GEN_INT_FUNC_PTR,
 ) -> Result<(), openssl2::Error> {
-    engine::Engine::register(e, Some(init))
+    engine::Engine::register(e, Some((init, destroy)))
 }
 
 /// Initialize an existing structural instance of the openssl engine with the given Keys Service client.
@@ -59,6 +60,14 @@ pub unsafe fn init(
     client: std::sync::Arc<aziot_key_client::Client>,
 ) -> Result<(), openssl2::Error> {
     engine::Engine::init(e, client)
+}
+
+/// Destroy an existing structural instance of the openssl engine.
+///
+/// This is intended to be used by aziot-key-engine-shared.
+#[doc(hidden)]
+pub unsafe fn destroy(e: *mut openssl_sys::ENGINE) -> Result<(), openssl2::Error> {
+    engine::Engine::destroy(e)
 }
 
 openssl_errors::openssl_errors! {

--- a/openssl-sys2/src/engine.rs
+++ b/openssl-sys2/src/engine.rs
@@ -63,6 +63,10 @@ extern "C" {
         e: *mut openssl_sys::ENGINE,
         name: *const std::os::raw::c_char,
     ) -> std::os::raw::c_int;
+    pub fn ENGINE_set_destroy_function(
+        e: *mut openssl_sys::ENGINE,
+        ctrl_f: ENGINE_GEN_INT_FUNC_PTR,
+    ) -> std::os::raw::c_int;
     pub fn ENGINE_set_init_function(
         e: *mut openssl_sys::ENGINE,
         ctrl_f: ENGINE_GEN_INT_FUNC_PTR,


### PR DESCRIPTION
- A quirk of openssl's dynamic engine loader appears to be that it registers
  its own ex data to unload the DSO of the engine it loaded,
  ie aziot-key-openssl-engine-shared. However it does this before
  any other ex data the engine might have, thus its freef triggers before
  the freef of the other ex data. This meant that, before this change,
  openssl would try to use `aziot_key_freef_engine_ex_data` after having
  already unloaded the DSO that contained it, leading to a segfault.

  With this change, the engine's ex data is instead deallocated via
  the `ENGINE_destroy` hook.

- Remove the call to `ENGINE_add` when it's being used as a dynamic engine.
  The call is only needed for static engines, since for dynamic engines
  the dynamic loader does it for the loaded engine. In fact, if
  the loaded engine is `_finish`'d and `_free`d and then `_by_id`'d again,
  the `ENGINE_add` call will fail because the engine had already been added
  the first time.