### PR TITLE
Use new rust-toolchain format which removes the need to install components manually.

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -128,19 +128,19 @@ else
     curl -Lo ~/.cargo/bin/rustup 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init'
     chmod +x ~/.cargo/bin/rustup
     hash -r
+    rustup self update # Create the hardlinks for cargo, rustc, etc
 fi
 
-RUST_TOOLCHAIN="$(cat /src/rust-toolchain)"
-rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal --component clippy,rustfmt
-rustup default "$RUST_TOOLCHAIN"
+# The toolchain specified by rust-toolchain will be automatically installed if it doesn't already exist,
+# when `cargo` is run below. We'd like rustup to use the minimal profile to do that so that it doesn't
+# use the default profile and download rust-docs, etc.
+#
+# Ref: https://github.com/rust-lang/rustup/issues/2579
+rustup set profile minimal
 
-if [ ! -f ~/.cargo/bin/bindgen ]; then
-    cargo install bindgen --version '^0.54'
-fi
+cargo install bindgen --version '^0.54'
 
-if [ ! -f ~/.cargo/bin/cbindgen ]; then
-    cargo install cbindgen --version '^0.15'
-fi
+cargo install cbindgen --version '^0.15'
 
 export CARGO_INCREMENTAL=0
 

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -122,14 +122,15 @@ mkdir -p ~/.cargo/bin
 # shellcheck disable=SC2155
 export PATH="$PATH:$(realpath ~/.cargo/bin)"
 
-if [ -f ~/.cargo/bin/rustup ]; then
-    rustup self update
-else
+if ! [ -f ~/.cargo/bin/rustup ]; then
     curl -Lo ~/.cargo/bin/rustup 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init'
     chmod +x ~/.cargo/bin/rustup
     hash -r
-    rustup self update # Create the hardlinks for cargo, rustc, etc
 fi
+
+# If rustup was already installed, make sure it's up-to-date.
+# If it was just installed above, create the hardlinks for cargo, rustc, etc.
+rustup self update
 
 # The toolchain specified by rust-toolchain will be automatically installed if it doesn't already exist,
 # when `cargo` is run below. We'd like rustup to use the minimal profile to do that so that it doesn't

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-stable
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Also remove the checks around bindgen and cbindgen existing before
`cargo install`ing them. `cargo install` already acts as a no-op if the crate
is installed with the requested version. It even correctly reinstalls the crate
if the currently installed version doesn't match the requested version (both
for upgrading and downgrading), which the previous code did not handle.