### PR TITLE
Make aziot-identity-service package conflict with the iotedge package.

### DIFF
--- a/contrib/centos/aziot-identity-service.spec
+++ b/contrib/centos/aziot-identity-service.spec
@@ -10,6 +10,8 @@ License: MIT
 URL: https://github.com/azure/iot-identity-service
 Source: aziot-identity-service-%{version}-%{release}.tar.gz
 
+Conflicts: iotedge
+
 BuildRequires: clang
 BuildRequires: gcc
 BuildRequires: gcc-c++
@@ -26,11 +28,14 @@ This package contains the Azure IoT device runtime, comprised of the following s
 - aziot-identityd - The Azure IoT Identity Service
 - aziot-certd - The Azure IoT Certificates Service
 - aziot-keyd - The Azure IoT Keys Service
+- aziot-tpmd - The Azure IoT TPM Service
 
 This package also contains the following libraries:
 
 - libaziot_keys.so - The library used by the Keys Service to communicate with HSMs for key operations.
 - <openssl engines directory>/openssl/engines/libaziot_keys.so - An openssl engine that can be used to work with asymmetric keys managed by the Azure IoT Keys Service.
+
+Lastly, this package contains the aziot binary that is used to configure and manage the services.
 
 
 %package devel

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -12,6 +12,7 @@ Vcs-Git: https://github.com/azure/iot-identity-service
 Package: aziot-identity-service
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Conflicts: iotedge
 Description: Azure IoT Identity Service and related services
  This package contains the Azure IoT device runtime, comprised of the following services:
  .
@@ -24,3 +25,5 @@ Description: Azure IoT Identity Service and related services
  .
  - libaziot_keys.so - The library used by the Keys Service to communicate with HSMs for key operations.
  - <openssl engines directory>/aziot_keys.so - An openssl engine that can be used to work with asymmetric keys managed by the Azure IoT Keys Service.
+ .
+ Lastly, this package contains the aziot binary that is used to configure and manage the services.

--- a/docs/dev/building.md
+++ b/docs/dev/building.md
@@ -3,7 +3,7 @@
 1. Clone this repo.
 
     ```sh
-    git clone https://github.com/Azure/iot-identity-service
+    git clone --recursive https://github.com/Azure/iot-identity-service
     cd iot-identity-service/
     ```
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -275,10 +275,10 @@ The `--force` option can be used to force the initialization sequence to select 
 iotedge init --force
 ```
 
-A non-interactive initialization that attempts to import the old configuration from `iotedge` can be done using the `--import` option.
+A non-interactive initialization that attempts to import the old configuration from `iotedge` can be done using the `import` subcommand.
 
 ```sh
-iotedge init --import
+iotedge init import
 ```
 
 ### Automating Upgrades of `iotedge` to `aziot-edge`


### PR DESCRIPTION
This helps prevent the user from having both installed.

Other changes:

- Fix command to import old IoT Edge config in the packaging doc, in line with
  https://github.com/Azure/iotedge/commit/e3bf3c9871bc9339253ac662eeefbcae43782287

- Fix `git clone` command in building doc to also clone submodules, as now
  required to bring in Azure/utpm for the TPM service.

- Mention the `aziot` command in the package descriptions.

- Mention the TPM service in the RPM package description.