### PR TITLE
Add proxy support to Identity Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
  "aziot-keys-common",
  "aziot-tpmd",
  "backtrace",
- "base64",
+ "base64 0.12.3",
  "bytes",
  "derive_more",
  "nix",
@@ -134,7 +134,7 @@ dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
  "aziot-key-openssl-engine",
- "base64",
+ "base64 0.12.3",
  "foreign-types-shared",
  "futures-util",
  "hex",
@@ -166,7 +166,7 @@ dependencies = [
  "aziot-key-client-async",
  "aziot-key-common",
  "aziot-tpm-client-async",
- "base64",
+ "base64 0.12.3",
  "bytes",
  "chrono",
  "futures-util",
@@ -174,6 +174,7 @@ dependencies = [
  "http-common",
  "hyper",
  "hyper-openssl",
+ "hyper-proxy",
  "log",
  "openssl",
  "openssl2",
@@ -181,6 +182,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "typed-headers",
  "url",
 ]
 
@@ -197,7 +199,7 @@ dependencies = [
  "aziot-key-openssl-engine",
  "aziot-tpm-client-async",
  "aziot-tpm-common",
- "base64",
+ "base64 0.12.3",
  "bytes",
  "chrono",
  "futures-util",
@@ -205,6 +207,7 @@ dependencies = [
  "http-common",
  "hyper",
  "hyper-openssl",
+ "hyper-proxy",
  "log",
  "openssl",
  "openssl2",
@@ -229,7 +232,7 @@ dependencies = [
  "aziot-key-openssl-engine",
  "aziot-tpm-client-async",
  "aziot-tpm-common",
- "base64",
+ "base64 0.12.3",
  "chrono",
  "futures-util",
  "http",
@@ -288,7 +291,7 @@ dependencies = [
  "aziot-tpm-client-async",
  "aziot-tpm-common",
  "aziot-tpm-common-http",
- "base64",
+ "base64 0.12.3",
  "chrono",
  "futures-util",
  "http",
@@ -359,7 +362,7 @@ version = "0.1.0"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
- "base64",
+ "base64 0.12.3",
  "foreign-types-shared",
  "log",
  "openssl",
@@ -411,7 +414,7 @@ dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
  "aziot-keys-common",
- "base64",
+ "base64 0.12.3",
  "futures-util",
  "http",
  "http-common",
@@ -508,7 +511,7 @@ dependencies = [
  "aziot-tpm-common",
  "aziot-tpm-common-http",
  "backtrace",
- "base64",
+ "base64 0.12.3",
  "futures-util",
  "http",
  "http-common",
@@ -555,6 +558,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -787,12 +796,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -800,6 +825,23 @@ name = "futures-core"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-macro"
@@ -834,9 +876,13 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project",
  "pin-utils",
  "proc-macro-hack",
@@ -950,7 +996,7 @@ name = "http-common"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.12.3",
  "futures-util",
  "http",
  "hyper",
@@ -1019,6 +1065,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-proxy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ec5be69758dfc06b9b29efa9d6e9306e387c85eb362c603912eead2ad98c7"
+dependencies = [
+ "bytes",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
+ "tower-service",
+ "typed-headers",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +1126,7 @@ dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
  "aziot-key-openssl-engine",
- "base64",
+ "base64 0.12.3",
  "chrono",
  "foreign-types-shared",
  "http-common",
@@ -1620,7 +1684,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12427a5577082c24419c9c417db35cfeb65962efc7675bb6b0d5f1f9d315bfe6"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1923,9 +1987,9 @@ checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tokio"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes",
  "fnv",
@@ -1943,9 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2006,6 +2070,19 @@ name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+
+[[package]]
+name = "typed-headers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3179a61e9eccceead5f1574fd173cf2e162ac42638b9bf214c6ad0baf7efa24a"
+dependencies = [
+ "base64 0.11.0",
+ "bytes",
+ "chrono",
+ "http",
+ "mime",
+]
 
 [[package]]
 name = "typenum"

--- a/identity/aziot-cloud-client-async-common/Cargo.toml
+++ b/identity/aziot-cloud-client-async-common/Cargo.toml
@@ -10,16 +10,18 @@ async-trait = "0.1.41"
 bytes = "0.5.6"
 base64 = "0.12"
 chrono = "0.4"
+futures-util = "0.3"
 http = "0.2"
 hyper = { version = "0.13", features = ["stream"] }
 hyper-openssl = "0.8"
+hyper-proxy = "0.8"
 log = "0.4"
 openssl = "0.10"
 percent-encoding = "2"
 tokio = { version = "0.2", features = ["dns", "macros"] }
 serde = "1"
 serde_json = "1"
-futures-util = "0.3"
+typed-headers = "0.2"
 url = "2"
 
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }

--- a/identity/aziot-dps-client-async/Cargo.toml
+++ b/identity/aziot-dps-client-async/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4"
 http = "0.2"
 hyper = { version = "0.13", features = ["stream"] }
 hyper-openssl = "0.8"
+hyper-proxy = "0.8"
 log = "0.4"
 openssl = "0.10"
 percent-encoding = "2"

--- a/identity/aziot-hub-client-async/src/lib.rs
+++ b/identity/aziot-hub-client-async/src/lib.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use aziot_cloud_client_async_common::{get_sas_connector, get_x509_connector};
+use aziot_cloud_client_async_common::{get_sas_connector, get_x509_connector, MaybeProxyClient};
 
 pub const IOT_HUB_ENCODE_SET: &percent_encoding::AsciiSet =
     &http_common::PATH_SEGMENT_ENCODE_SET.add(b'=');
@@ -26,6 +26,7 @@ pub struct Client {
     key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
     cert_client: Arc<aziot_cert_client_async::Client>,
     tpm_client: Arc<aziot_tpm_client_async::Client>,
+    proxy_uri: Option<hyper::Uri>,
 }
 
 impl Client {
@@ -36,6 +37,7 @@ impl Client {
         key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
         cert_client: Arc<aziot_cert_client_async::Client>,
         tpm_client: Arc<aziot_tpm_client_async::Client>,
+        proxy_uri: Option<hyper::Uri>,
     ) -> Self {
         Client {
             device,
@@ -43,6 +45,7 @@ impl Client {
             key_engine,
             cert_client,
             tpm_client,
+            proxy_uri,
         }
     }
 }
@@ -68,20 +71,9 @@ impl Client {
             authentication: authentication_type,
         };
 
-        let mut key_engine = self.key_engine.lock().await;
-
-        let res: aziot_identity_common::hub::Module = request(
-            &self.device,
-            http::Method::PUT,
-            &uri,
-            Some(&body),
-            false,
-            &self.key_client,
-            &mut *key_engine,
-            &self.cert_client,
-            &self.tpm_client,
-        )
-        .await?;
+        let res: aziot_identity_common::hub::Module = self
+            .request(&self.device, http::Method::PUT, &uri, Some(&body), false)
+            .await?;
 
         Ok(res)
     }
@@ -106,20 +98,9 @@ impl Client {
             authentication: authentication_type,
         };
 
-        let mut key_engine = self.key_engine.lock().await;
-
-        let res: aziot_identity_common::hub::Module = request(
-            &self.device,
-            http::Method::PUT,
-            &uri,
-            Some(&body),
-            true,
-            &self.key_client,
-            &mut *key_engine,
-            &self.cert_client,
-            &self.tpm_client,
-        )
-        .await?;
+        let res: aziot_identity_common::hub::Module = self
+            .request(&self.device, http::Method::PUT, &uri, Some(&body), true)
+            .await?;
         Ok(res)
     }
 
@@ -133,20 +114,9 @@ impl Client {
             percent_encoding::percent_encode(module_id.as_bytes(), IOT_HUB_ENCODE_SET),
         );
 
-        let mut key_engine = self.key_engine.lock().await;
-
-        let res: aziot_identity_common::hub::Module = request::<(), _>(
-            &self.device,
-            http::Method::GET,
-            &uri,
-            None,
-            false,
-            &self.key_client,
-            &mut *key_engine,
-            &self.cert_client,
-            &self.tpm_client,
-        )
-        .await?;
+        let res: aziot_identity_common::hub::Module = self
+            .request::<(), _>(&self.device, http::Method::GET, &uri, None, false)
+            .await?;
         Ok(res)
     }
 
@@ -158,20 +128,9 @@ impl Client {
             percent_encoding::percent_encode(&self.device.device_id.as_bytes(), IOT_HUB_ENCODE_SET),
         );
 
-        let mut key_engine = self.key_engine.lock().await;
-
-        let res: Vec<aziot_identity_common::hub::Module> = request::<(), _>(
-            &self.device,
-            http::Method::GET,
-            &uri,
-            None,
-            false,
-            &self.key_client,
-            &mut *key_engine,
-            &self.cert_client,
-            &self.tpm_client,
-        )
-        .await?;
+        let res: Vec<aziot_identity_common::hub::Module> = self
+            .request::<(), _>(&self.device, http::Method::GET, &uri, None, false)
+            .await?;
         Ok(res)
     }
 
@@ -182,20 +141,294 @@ impl Client {
             percent_encoding::percent_encode(module_id.as_bytes(), IOT_HUB_ENCODE_SET),
         );
 
-        let mut key_engine = self.key_engine.lock().await;
-
-        let () = request_no_content::<()>(
-            &self.device,
-            http::Method::DELETE,
-            &uri,
-            None,
-            &self.key_client,
-            &mut *key_engine,
-            &self.cert_client,
-            &self.tpm_client,
-        )
-        .await?;
+        let () = self
+            .request_no_content::<()>(&self.device, http::Method::DELETE, &uri, None)
+            .await?;
         Ok(())
+    }
+
+    async fn request<TRequest, TResponse>(
+        &self,
+        hub_device: &aziot_identity_common::IoTHubDevice,
+        method: http::Method,
+        uri: &str,
+        body: Option<&TRequest>,
+        add_if_match: bool,
+    ) -> std::io::Result<TResponse>
+    where
+        TRequest: serde::Serialize,
+        TResponse: serde::de::DeserializeOwned,
+    {
+        let uri = format!("https://{}{}", hub_device.iothub_hostname, uri);
+
+        let req = hyper::Request::builder().method(method).uri(uri);
+        // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
+        //
+        // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
+        #[allow(clippy::option_if_let_else)]
+        let req = if let Some(body) = body {
+            let body = serde_json::to_vec(body)
+                .expect("serializing request body to JSON cannot fail")
+                .into();
+            req.header(hyper::header::CONTENT_TYPE, "application/json")
+                .body(body)
+        } else {
+            req.body(hyper::Body::default())
+        };
+
+        let mut req = req.expect("cannot fail to create hyper request");
+
+        if add_if_match {
+            req.headers_mut().insert(
+                hyper::header::IF_MATCH,
+                hyper::header::HeaderValue::from_static("*"),
+            );
+        }
+
+        let connector = match hub_device.credentials.clone() {
+            aziot_identity_common::Credentials::SharedPrivateKey(key) => {
+                let audience = format!(
+                    "{}/devices/{}",
+                    hub_device.iothub_hostname, hub_device.device_id
+                );
+                let (connector, token) =
+                    get_sas_connector(&audience, &key, &*self.key_client, false).await?;
+
+                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                req.headers_mut()
+                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
+                connector
+            }
+            aziot_identity_common::Credentials::Tpm => {
+                let audience = format!(
+                    "{}/devices/{}",
+                    hub_device.iothub_hostname, hub_device.device_id
+                );
+                let (connector, token) =
+                    get_sas_connector(&audience, "", &*self.tpm_client, false).await?;
+
+                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                req.headers_mut()
+                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
+                connector
+            }
+            aziot_identity_common::Credentials::X509 {
+                identity_cert,
+                identity_pk,
+            } => {
+                get_x509_connector(
+                    &identity_cert,
+                    &identity_pk,
+                    &self.key_client,
+                    &mut *self.key_engine.lock().await,
+                    &self.cert_client,
+                )
+                .await?
+            }
+        };
+
+        let client = MaybeProxyClient::build(self.proxy_uri.clone(), connector)?;
+
+        log::debug!("IoTHub request {:?}", req);
+
+        let res = client
+            .request(req)
+            .await
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+        let (
+            http::response::Parts {
+                status: res_status_code,
+                headers,
+                ..
+            },
+            body,
+        ) = res.into_parts();
+        log::debug!("IoTHub response status {:?}", res_status_code);
+        log::debug!("IoTHub response headers{:?}", headers);
+
+        let mut is_json = false;
+        for (header_name, header_value) in headers {
+            if header_name == Some(hyper::header::CONTENT_TYPE) {
+                let value = header_value
+                    .to_str()
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                if value.contains("application/json") {
+                    is_json = true;
+                }
+            }
+        }
+
+        let body = hyper::body::to_bytes(body)
+            .await
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+        log::debug!("IoTHub response body {:?}", body);
+
+        let res: TResponse = match res_status_code {
+            hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
+                if !is_json {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "malformed HTTP response",
+                    ));
+                }
+                let res = serde_json::from_slice(&body)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                res
+            }
+
+            res_status_code
+                if res_status_code.is_client_error() || res_status_code.is_server_error() =>
+            {
+                let res: crate::Error = serde_json::from_slice(&body)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
+            }
+
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "malformed HTTP response",
+                ))
+            }
+        };
+        Ok(res)
+    }
+
+    async fn request_no_content<TRequest>(
+        &self,
+        hub_device: &aziot_identity_common::IoTHubDevice,
+        method: http::Method,
+        uri: &str,
+        body: Option<&TRequest>,
+    ) -> std::io::Result<()>
+    where
+        TRequest: serde::Serialize,
+    {
+        let uri = format!("https://{}{}", hub_device.iothub_hostname, uri);
+
+        let req = hyper::Request::builder().method(method).uri(uri);
+        // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
+        //
+        // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
+        #[allow(clippy::option_if_let_else)]
+        let req = if let Some(body) = body {
+            let body = serde_json::to_vec(body)
+                .expect("serializing request body to JSON cannot fail")
+                .into();
+            req.header(hyper::header::CONTENT_TYPE, "application/json")
+                .body(body)
+        } else {
+            req.body(Default::default())
+        };
+        let mut req = req.expect("cannot fail to create hyper request");
+
+        req.headers_mut().insert(
+            hyper::header::IF_MATCH,
+            hyper::header::HeaderValue::from_static("*"),
+        );
+
+        let connector = match hub_device.credentials.clone() {
+            aziot_identity_common::Credentials::SharedPrivateKey(key) => {
+                let audience = format!(
+                    "{}/devices/{}",
+                    hub_device.iothub_hostname, hub_device.device_id
+                );
+                let (connector, token) =
+                    get_sas_connector(&audience, &key, &*self.key_client, false).await?;
+
+                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                req.headers_mut()
+                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
+                connector
+            }
+            aziot_identity_common::Credentials::Tpm => {
+                let audience = format!(
+                    "{}/devices/{}",
+                    hub_device.iothub_hostname, hub_device.device_id
+                );
+                let (connector, token) =
+                    get_sas_connector(&audience, "", &*self.tpm_client, false).await?;
+
+                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                req.headers_mut()
+                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
+                connector
+            }
+            aziot_identity_common::Credentials::X509 {
+                identity_cert,
+                identity_pk,
+            } => {
+                get_x509_connector(
+                    &identity_cert,
+                    &identity_pk,
+                    &self.key_client,
+                    &mut *self.key_engine.lock().await,
+                    &self.cert_client,
+                )
+                .await?
+            }
+        };
+
+        let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);
+
+        let res = client
+            .request(req)
+            .await
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+        let (
+            http::response::Parts {
+                status: res_status_code,
+                headers,
+                ..
+            },
+            body,
+        ) = res.into_parts();
+
+        let body = hyper::body::to_bytes(body)
+            .await
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+        match res_status_code {
+            hyper::StatusCode::NO_CONTENT => Ok(()),
+
+            res_status_code
+                if res_status_code.is_client_error() || res_status_code.is_server_error() =>
+            {
+                let mut is_json = false;
+                for (header_name, header_value) in headers {
+                    if header_name == Some(hyper::header::CONTENT_TYPE) {
+                        let value = header_value
+                            .to_str()
+                            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                        if value.contains("application/json") {
+                            is_json = true;
+                        }
+                    }
+                }
+
+                if !is_json {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "malformed HTTP response",
+                    ));
+                }
+
+                let res: crate::Error = serde_json::from_slice(&body)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
+            }
+
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "malformed HTTP response",
+            )),
+        }
     }
 }
 
@@ -203,288 +436,4 @@ impl Client {
 pub struct Error {
     #[serde(alias = "Message")]
     pub message: std::borrow::Cow<'static, str>,
-}
-
-async fn request<TRequest, TResponse>(
-    hub_device: &aziot_identity_common::IoTHubDevice,
-    method: http::Method,
-    uri: &str,
-    body: Option<&TRequest>,
-    add_if_match: bool,
-    key_client: &aziot_key_client_async::Client,
-    key_engine: &mut openssl2::FunctionalEngineRef,
-    cert_client: &aziot_cert_client_async::Client,
-    tpm_client: &aziot_tpm_client_async::Client,
-) -> std::io::Result<TResponse>
-where
-    TRequest: serde::Serialize,
-    TResponse: serde::de::DeserializeOwned,
-{
-    let uri = format!("https://{}{}", hub_device.iothub_hostname, uri);
-
-    let req = hyper::Request::builder().method(method).uri(uri);
-    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let req = if let Some(body) = body {
-        let body = serde_json::to_vec(body)
-            .expect("serializing request body to JSON cannot fail")
-            .into();
-        req.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        req.body(hyper::Body::default())
-    };
-
-    let mut req = req.expect("cannot fail to create hyper request");
-
-    if add_if_match {
-        req.headers_mut().insert(
-            hyper::header::IF_MATCH,
-            hyper::header::HeaderValue::from_static("*"),
-        );
-    }
-
-    let connector = match hub_device.credentials.clone() {
-        aziot_identity_common::Credentials::SharedPrivateKey(key) => {
-            let audience = format!(
-                "{}/devices/{}",
-                hub_device.iothub_hostname, hub_device.device_id
-            );
-            let (connector, token) = get_sas_connector(&audience, &key, key_client, false).await?;
-
-            let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            req.headers_mut()
-                .append(hyper::header::AUTHORIZATION, authorization_header_value);
-            connector
-        }
-        aziot_identity_common::Credentials::Tpm => {
-            let audience = format!(
-                "{}/devices/{}",
-                hub_device.iothub_hostname, hub_device.device_id
-            );
-            let (connector, token) = get_sas_connector(&audience, "", tpm_client, false).await?;
-
-            let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            req.headers_mut()
-                .append(hyper::header::AUTHORIZATION, authorization_header_value);
-            connector
-        }
-        aziot_identity_common::Credentials::X509 {
-            identity_cert,
-            identity_pk,
-        } => {
-            get_x509_connector(
-                &identity_cert,
-                &identity_pk,
-                key_client,
-                key_engine,
-                cert_client,
-            )
-            .await?
-        }
-    };
-
-    let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);
-    log::debug!("IoTHub request {:?}", req);
-
-    let res = client
-        .request(req)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let (
-        http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
-        },
-        body,
-    ) = res.into_parts();
-    log::debug!("IoTHub response status {:?}", res_status_code);
-    log::debug!("IoTHub response headers{:?}", headers);
-
-    let mut is_json = false;
-    for (header_name, header_value) in headers {
-        if header_name == Some(hyper::header::CONTENT_TYPE) {
-            let value = header_value
-                .to_str()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            if value.contains("application/json") {
-                is_json = true;
-            }
-        }
-    }
-
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-    log::debug!("IoTHub response body {:?}", body);
-
-    let res: TResponse = match res_status_code {
-        hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
-            if !is_json {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "malformed HTTP response",
-                ));
-            }
-            let res = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            res
-        }
-
-        res_status_code
-            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-        {
-            let res: crate::Error = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
-        }
-
-        _ => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "malformed HTTP response",
-            ))
-        }
-    };
-    Ok(res)
-}
-
-async fn request_no_content<TRequest>(
-    hub_device: &aziot_identity_common::IoTHubDevice,
-    method: http::Method,
-    uri: &str,
-    body: Option<&TRequest>,
-    key_client: &aziot_key_client_async::Client,
-    key_engine: &mut openssl2::FunctionalEngineRef,
-    cert_client: &aziot_cert_client_async::Client,
-    tpm_client: &aziot_tpm_client_async::Client,
-) -> std::io::Result<()>
-where
-    TRequest: serde::Serialize,
-{
-    let uri = format!("https://{}{}", hub_device.iothub_hostname, uri);
-
-    let req = hyper::Request::builder().method(method).uri(uri);
-    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let req = if let Some(body) = body {
-        let body = serde_json::to_vec(body)
-            .expect("serializing request body to JSON cannot fail")
-            .into();
-        req.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        req.body(Default::default())
-    };
-    let mut req = req.expect("cannot fail to create hyper request");
-
-    req.headers_mut().insert(
-        hyper::header::IF_MATCH,
-        hyper::header::HeaderValue::from_static("*"),
-    );
-
-    let connector = match hub_device.credentials.clone() {
-        aziot_identity_common::Credentials::SharedPrivateKey(key) => {
-            let audience = format!(
-                "{}/devices/{}",
-                hub_device.iothub_hostname, hub_device.device_id
-            );
-            let (connector, token) = get_sas_connector(&audience, &key, key_client, false).await?;
-
-            let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            req.headers_mut()
-                .append(hyper::header::AUTHORIZATION, authorization_header_value);
-            connector
-        }
-        aziot_identity_common::Credentials::Tpm => {
-            let audience = format!(
-                "{}/devices/{}",
-                hub_device.iothub_hostname, hub_device.device_id
-            );
-            let (connector, token) = get_sas_connector(&audience, "", tpm_client, false).await?;
-
-            let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            req.headers_mut()
-                .append(hyper::header::AUTHORIZATION, authorization_header_value);
-            connector
-        }
-        aziot_identity_common::Credentials::X509 {
-            identity_cert,
-            identity_pk,
-        } => {
-            get_x509_connector(
-                &identity_cert,
-                &identity_pk,
-                key_client,
-                key_engine,
-                cert_client,
-            )
-            .await?
-        }
-    };
-
-    let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);
-    let res = client
-        .request(req)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let (
-        http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
-        },
-        body,
-    ) = res.into_parts();
-
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    match res_status_code {
-        hyper::StatusCode::NO_CONTENT => Ok(()),
-
-        res_status_code
-            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-        {
-            let mut is_json = false;
-            for (header_name, header_value) in headers {
-                if header_name == Some(hyper::header::CONTENT_TYPE) {
-                    let value = header_value
-                        .to_str()
-                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                    if value.contains("application/json") {
-                        is_json = true;
-                    }
-                }
-            }
-
-            if !is_json {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "malformed HTTP response",
-                ));
-            }
-
-            let res: crate::Error = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
-        }
-
-        _ => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "malformed HTTP response",
-        )),
-    }
 }

--- a/identity/aziot-identityd/src/error.rs
+++ b/identity/aziot-identityd/src/error.rs
@@ -60,6 +60,7 @@ pub enum InternalError {
     BadSettings(std::io::Error),
     CreateCertificate(Box<dyn std::error::Error + Send + Sync>),
     CreateHomeDir(std::io::Error),
+    InvalidProxyUri(Box<dyn std::error::Error + Send + Sync>),
     InvalidUri(http::uri::InvalidUri),
     LoadKeyOpensslEngine(openssl2::Error),
     LoadDeviceInfo(std::io::Error),
@@ -77,6 +78,7 @@ impl std::fmt::Display for InternalError {
             InternalError::BadSettings(m) => write!(f, "bad settings: {}", m),
             InternalError::CreateCertificate(_) => f.write_str("could not create certificate"),
             InternalError::CreateHomeDir(_) => f.write_str("could not create home directory"),
+            InternalError::InvalidProxyUri(_) => f.write_str("invalid proxy uri"),
             InternalError::InvalidUri(_) => f.write_str("invalid resource uri"),
             InternalError::LoadKeyOpensslEngine(_) => {
                 f.write_str("could not load aziot-key-openssl-engine")
@@ -105,6 +107,7 @@ impl std::error::Error for InternalError {
             InternalError::BadSettings(err) => Some(err),
             InternalError::CreateCertificate(err) => Some(&**err),
             InternalError::CreateHomeDir(err) => Some(err),
+            InternalError::InvalidProxyUri(err) => Some(&**err),
             InternalError::InvalidUri(err) => Some(err),
             InternalError::LoadKeyOpensslEngine(err) => Some(err),
             InternalError::LoadDeviceInfo(err) => Some(err),

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -14,6 +14,7 @@ pub struct IdentityManager {
     cert_client: Arc<aziot_cert_client_async::Client>,
     tpm_client: Arc<aziot_tpm_client_async::Client>,
     iot_hub_device: Option<aziot_identity_common::IoTHubDevice>,
+    proxy_uri: Option<hyper::Uri>,
 }
 
 impl IdentityManager {
@@ -23,6 +24,7 @@ impl IdentityManager {
         cert_client: Arc<aziot_cert_client_async::Client>,
         tpm_client: Arc<aziot_tpm_client_async::Client>,
         iot_hub_device: Option<aziot_identity_common::IoTHubDevice>,
+        proxy_uri: Option<hyper::Uri>,
     ) -> Self {
         IdentityManager {
             locks: Default::default(),
@@ -31,6 +33,7 @@ impl IdentityManager {
             cert_client,
             tpm_client,
             iot_hub_device, //set by Server over futures channel
+            proxy_uri,
         }
     }
 
@@ -57,6 +60,7 @@ impl IdentityManager {
                     self.key_engine.clone(),
                     self.cert_client.clone(),
                     self.tpm_client.clone(),
+                    self.proxy_uri.clone(),
                 );
                 let new_module = client
                     .create_module(&*module_id, None, None)
@@ -121,6 +125,7 @@ impl IdentityManager {
                     self.key_engine.clone(),
                     self.cert_client.clone(),
                     self.tpm_client.clone(),
+                    self.proxy_uri.clone(),
                 );
                 let curr_module = client
                     .get_module(&*module_id)
@@ -200,6 +205,7 @@ impl IdentityManager {
                     self.key_engine.clone(),
                     self.cert_client.clone(),
                     self.tpm_client.clone(),
+                    self.proxy_uri.clone(),
                 );
                 let module = client
                     .get_module(&*module_id)
@@ -241,6 +247,7 @@ impl IdentityManager {
                     self.key_engine.clone(),
                     self.cert_client.clone(),
                     self.tpm_client.clone(),
+                    self.proxy_uri.clone(),
                 );
 
                 let response = client.get_modules().await.map_err(Error::HubClient)?;
@@ -281,6 +288,7 @@ impl IdentityManager {
                     self.key_engine.clone(),
                     self.cert_client.clone(),
                     self.tpm_client.clone(),
+                    self.proxy_uri.clone(),
                 );
                 client
                     .delete_module(&*module_id)

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -14,6 +14,7 @@
 )]
 #![allow(dead_code)]
 
+use std::env;
 use std::sync::Arc;
 
 pub mod auth;
@@ -139,6 +140,7 @@ pub struct Api {
     key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
     cert_client: Arc<aziot_cert_client_async::Client>,
     tpm_client: Arc<aziot_tpm_client_async::Client>,
+    proxy_uri: Option<hyper::Uri>,
 }
 
 impl Api {
@@ -194,12 +196,15 @@ impl Api {
             tpm_client
         };
 
+        let proxy_uri = get_proxy_uri(None)?;
+
         let id_manager = identity::IdentityManager::new(
             key_client.clone(),
             key_engine.clone(),
             cert_client.clone(),
             tpm_client.clone(),
             None,
+            proxy_uri.clone(),
         );
 
         Ok(Api {
@@ -213,6 +218,7 @@ impl Api {
             key_engine,
             cert_client,
             tpm_client,
+            proxy_uri,
         })
     }
 
@@ -467,6 +473,7 @@ impl Api {
                     self.key_engine.clone(),
                     self.cert_client.clone(),
                     self.tpm_client.clone(),
+                    self.proxy_uri.clone(),
                 );
 
                 let device = match attestation {
@@ -878,6 +885,36 @@ fn convert_to_map(
     (pmap, module_mset, local_mmap)
 }
 
+pub fn get_proxy_uri(https_proxy: Option<String>) -> Result<Option<hyper::Uri>, Error> {
+    let proxy_uri = https_proxy
+        .or_else(|| env::var("HTTPS_PROXY").ok())
+        .or_else(|| env::var("https_proxy").ok());
+    let proxy_uri = match proxy_uri {
+        None => None,
+        Some(s) => {
+            let proxy = s
+                .parse::<hyper::Uri>()
+                .map_err(|err| Error::Internal(InternalError::InvalidProxyUri(Box::new(err))))?;
+
+            // Mask the password in the proxy URI before logging it
+            let mut sanitized_proxy = url::Url::parse(&proxy.to_string())
+                .map_err(|err| Error::Internal(InternalError::InvalidProxyUri(Box::new(err))))?;
+
+            if sanitized_proxy.password().is_some() {
+                sanitized_proxy.set_password(Some("******")).map_err(|()| {
+                    Error::Internal(InternalError::InvalidProxyUri(
+                        "set proxy password failed".into(),
+                    ))
+                })?;
+            }
+            log::info!("Detected HTTPS proxy server {}", sanitized_proxy);
+
+            Some(proxy)
+        }
+    };
+    Ok(proxy_uri)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
@@ -894,7 +931,7 @@ mod tests {
     };
     use crate::SettingsAuthorizer;
 
-    use super::{convert_to_map, Api};
+    use super::{convert_to_map, get_proxy_uri, Api};
 
     fn make_empty_settings() -> Settings {
         Settings {
@@ -1081,5 +1118,43 @@ mod tests {
             Ok(false) => (),
             _ => panic!("incorrect authorization returned"),
         }
+    }
+
+    #[test]
+    fn get_proxy_uri_recognizes_https_proxy() {
+        let proxy_val = "https://example.com"
+            .to_string()
+            .parse::<hyper::Uri>()
+            .unwrap()
+            .to_string();
+
+        assert_eq!(
+            get_proxy_uri(Some(proxy_val.clone()))
+                .unwrap()
+                .unwrap()
+                .to_string(),
+            proxy_val
+        );
+    }
+
+    #[test]
+    fn get_proxy_uri_allows_credentials_in_authority() {
+        let proxy_val = "https://username:password@example.com/".to_string();
+        assert_eq!(
+            get_proxy_uri(Some(proxy_val.clone()))
+                .unwrap()
+                .unwrap()
+                .to_string(),
+            proxy_val
+        );
+
+        let proxy_val = "https://username%2f:password%2f@example.com/".to_string();
+        assert_eq!(
+            get_proxy_uri(Some(proxy_val.clone()))
+                .unwrap()
+                .unwrap()
+                .to_string(),
+            proxy_val
+        );
     }
 }


### PR DESCRIPTION
Changes:
- Added proxy client support
- Refactored Hub client to reduce redundancy

Verified using local squid proxy (Sas connector works only so far)

TODO:
[ ] Close open issue for setting TLS tunneling on `hyper_openssl` (X509 provisioning fails without setting tunneling connector)