### PR TITLE
Update clippy suppression for new 1.49.0 release.

### DIFF
--- a/aziot/src/init.rs
+++ b/aziot/src/init.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 //! This subcommand interactively asks the user to give out basic provisioning information for their device and
-//! creates the config files for the three services based on that information.
+//! creates the config files for the four services based on that information.
 //!
 //! Notes:
 //!
@@ -40,7 +40,7 @@ pub(crate) fn run() -> Result<(), crate::Error> {
     // But it's convenient to not do this for the sake of development because the the development machine doesn't necessarily
     // have the package installed and the users created, and it's easier to have the config files owned by the current user anyway.
     //
-    // So when running as root, get the three users appropriately.
+    // So when running as root, get the four users appropriately.
     // Otherwise, if this is a debug build, fall back to using the current user.
     // Otherwise, tell the user to re-run as root.
     let (aziotks_user, aziotcs_user, aziotid_user, aziottpm_user) =
@@ -1171,7 +1171,7 @@ mod tests {
                 preloaded_device_id_pk_bytes: actual_preloaded_device_id_pk_bytes,
             } = super::run_inner(&mut input).unwrap();
 
-            // Convert the three configs to bytes::Bytes before asserting, because bytes::Bytes's Debug format prints strings.
+            // Convert the four configs to bytes::Bytes before asserting, because bytes::Bytes's Debug format prints strings.
             // It doesn't matter for the device ID file since it's binary anyway.
             assert_eq!(
                 bytes::Bytes::from(expected_keyd_config),

--- a/aziot/test-files/init/README.md
+++ b/aziot/test-files/init/README.md
@@ -1,3 +1,3 @@
 This directory contains test files for the `aziot init` tests.
 
-For each test, passing `input.txt` to `aziot init` should produce the three services' configs in `keyd.toml`, `certd.toml` and `identityd.toml`. In the tests that involve a symmetric key, the `device-id` file stores the contents of the `/var/secrets/aziot/keyd/device-id` file that `aziot init` would generate.
+For each test, passing `input.txt` to `aziot init` should produce the four services' configs in `keyd.toml`, `certd.toml`, `identityd.toml` and `tpmd.toml`. In the tests that involve a symmetric key, the `device-id` file stores the contents of the `/var/secrets/aziot/keyd/device-id` file that `aziot init` would generate.

--- a/openssl-build/src/lib.rs
+++ b/openssl-build/src/lib.rs
@@ -10,7 +10,7 @@ pub fn define_version_number_cfg() {
         .expect("DEP_OPENSSL_VERSION_NUMBER must have been set by openssl-sys");
     let openssl_version = u64::from_str_radix(&openssl_version, 16)
         .expect("DEP_OPENSSL_VERSION_NUMBER must have been set to a valid integer");
-    #[allow(clippy::inconsistent_digit_grouping)]
+    #[allow(clippy::unusual_byte_groupings)]
     {
         if openssl_version >= 0x01_01_00_00_0 {
             println!("cargo:rustc-cfg=ossl110");


### PR DESCRIPTION
Also fix some documentation that wasn't updated when tpmd was introduced.