### PR TITLE
Add settings file watcher for dynamic provisioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,6 @@ dependencies = [
  "aziot-tpm-common-http",
  "chrono",
  "config-common",
- "futures",
  "futures-util",
  "http",
  "http-common",
@@ -1554,6 +1553,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "nix"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,9 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "winapi 0.3.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,16 +34,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "antidote"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-
-[[package]]
 name = "anyhow"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "async-recursion"
@@ -104,8 +98,8 @@ dependencies = [
  "derive_more",
  "erased-serde",
  "http-common",
- "hyper 0.14.2",
- "hyper-openssl 0.9.1",
+ "hyper",
+ "hyper-openssl",
  "mini-sntp",
  "nix",
  "openssl",
@@ -114,7 +108,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "sysinfo",
- "tokio 1.0.1",
+ "tokio",
  "toml",
  "url",
 ]
@@ -127,7 +121,7 @@ dependencies = [
  "aziot-key-common",
  "http",
  "http-common",
- "hyper 0.14.2",
+ "hyper",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -162,8 +156,8 @@ dependencies = [
  "hex",
  "http",
  "http-common",
- "hyper 0.14.2",
- "hyper-openssl 0.9.1",
+ "hyper",
+ "hyper-openssl",
  "lazy_static",
  "log",
  "openssl",
@@ -212,8 +206,8 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper 0.14.2",
- "hyper-openssl 0.9.1",
+ "hyper",
+ "hyper-openssl",
  "log",
  "openssl",
  "openssl2",
@@ -240,15 +234,15 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper 0.14.2",
- "hyper-openssl 0.9.1",
+ "hyper",
+ "hyper-openssl",
  "log",
  "openssl",
  "openssl2",
  "percent-encoding",
  "serde",
  "serde_json",
- "tokio 1.0.1",
+ "tokio",
  "url",
 ]
 
@@ -269,8 +263,8 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper 0.14.2",
- "hyper-openssl 0.9.1",
+ "hyper",
+ "hyper-openssl",
  "log",
  "openssl",
  "openssl2",
@@ -323,10 +317,11 @@ dependencies = [
  "aziot-tpm-common-http",
  "chrono",
  "config-common",
+ "futures",
  "futures-util",
  "http",
  "http-common",
- "hyper 0.14.2",
+ "hyper",
  "lazy_static",
  "libc",
  "log",
@@ -337,7 +332,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "tokio 1.0.1",
+ "tokio",
  "toml",
  "url",
 ]
@@ -375,7 +370,7 @@ dependencies = [
  "aziot-key-common-http",
  "http",
  "http-common",
- "hyper 0.14.2",
+ "hyper",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -437,14 +432,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "hyper 0.13.9",
- "hyper-openssl 0.8.1",
+ "hyper",
+ "hyper-openssl",
  "openssl",
  "openssl-sys2",
  "openssl2",
  "structopt",
- "tokio 0.2.24",
- "tokio-openssl 0.4.0",
+ "tokio",
+ "tokio-openssl",
 ]
 
 [[package]]
@@ -459,7 +454,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper 0.14.2",
+ "hyper",
  "lazy_static",
  "log",
  "openssl",
@@ -524,7 +519,7 @@ dependencies = [
  "aziot-tpm-common-http",
  "http",
  "http-common",
- "hyper 0.14.2",
+ "hyper",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -562,7 +557,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper 0.14.2",
+ "hyper",
  "log",
  "serde",
  "serde_json",
@@ -590,10 +585,10 @@ dependencies = [
  "config-common",
  "env_logger",
  "http-common",
- "hyper 0.14.2",
+ "hyper",
  "log",
  "serde",
- "tokio 1.0.1",
+ "tokio",
  "toml",
 ]
 
@@ -649,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
@@ -1053,7 +1048,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.1",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1100,26 +1095,6 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "h2"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 0.2.24",
- "tokio-util 0.3.1",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "h2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
@@ -1132,8 +1107,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.0.1",
- "tokio-util 0.6.0",
+ "tokio",
+ "tokio-util",
  "tracing",
  "tracing-futures",
 ]
@@ -1191,16 +1166,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
-dependencies = [
- "bytes 0.5.6",
- "http",
-]
-
-[[package]]
-name = "http-body"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
@@ -1217,14 +1182,14 @@ dependencies = [
  "base64",
  "futures-util",
  "http",
- "hyper 0.14.2",
+ "hyper",
  "libc",
  "log",
  "nix",
  "percent-encoding",
  "serde",
  "serde_json",
- "tokio 1.0.1",
+ "tokio",
  "url",
 ]
 
@@ -1248,30 +1213,6 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
-dependencies = [
- "bytes 0.5.6",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.2.7",
- "http",
- "http-body 0.3.1",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project 1.0.3",
- "socket2",
- "tokio 0.2.24",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
@@ -1280,37 +1221,18 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.0",
+ "h2",
  "http",
- "http-body 0.4.0",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project 1.0.4",
  "socket2",
- "tokio 1.0.1",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper-openssl"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90705b797966f4774ffbc5e4dbda9e5b95f2a49991a3187f753171cdd7db3c58"
-dependencies = [
- "antidote",
- "bytes 0.5.6",
- "http",
- "hyper 0.13.9",
- "linked_hash_set",
- "once_cell",
- "openssl",
- "openssl-sys",
- "tokio 0.2.24",
- "tokio-openssl 0.4.0",
- "tower-layer",
 ]
 
 [[package]]
@@ -1320,14 +1242,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d52322a69f0a93f177d76ca82073fcec8d5b4eb6e28525d5b3142fa718195c"
 dependencies = [
  "http",
- "hyper 0.14.2",
+ "hyper",
  "linked_hash_set",
  "once_cell",
  "openssl",
  "openssl-sys",
  "parking_lot",
- "tokio 1.0.1",
- "tokio-openssl 0.6.0",
+ "tokio",
+ "tokio-openssl",
  "tower-layer",
 ]
 
@@ -1396,8 +1318,8 @@ dependencies = [
  "chrono",
  "foreign-types-shared",
  "http-common",
- "hyper 0.14.2",
- "hyper-openssl 0.9.1",
+ "hyper",
+ "hyper-openssl",
  "openssl",
  "openssl-sys2",
  "openssl2",
@@ -1406,7 +1328,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "structopt",
- "tokio 1.0.1",
+ "tokio",
  "url",
 ]
 
@@ -1503,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -1617,17 +1539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
  "winapi 0.3.9",
 ]
 
@@ -1865,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba36e0a6cc5a4c645073f4984f1ed55d09f5857d4de7c14550baa81a39ef5a17"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -2037,9 +1948,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b82c2a1e8eb6e1bfde608de2bcbebd4072aa32d056ea48a986990cd5ca0f5a"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
 dependencies = [
  "bitflags",
 ]
@@ -2051,7 +1962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.1",
- "redox_syscall 0.2.1",
+ "redox_syscall 0.2.4",
 ]
 
 [[package]]
@@ -2092,7 +2003,7 @@ dependencies = [
  "log",
  "mime",
  "percent-encoding",
- "pin-project-lite 0.2.1",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2278,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8ecec865d39a5aeb915ffa9f910073055659c0b5107ef081b7557ab83b6d58"
+checksum = "ec92c229ee7894cde9fca41d3ca387fb980dd04fc04375ffea06474e65753b4e"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
@@ -2322,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2347,24 +2258,6 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "memchr",
- "mio 0.6.23",
- "pin-project-lite 0.1.11",
- "slab",
- "tokio-macros 0.2.6",
-]
-
-[[package]]
-name = "tokio"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
@@ -2375,19 +2268,8 @@ dependencies = [
  "memchr",
  "mio 0.7.7",
  "num_cpus",
- "pin-project-lite 0.2.1",
- "tokio-macros 1.0.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-lite",
+ "tokio-macros",
 ]
 
 [[package]]
@@ -2420,22 +2302,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.1",
- "tokio 1.0.1",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.1.11",
- "tokio 0.2.24",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2448,8 +2316,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.1",
- "tokio 1.0.1",
+ "pin-project-lite",
+ "tokio",
  "tokio-stream",
 ]
 
@@ -2481,8 +2349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
- "pin-project-lite 0.2.1",
+ "pin-project-lite",
  "tracing-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,6 @@ dependencies = [
  "aziot-tpm-common-http",
  "chrono",
  "config-common",
- "futures",
  "futures-util",
  "http",
  "http-common",
@@ -589,7 +588,6 @@ dependencies = [
  "log",
  "serde",
  "tokio",
- "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,8 @@ dependencies = [
  "aziot-tpm-client-async",
  "aziot-tpm-common-http",
  "chrono",
+ "config-common",
+ "futures",
  "futures-util",
  "http",
  "http-common",
@@ -323,6 +325,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "notify",
  "openssl",
  "openssl2",
  "percent-encoding",
@@ -579,13 +582,13 @@ dependencies = [
  "aziot-keyd",
  "aziot-tpmd",
  "backtrace",
+ "config-common",
  "env_logger",
  "http-common",
  "hyper",
  "log",
  "serde",
  "tokio",
- "toml",
 ]
 
 [[package]]
@@ -916,6 +919,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +965,23 @@ name = "futures-io"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-macro"
@@ -1224,6 +1259,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4563555856585ab3180a5bf0b2f9f8d301a728462afffc8195b3f5394229c55"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "iotedged"
 version = "0.1.0"
 dependencies = [
@@ -1287,6 +1342,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -2276,6 +2337,17 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
 name = "anyhow"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,8 +104,8 @@ dependencies = [
  "derive_more",
  "erased-serde",
  "http-common",
- "hyper",
- "hyper-openssl",
+ "hyper 0.14.2",
+ "hyper-openssl 0.9.1",
  "mini-sntp",
  "nix",
  "openssl",
@@ -108,7 +114,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "sysinfo",
- "tokio",
+ "tokio 1.0.1",
  "toml",
  "url",
 ]
@@ -121,7 +127,7 @@ dependencies = [
  "aziot-key-common",
  "http",
  "http-common",
- "hyper",
+ "hyper 0.14.2",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -156,8 +162,8 @@ dependencies = [
  "hex",
  "http",
  "http-common",
- "hyper",
- "hyper-openssl",
+ "hyper 0.14.2",
+ "hyper-openssl 0.9.1",
  "lazy_static",
  "log",
  "openssl",
@@ -206,8 +212,8 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper",
- "hyper-openssl",
+ "hyper 0.14.2",
+ "hyper-openssl 0.9.1",
  "log",
  "openssl",
  "openssl2",
@@ -234,15 +240,15 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper",
- "hyper-openssl",
+ "hyper 0.14.2",
+ "hyper-openssl 0.9.1",
  "log",
  "openssl",
  "openssl2",
  "percent-encoding",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 1.0.1",
  "url",
 ]
 
@@ -263,8 +269,8 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper",
- "hyper-openssl",
+ "hyper 0.14.2",
+ "hyper-openssl 0.9.1",
  "log",
  "openssl",
  "openssl2",
@@ -320,7 +326,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper",
+ "hyper 0.14.2",
  "lazy_static",
  "libc",
  "log",
@@ -331,7 +337,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 1.0.1",
  "toml",
  "url",
 ]
@@ -369,7 +375,7 @@ dependencies = [
  "aziot-key-common-http",
  "http",
  "http-common",
- "hyper",
+ "hyper 0.14.2",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -431,14 +437,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "hyper",
- "hyper-openssl",
+ "hyper 0.13.9",
+ "hyper-openssl 0.8.1",
  "openssl",
  "openssl-sys2",
  "openssl2",
  "structopt",
- "tokio",
- "tokio-openssl",
+ "tokio 0.2.24",
+ "tokio-openssl 0.4.0",
 ]
 
 [[package]]
@@ -453,7 +459,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper",
+ "hyper 0.14.2",
  "lazy_static",
  "log",
  "openssl",
@@ -518,7 +524,7 @@ dependencies = [
  "aziot-tpm-common-http",
  "http",
  "http-common",
- "hyper",
+ "hyper 0.14.2",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -556,7 +562,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-common",
- "hyper",
+ "hyper 0.14.2",
  "log",
  "serde",
  "serde_json",
@@ -584,10 +590,10 @@ dependencies = [
  "config-common",
  "env_logger",
  "http-common",
- "hyper",
+ "hyper 0.14.2",
  "log",
  "serde",
- "tokio",
+ "tokio 1.0.1",
  "toml",
 ]
 
@@ -1047,7 +1053,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.1",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1094,6 +1100,26 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "h2"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 0.2.24",
+ "tokio-util 0.3.1",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "h2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
@@ -1106,8 +1132,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 1.0.1",
+ "tokio-util 0.6.0",
  "tracing",
  "tracing-futures",
 ]
@@ -1165,6 +1191,16 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.6",
+ "http",
+]
+
+[[package]]
+name = "http-body"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
@@ -1181,14 +1217,14 @@ dependencies = [
  "base64",
  "futures-util",
  "http",
- "hyper",
+ "hyper 0.14.2",
  "libc",
  "log",
  "nix",
  "percent-encoding",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 1.0.1",
  "url",
 ]
 
@@ -1212,6 +1248,30 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
+version = "0.13.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.2.7",
+ "http",
+ "http-body 0.3.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.3",
+ "socket2",
+ "tokio 0.2.24",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
@@ -1220,18 +1280,37 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.0",
  "http",
- "http-body",
+ "http-body 0.4.0",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project 1.0.4",
  "socket2",
- "tokio",
+ "tokio 1.0.1",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-openssl"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90705b797966f4774ffbc5e4dbda9e5b95f2a49991a3187f753171cdd7db3c58"
+dependencies = [
+ "antidote",
+ "bytes 0.5.6",
+ "http",
+ "hyper 0.13.9",
+ "linked_hash_set",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "tokio 0.2.24",
+ "tokio-openssl 0.4.0",
+ "tower-layer",
 ]
 
 [[package]]
@@ -1241,14 +1320,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d52322a69f0a93f177d76ca82073fcec8d5b4eb6e28525d5b3142fa718195c"
 dependencies = [
  "http",
- "hyper",
+ "hyper 0.14.2",
  "linked_hash_set",
  "once_cell",
  "openssl",
  "openssl-sys",
  "parking_lot",
- "tokio",
- "tokio-openssl",
+ "tokio 1.0.1",
+ "tokio-openssl 0.6.0",
  "tower-layer",
 ]
 
@@ -1317,8 +1396,8 @@ dependencies = [
  "chrono",
  "foreign-types-shared",
  "http-common",
- "hyper",
- "hyper-openssl",
+ "hyper 0.14.2",
+ "hyper-openssl 0.9.1",
  "openssl",
  "openssl-sys2",
  "openssl2",
@@ -1327,7 +1406,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "structopt",
- "tokio",
+ "tokio 1.0.1",
  "url",
 ]
 
@@ -2013,7 +2092,7 @@ dependencies = [
  "log",
  "mime",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2268,6 +2347,24 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "memchr",
+ "mio 0.6.23",
+ "pin-project-lite 0.1.11",
+ "slab",
+ "tokio-macros 0.2.6",
+]
+
+[[package]]
+name = "tokio"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
@@ -2278,8 +2375,19 @@ dependencies = [
  "memchr",
  "mio 0.7.7",
  "num_cpus",
- "pin-project-lite",
- "tokio-macros",
+ "pin-project-lite 0.2.1",
+ "tokio-macros 1.0.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2312,8 +2420,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.2.1",
+ "tokio 1.0.1",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.1.11",
+ "tokio 0.2.24",
 ]
 
 [[package]]
@@ -2326,8 +2448,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.2.1",
+ "tokio 1.0.1",
  "tokio-stream",
 ]
 
@@ -2359,7 +2481,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "pin-project-lite",
+ "log",
+ "pin-project-lite 0.2.1",
  "tracing-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -589,6 +589,7 @@ dependencies = [
  "log",
  "serde",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -676,7 +677,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -711,7 +712,16 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "config-common"
+version = "0.1.0"
+dependencies = [
+ "backtrace",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -826,7 +836,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -873,6 +883,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.1.57",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,25 +926,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
 name = "futures"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -965,23 +1007,6 @@ name = "futures-io"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-macro"
@@ -1250,15 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "inotify"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1292,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4563555856585ab3180a5bf0b2f9f8d301a728462afffc8195b3f5394229c55"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1308,6 +1333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1369,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -1434,15 +1478,58 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.6",
  "ntapi",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -1452,7 +1539,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1468,12 +1566,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio 0.6.23",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1609,7 +1725,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.1.57",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1921,7 +2037,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1929,6 +2045,15 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2012,7 +2137,7 @@ checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2076,7 +2201,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2113,7 +2238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2141,7 +2266,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.7",
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
@@ -2451,6 +2576,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2458,6 +2589,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2471,7 +2608,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2486,5 +2623,15 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ members = [
 	"cert/aziot-cert-common-http",
 	"cert/aziot-certd",
 
+	"config-common",
+
 	"http-common",
 
 	"identity/aziot-cloud-client-async-common",

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ dist:
 
 	# Copy source files
 	cp -R \
-		./aziot ./aziotd ./cert ./http-common ./identity ./iotedged ./key ./mini-sntp ./openssl-build ./openssl-sys2 ./openssl2 ./pkcs11 ./tpm \
+		./aziot ./aziotd ./cert ./config-common ./http-common ./identity ./iotedged ./key ./mini-sntp ./openssl-build ./openssl-sys2 ./openssl2 ./pkcs11 ./tpm \
 		/tmp/aziot-identity-service-$(PACKAGE_VERSION)
 	cp ./Cargo.toml ./Cargo.lock ./CODE_OF_CONDUCT.md ./CONTRIBUTING.md ./LICENSE ./Makefile ./README.md ./rust-toolchain ./SECURITY.md /tmp/aziot-identity-service-$(PACKAGE_VERSION)
 

--- a/aziot/src/init.rs
+++ b/aziot/src/init.rs
@@ -9,7 +9,7 @@
 //!   saved to a file. This subcommand uses a file named `/var/secrets/aziot/keyd/device-id` for that purpose.
 //!   It creates the directory structure and ACLs the directory and the file appropriately to the KS user.
 //!
-//! - `dynamic_reprovisioning` is enabled by default in IS provisioning settings.
+//! - `always_reprovisioning_on_startup` is enabled by default in IS provisioning settings.
 //!
 //! - This implementation assumes that Microsoft's implementation of libaziot-keys is being used, in that it generates the keyd config
 //!   with the `aziot_keys.homedir_path` property set, and with validation that the preloaded keys must be `file://` or `pkcs11:` URIs.
@@ -651,7 +651,7 @@ fn run_inner(stdin: &mut impl Reader) -> Result<RunOutput> {
             homedir: AZIOT_IDENTITYD_HOMEDIR_PATH.into(),
             principal: vec![],
             provisioning: aziot_identityd_config::Provisioning {
-                dynamic_reprovisioning: true,
+                always_reprovisioning_on_startup: true,
                 provisioning: provisioning_type,
             },
             endpoints: Default::default(),

--- a/aziot/src/init.rs
+++ b/aziot/src/init.rs
@@ -9,7 +9,7 @@
 //!   saved to a file. This subcommand uses a file named `/var/secrets/aziot/keyd/device-id` for that purpose.
 //!   It creates the directory structure and ACLs the directory and the file appropriately to the KS user.
 //!
-//! - `always_reprovisioning_on_startup` is enabled by default in IS provisioning settings.
+//! - `always_reprovision_on_startup` is enabled by default in IS provisioning settings.
 //!
 //! - This implementation assumes that Microsoft's implementation of libaziot-keys is being used, in that it generates the keyd config
 //!   with the `aziot_keys.homedir_path` property set, and with validation that the preloaded keys must be `file://` or `pkcs11:` URIs.
@@ -651,7 +651,7 @@ fn run_inner(stdin: &mut impl Reader) -> Result<RunOutput> {
             homedir: AZIOT_IDENTITYD_HOMEDIR_PATH.into(),
             principal: vec![],
             provisioning: aziot_identityd_config::Provisioning {
-                always_reprovisioning_on_startup: true,
+                always_reprovision_on_startup: true,
                 provisioning: provisioning_type,
             },
             endpoints: Default::default(),

--- a/aziot/test-files/init/dps-symmetric-key/identityd.toml
+++ b/aziot/test-files/init/dps-symmetric-key/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-symmetric-key/identityd.toml
+++ b/aziot/test-files/init/dps-symmetric-key/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-tpm/identityd.toml
+++ b/aziot/test-files/init/dps-tpm/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-tpm/identityd.toml
+++ b/aziot/test-files/init/dps-tpm/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509-pkcs11-est-bootstrap/identityd.toml
+++ b/aziot/test-files/init/dps-x509-pkcs11-est-bootstrap/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509-pkcs11-est-bootstrap/identityd.toml
+++ b/aziot/test-files/init/dps-x509-pkcs11-est-bootstrap/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509-pkcs11-est/identityd.toml
+++ b/aziot/test-files/init/dps-x509-pkcs11-est/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509-pkcs11-est/identityd.toml
+++ b/aziot/test-files/init/dps-x509-pkcs11-est/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509-pkcs11-localca/identityd.toml
+++ b/aziot/test-files/init/dps-x509-pkcs11-localca/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509-pkcs11-localca/identityd.toml
+++ b/aziot/test-files/init/dps-x509-pkcs11-localca/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509-pkcs11/identityd.toml
+++ b/aziot/test-files/init/dps-x509-pkcs11/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509-pkcs11/identityd.toml
+++ b/aziot/test-files/init/dps-x509-pkcs11/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509/identityd.toml
+++ b/aziot/test-files/init/dps-x509/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/dps-x509/identityd.toml
+++ b/aziot/test-files/init/dps-x509/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net"
 scope_id = "0ab1234C5D6"

--- a/aziot/test-files/init/manual-connection-string/identityd.toml
+++ b/aziot/test-files/init/manual-connection-string/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziot/test-files/init/manual-connection-string/identityd.toml
+++ b/aziot/test-files/init/manual-connection-string/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziot/test-files/init/manual-symmetric-key/identityd.toml
+++ b/aziot/test-files/init/manual-symmetric-key/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziot/test-files/init/manual-symmetric-key/identityd.toml
+++ b/aziot/test-files/init/manual-symmetric-key/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziot/test-files/init/manual-x509-pkcs11/identityd.toml
+++ b/aziot/test-files/init/manual-x509-pkcs11/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziot/test-files/init/manual-x509-pkcs11/identityd.toml
+++ b/aziot/test-files/init/manual-x509-pkcs11/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziot/test-files/init/manual-x509/identityd.toml
+++ b/aziot/test-files/init/manual-x509/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziot/test-files/init/manual-x509/identityd.toml
+++ b/aziot/test-files/init/manual-x509/identityd.toml
@@ -2,7 +2,7 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziotd/Cargo.toml
+++ b/aziotd/Cargo.toml
@@ -18,4 +18,5 @@ aziot-certd = { path = "../cert/aziot-certd" }
 aziot-identityd = { path = "../identity/aziot-identityd" }
 aziot-keyd = { path = "../key/aziot-keyd" }
 aziot-tpmd = { path = "../tpm/aziot-tpmd" }
+config-common = { path = "../config-common" }
 http-common = { path = "../http-common", features = ["tokio1"] }

--- a/aziotd/Cargo.toml
+++ b/aziotd/Cargo.toml
@@ -12,7 +12,6 @@ hyper = "0.14"
 log = "0.4"
 serde = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-toml = "0.5"
 
 aziot-certd = { path = "../cert/aziot-certd" }
 aziot-identityd = { path = "../identity/aziot-identityd" }

--- a/aziotd/src/config.rs
+++ b/aziotd/src/config.rs
@@ -2,10 +2,12 @@
 
 use crate::error::{Error, ErrorKind};
 
-pub(crate) fn read_config<TConfig>(config_path: std::path::PathBuf, config_directory_path: std::path::PathBuf) -> Result<TConfig, Error> 
+pub(crate) fn read_config<TConfig>(
+    config_path: std::path::PathBuf,
+    config_directory_path: std::path::PathBuf,
+) -> Result<TConfig, Error>
 where
     TConfig: serde::de::DeserializeOwned,
-
 {
     let config = std::fs::read(&config_path)
         .map_err(|err| ErrorKind::ReadConfig(Some(config_path.clone()), Box::new(err)))?;
@@ -55,10 +57,9 @@ where
 
     let config: TConfig = serde::Deserialize::deserialize(config)
         .map_err(|err| ErrorKind::ReadConfig(None, Box::new(err)))?;
-    
+
     Ok(config)
 }
-
 
 fn merge_toml(base: &mut toml::Value, patch: toml::Value) {
     // Similar to JSON patch, except that:
@@ -88,7 +89,6 @@ fn merge_toml(base: &mut toml::Value, patch: toml::Value) {
 
     *base = patch;
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/aziotd/src/config.rs
+++ b/aziotd/src/config.rs
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use crate::error::{Error, ErrorKind};
+
+pub(crate) fn read_config<TConfig>(config_path: std::path::PathBuf, config_directory_path: std::path::PathBuf) -> Result<TConfig, Error> 
+where
+    TConfig: serde::de::DeserializeOwned,
+
+{
+    let config = std::fs::read(&config_path)
+        .map_err(|err| ErrorKind::ReadConfig(Some(config_path.clone()), Box::new(err)))?;
+    let mut config: toml::Value = toml::from_slice(&config)
+        .map_err(|err| ErrorKind::ReadConfig(Some(config_path), Box::new(err)))?;
+
+    match std::fs::read_dir(&config_directory_path) {
+        Ok(entries) => {
+            let mut patch_paths = vec![];
+            for entry in entries {
+                let entry = entry.map_err(|err| {
+                    ErrorKind::ReadConfig(Some(config_directory_path.clone()), Box::new(err))
+                })?;
+
+                let entry_file_type = entry.file_type().map_err(|err| {
+                    ErrorKind::ReadConfig(Some(config_directory_path.clone()), Box::new(err))
+                })?;
+                if !entry_file_type.is_file() {
+                    continue;
+                }
+
+                let patch_path = entry.path();
+                if patch_path.extension().and_then(std::ffi::OsStr::to_str) != Some("toml") {
+                    continue;
+                }
+
+                patch_paths.push(patch_path);
+            }
+            patch_paths.sort();
+
+            for patch_path in patch_paths {
+                let patch = std::fs::read(&patch_path).map_err(|err| {
+                    ErrorKind::ReadConfig(Some(patch_path.clone()), Box::new(err))
+                })?;
+                let patch: toml::Value = toml::from_slice(&patch)
+                    .map_err(|err| ErrorKind::ReadConfig(Some(patch_path), Box::new(err)))?;
+                merge_toml(&mut config, patch);
+            }
+        }
+
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => (),
+
+        Err(err) => {
+            return Err(ErrorKind::ReadConfig(Some(config_directory_path), Box::new(err)).into())
+        }
+    }
+
+    let config: TConfig = serde::Deserialize::deserialize(config)
+        .map_err(|err| ErrorKind::ReadConfig(None, Box::new(err)))?;
+    
+    Ok(config)
+}
+
+
+fn merge_toml(base: &mut toml::Value, patch: toml::Value) {
+    // Similar to JSON patch, except that:
+    //
+    // - Maps are called tables.
+    // - There is no equivalent of null that can be used to remove keys from an object.
+    // - Arrays are merged via concatenating the patch to the base, rather than replacing the base with the patch.
+
+    if let toml::Value::Table(base) = base {
+        if let toml::Value::Table(patch) = patch {
+            for (key, value) in patch {
+                // Insert a dummy `false` if the original key didn't exist at all. It'll be overwritten by `value` in that case.
+                let original_value = base.entry(key).or_insert(toml::Value::Boolean(false));
+                merge_toml(original_value, value);
+            }
+
+            return;
+        }
+    }
+
+    if let toml::Value::Array(base) = base {
+        if let toml::Value::Array(patch) = patch {
+            base.extend(patch);
+            return;
+        }
+    }
+
+    *base = patch;
+}
+
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn merge_toml() {
+        let base = r#"
+foo_key = "A"
+foo_parent_key = { foo_sub_key = "B" }
+
+[bar_table]
+bar_table_key = "C"
+bar_table_parent_key = { bar_table_sub_key = "D" }
+
+[[baz_table_array]]
+baz_table_array_key = "E"
+baz_table_array_parent_key = { baz_table_sub_key = "F" }
+"#;
+        let mut base: toml::Value = toml::from_str(base).unwrap();
+
+        let patch = r#"
+foo_key = "A2"
+foo_key_new = "A3"
+foo_parent_key = { foo_sub_key = "B2", foo_sub_key2 = "B3" }
+foo_parent_key_new = { foo_sub_key = "B4", foo_sub_key2 = "B5" }
+
+[bar_table]
+bar_table_key = "C2"
+bar_table_key_new = "C3"
+bar_table_parent_key = { bar_table_sub_key = "D2", bar_table_sub_key2 = "D3" }
+bar_table_parent_key_new = { bar_table_sub_key = "D4", bar_table_sub_key2 = "D5" }
+
+[[baz_table_array]]
+baz_table_array_key = "G"
+baz_table_array_parent_key = { baz_table_sub_key = "H" }
+"#;
+        let patch: toml::Value = toml::from_str(patch).unwrap();
+
+        super::merge_toml(&mut base, patch);
+
+        let expected = r#"
+foo_key = "A2"
+foo_key_new = "A3"
+foo_parent_key = { foo_sub_key = "B2", foo_sub_key2 = "B3" }
+foo_parent_key_new = { foo_sub_key = "B4", foo_sub_key2 = "B5" }
+
+[bar_table]
+bar_table_key = "C2"
+bar_table_key_new = "C3"
+bar_table_parent_key = { bar_table_sub_key = "D2", bar_table_sub_key2 = "D3" }
+bar_table_parent_key_new = { bar_table_sub_key = "D4", bar_table_sub_key2 = "D5" }
+
+[[baz_table_array]]
+baz_table_array_key = "E"
+baz_table_array_parent_key = { baz_table_sub_key = "F" }
+
+[[baz_table_array]]
+baz_table_array_key = "G"
+baz_table_array_parent_key = { baz_table_sub_key = "H" }
+"#;
+        let expected: toml::Value = toml::from_str(expected).unwrap();
+        assert_eq!(expected, base);
+    }
+}

--- a/aziotd/src/error.rs
+++ b/aziotd/src/error.rs
@@ -6,7 +6,7 @@ pub(crate) struct Error(pub(crate) ErrorKind, pub(crate) backtrace::Backtrace);
 #[derive(Debug)]
 pub(crate) enum ErrorKind {
     GetProcessName(std::borrow::Cow<'static, str>),
-    ReadConfig(Option<std::path::PathBuf>, Box<dyn std::error::Error>),
+    ReadConfig(config_common::error::Error),
     Service(Box<dyn std::error::Error>),
 }
 
@@ -14,10 +14,7 @@ impl std::fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ErrorKind::GetProcessName(message) => write!(f, "could not read argv[0]: {}", message),
-            ErrorKind::ReadConfig(Some(path), _) => {
-                write!(f, "could not read config from {}", path.display())
-            }
-            ErrorKind::ReadConfig(None, _) => f.write_str("could not read config"),
+            ErrorKind::ReadConfig(_) => f.write_str("could not read config"),
             ErrorKind::Service(_) => f.write_str("service encountered an error"),
         }
     }
@@ -28,7 +25,7 @@ impl std::error::Error for ErrorKind {
         #[allow(clippy::match_same_arms)]
         match self {
             ErrorKind::GetProcessName(_) => None,
-            ErrorKind::ReadConfig(_, err) => Some(&**err),
+            ErrorKind::ReadConfig(_) => None,
             ErrorKind::Service(err) => Some(&**err),
         }
     }

--- a/aziotd/src/error.rs
+++ b/aziotd/src/error.rs
@@ -6,7 +6,7 @@ pub(crate) struct Error(pub(crate) ErrorKind, pub(crate) backtrace::Backtrace);
 #[derive(Debug)]
 pub(crate) enum ErrorKind {
     GetProcessName(std::borrow::Cow<'static, str>),
-    ReadConfig(config_common::error::Error),
+    ReadConfig(Box<dyn std::error::Error>),
     Service(Box<dyn std::error::Error>),
 }
 
@@ -25,7 +25,7 @@ impl std::error::Error for ErrorKind {
         #[allow(clippy::match_same_arms)]
         match self {
             ErrorKind::GetProcessName(_) => None,
-            ErrorKind::ReadConfig(_) => None,
+            ErrorKind::ReadConfig(err) => Some(&**err),
             ErrorKind::Service(err) => Some(&**err),
         }
     }

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -173,9 +173,13 @@ where
     let config_directory_path: std::path::PathBuf = std::env::var_os(config_directory_env_var)
         .map_or_else(|| config_directory_default.into(), Into::into);
 
-    let config: TConfig = config_common::read_config(config_path.clone(), config_directory_path.clone()).map_err(|err| ErrorKind::ReadConfig(err))?;
+    let config: TConfig =
+        config_common::read_config(config_path.clone(), config_directory_path.clone())
+            .map_err(ErrorKind::ReadConfig)?;
 
-    let (connector, server) = main(config, config_path, config_directory_path).await.map_err(ErrorKind::Service)?;
+    let (connector, server) = main(config, config_path, config_directory_path)
+        .await
+        .map_err(ErrorKind::Service)?;
 
     log::info!("Starting server...");
 

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -139,6 +139,19 @@ where
     }
 }
 
+/// Executes the main function of the running service.
+///
+/// The `main` function accepts 3 arguments:
+/// * TOML Configuration file for the running service that is created by reading 
+///   the base configuration TOML file and configuration override directory path that 
+///   contains patch TOML files (that should be merged with the base 
+///   configuration file).
+/// * Path to the base configuration file for the running service, if needed for 
+///   detecting configuration changes at run time.
+/// * Path to the configuration override directory for the running service, if needed for 
+///   detecting configuration changes at run time.
+///
+/// ```
 async fn run<TMain, TConfig, TFuture, TServer>(
     main: TMain,
     config_env_var: &str,

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -9,6 +9,7 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::default_trait_access, clippy::let_unit_value)]
 
+mod config;
 mod error;
 mod logging;
 
@@ -170,57 +171,10 @@ where
     let config_path: std::path::PathBuf =
         std::env::var_os(config_env_var).map_or_else(|| config_file_default.into(), Into::into);
 
-    let config = std::fs::read(&config_path)
-        .map_err(|err| ErrorKind::ReadConfig(Some(config_path.clone()), Box::new(err)))?;
-    let mut config: toml::Value = toml::from_slice(&config)
-        .map_err(|err| ErrorKind::ReadConfig(Some(config_path), Box::new(err)))?;
-
     let config_directory_path: std::path::PathBuf = std::env::var_os(config_directory_env_var)
         .map_or_else(|| config_directory_default.into(), Into::into);
 
-    match std::fs::read_dir(&config_directory_path) {
-        Ok(entries) => {
-            let mut patch_paths = vec![];
-            for entry in entries {
-                let entry = entry.map_err(|err| {
-                    ErrorKind::ReadConfig(Some(config_directory_path.clone()), Box::new(err))
-                })?;
-
-                let entry_file_type = entry.file_type().map_err(|err| {
-                    ErrorKind::ReadConfig(Some(config_directory_path.clone()), Box::new(err))
-                })?;
-                if !entry_file_type.is_file() {
-                    continue;
-                }
-
-                let patch_path = entry.path();
-                if patch_path.extension().and_then(std::ffi::OsStr::to_str) != Some("toml") {
-                    continue;
-                }
-
-                patch_paths.push(patch_path);
-            }
-            patch_paths.sort();
-
-            for patch_path in patch_paths {
-                let patch = std::fs::read(&patch_path).map_err(|err| {
-                    ErrorKind::ReadConfig(Some(patch_path.clone()), Box::new(err))
-                })?;
-                let patch: toml::Value = toml::from_slice(&patch)
-                    .map_err(|err| ErrorKind::ReadConfig(Some(patch_path), Box::new(err)))?;
-                merge_toml(&mut config, patch);
-            }
-        }
-
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => (),
-
-        Err(err) => {
-            return Err(ErrorKind::ReadConfig(Some(config_directory_path), Box::new(err)).into())
-        }
-    }
-
-    let config: TConfig = serde::Deserialize::deserialize(config)
-        .map_err(|err| ErrorKind::ReadConfig(None, Box::new(err)))?;
+    let config: TConfig = crate::config::read_config(config_path, config_directory_path)?;
 
     let (connector, server) = main(config).await.map_err(ErrorKind::Service)?;
 
@@ -237,35 +191,6 @@ where
 
     log::info!("Stopped server.");
     Ok(())
-}
-
-fn merge_toml(base: &mut toml::Value, patch: toml::Value) {
-    // Similar to JSON patch, except that:
-    //
-    // - Maps are called tables.
-    // - There is no equivalent of null that can be used to remove keys from an object.
-    // - Arrays are merged via concatenating the patch to the base, rather than replacing the base with the patch.
-
-    if let toml::Value::Table(base) = base {
-        if let toml::Value::Table(patch) = patch {
-            for (key, value) in patch {
-                // Insert a dummy `false` if the original key didn't exist at all. It'll be overwritten by `value` in that case.
-                let original_value = base.entry(key).or_insert(toml::Value::Boolean(false));
-                merge_toml(original_value, value);
-            }
-
-            return;
-        }
-    }
-
-    if let toml::Value::Array(base) = base {
-        if let toml::Value::Array(patch) = patch {
-            base.extend(patch);
-            return;
-        }
-    }
-
-    *base = patch;
 }
 
 #[cfg(test)]
@@ -346,65 +271,5 @@ mod tests {
             let mut input = input.iter().copied().map(std::ffi::OsStr::new);
             let _ = super::process_name_from_args(&mut input).unwrap_err();
         }
-    }
-
-    #[test]
-    fn merge_toml() {
-        let base = r#"
-foo_key = "A"
-foo_parent_key = { foo_sub_key = "B" }
-
-[bar_table]
-bar_table_key = "C"
-bar_table_parent_key = { bar_table_sub_key = "D" }
-
-[[baz_table_array]]
-baz_table_array_key = "E"
-baz_table_array_parent_key = { baz_table_sub_key = "F" }
-"#;
-        let mut base: toml::Value = toml::from_str(base).unwrap();
-
-        let patch = r#"
-foo_key = "A2"
-foo_key_new = "A3"
-foo_parent_key = { foo_sub_key = "B2", foo_sub_key2 = "B3" }
-foo_parent_key_new = { foo_sub_key = "B4", foo_sub_key2 = "B5" }
-
-[bar_table]
-bar_table_key = "C2"
-bar_table_key_new = "C3"
-bar_table_parent_key = { bar_table_sub_key = "D2", bar_table_sub_key2 = "D3" }
-bar_table_parent_key_new = { bar_table_sub_key = "D4", bar_table_sub_key2 = "D5" }
-
-[[baz_table_array]]
-baz_table_array_key = "G"
-baz_table_array_parent_key = { baz_table_sub_key = "H" }
-"#;
-        let patch: toml::Value = toml::from_str(patch).unwrap();
-
-        super::merge_toml(&mut base, patch);
-
-        let expected = r#"
-foo_key = "A2"
-foo_key_new = "A3"
-foo_parent_key = { foo_sub_key = "B2", foo_sub_key2 = "B3" }
-foo_parent_key_new = { foo_sub_key = "B4", foo_sub_key2 = "B5" }
-
-[bar_table]
-bar_table_key = "C2"
-bar_table_key_new = "C3"
-bar_table_parent_key = { bar_table_sub_key = "D2", bar_table_sub_key2 = "D3" }
-bar_table_parent_key_new = { bar_table_sub_key = "D4", bar_table_sub_key2 = "D5" }
-
-[[baz_table_array]]
-baz_table_array_key = "E"
-baz_table_array_parent_key = { baz_table_sub_key = "F" }
-
-[[baz_table_array]]
-baz_table_array_key = "G"
-baz_table_array_parent_key = { baz_table_sub_key = "H" }
-"#;
-        let expected: toml::Value = toml::from_str(expected).unwrap();
-        assert_eq!(expected, base);
     }
 }

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -191,7 +191,7 @@ where
         .map_or_else(|| config_directory_default.into(), Into::into);
 
     let config: TConfig = config_common::read_config(&config_path, &config_directory_path)
-        .map_err(ErrorKind::ReadConfig)?;
+        .map_err(|err| ErrorKind::ReadConfig(Box::new(err)))?;
 
     let (connector, server) = main(config, config_path, config_directory_path)
         .await

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -25,6 +25,8 @@ use aziot_certd_config::{
 
 pub async fn main(
     config: Config,
+    _: std::path::PathBuf,
+    _: std::path::PathBuf,
 ) -> Result<(http_common::Connector, http::Service), Box<dyn std::error::Error>> {
     let Config {
         homedir_path,

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -371,7 +371,7 @@ hostname = "$common_resource_name"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-dynamic_reprovisioning = true
+always_reprovisioning_on_startup = true
 source = "manual"
 iothub_hostname = "$common_resource_name.azure-devices.net"
 device_id = "$iot_device_id"

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -371,7 +371,7 @@ hostname = "$common_resource_name"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = true
+always_reprovision_on_startup = true
 source = "manual"
 iothub_hostname = "$common_resource_name.azure-devices.net"
 device_id = "$iot_device_id"

--- a/config-common/Cargo.toml
+++ b/config-common/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "config-common"
+version = "0.1.0"
+authors = ["Rajeev Massand <massand@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+backtrace = "0.3"
+serde = "1"
+toml = "0.5"

--- a/config-common/Cargo.toml
+++ b/config-common/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "config-common"
 version = "0.1.0"
-authors = ["Rajeev Massand <massand@gmail.com>"]
+authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 backtrace = "0.3"

--- a/config-common/src/error.rs
+++ b/config-common/src/error.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#[derive(Debug)]
+pub struct Error(pub(crate) ErrorKind, pub(crate) backtrace::Backtrace);
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    ReadConfig(Option<std::path::PathBuf>, Box<dyn std::error::Error>),
+}
+
+impl std::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ErrorKind::ReadConfig(Some(path), _) => {
+                write!(f, "could not read config from {}", path.display())
+            }
+            ErrorKind::ReadConfig(None, _) => f.write_str("could not read config"),
+        }
+    }
+}
+
+impl std::error::Error for ErrorKind {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        #[allow(clippy::match_same_arms)]
+        match self {
+            ErrorKind::ReadConfig(_, err) => Some(&**err),
+        }
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(err: ErrorKind) -> Self {
+        Error(err, Default::default())
+    }
+}

--- a/config-common/src/error.rs
+++ b/config-common/src/error.rs
@@ -3,6 +3,18 @@
 #[derive(Debug)]
 pub struct Error(pub(crate) ErrorKind, pub(crate) backtrace::Backtrace);
 
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("configuration read encountered an error")
+    }
+}
+
 #[derive(Debug)]
 pub enum ErrorKind {
     ReadConfig(Option<std::path::PathBuf>, Box<dyn std::error::Error>),

--- a/config-common/src/lib.rs
+++ b/config-common/src/lib.rs
@@ -1,5 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::default_trait_access,
+    clippy::missing_errors_doc,
+    clippy::module_name_repetitions
+)]
+
 pub mod error;
 
 use crate::error::{Error, ErrorKind};

--- a/config-common/src/lib.rs
+++ b/config-common/src/lib.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+pub mod error;
+
 use crate::error::{Error, ErrorKind};
 
-pub(crate) fn read_config<TConfig>(
+pub fn read_config<TConfig>(
     config_path: std::path::PathBuf,
     config_directory_path: std::path::PathBuf,
 ) -> Result<TConfig, Error>

--- a/contrib/third-party-notices.sh
+++ b/contrib/third-party-notices.sh
@@ -149,6 +149,10 @@ cargo metadata --format-version 1 |
                     "Zlib"
                 elif $license == "MPL-2.0" then
                     "MPL-2.0"
+                elif $license == "ISC" then
+                    "ISC"
+                elif $license == "CC0-1.0" then
+                    "CC0-1.0"
                 else
                     error("crate \($name) has unknown license \($license)")
                 end
@@ -185,6 +189,14 @@ cargo metadata --format-version 1 |
                 license_file_suffix='MPL2'
                 ;;
 
+            'ISC')
+                license_file_suffix='ISC'
+                ;;
+
+            'CC0-1.0')
+                license_file_suffix='CC0'
+                ;;
+
             *)
                 echo "$name:$version at $manifest_path has unsupported license $license" >&2
                 exit 1
@@ -196,6 +208,30 @@ cargo metadata --format-version 1 |
             # https://github.com/tokio-rs/tracing/commit/0de7d516896ce52726fe58591797e0e8f6bfa5da
             # Remove this when new version with this commit is released.
             curl -Lo "$crate_directory/LICENSE" 'https://github.com/tokio-rs/tracing/raw/fe570afaffdeeac3d7023b24e3aa05935ec55d14/tracing-futures/LICENSE'
+        fi
+        
+        if [ "$name:$version" == 'inotify:0.7.1' ]; then
+            # TODO: Crate doesn't ship with LICENSE file but it's ISC. Fixed by upstream in
+            # https://github.com/hannobraun/inotify/commit/52c18c527fe227b329f8428d73a1c732f2d56ce5
+            # but that requires inotify v0.8 and notify v4 uses inotify v0.7.
+            # notify v5.0 will depend on inotify v0.8, so remove this when that happens.
+            curl -Lo "$crate_directory/LICENSE" 'https://github.com/hannobraun/inotify/raw/52c18c527fe227b329f8428d73a1c732f2d56ce5/LICENSE'
+        fi
+
+        if [ "$name:$version" == 'inotify-sys:0.1.4' ]; then
+            # TODO: Crate doesn't ship with LICENSE file but it's ISC. Will be fixed by this PR (when merged) -
+            # https://github.com/hannobraun/inotify-sys/pull/21 
+            # notify will need to depend on newer version of inotify (> 0.8) that depends 
+            # on newer version of inotify-sys (> 0.1.4), so remove this when that happens.
+            # The ISC license content is identical in both inotify and inotify-sys repos. 
+            curl -Lo "$crate_directory/LICENSE" 'https://github.com/hannobraun/inotify/raw/52c18c527fe227b329f8428d73a1c732f2d56ce5/LICENSE'
+        fi
+
+        if [ "$name:$version" == 'notify:4.0.15' ]; then
+            # TODO: Crate doesn't ship with LICENSE file but it's CC0-1.0. Fixed by upstream in
+            # https://github.com/notify-rs/notify/commit/e0982ffc760bc0e34544d2a7c9d10cdba65183d9
+            # but that requires notify v5.0, so remove this when that happens.
+            curl -Lo "$crate_directory/LICENSE" 'https://github.com/notify-rs/notify/raw/e0982ffc760bc0e34544d2a7c9d10cdba65183d9/LICENSE'
         fi
 
         license_file="$(find "$crate_directory" -maxdepth 1 -type f -regextype posix-egrep -regex ".*/LICEN[CS]E-$license_file_suffix(\\.(md|txt))?" | head -n1)"

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -417,6 +417,7 @@ impl tokio::io::AsyncWrite for AsyncStream {
 
 #[cfg(feature = "tokio1")]
 impl hyper::client::connect::Connection for AsyncStream {
+    #[allow(clippy::match_same_arms)]
     fn connected(&self) -> hyper::client::connect::Connected {
         match self {
             AsyncStream::Tcp(inner) => inner.connected(),

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -417,7 +417,6 @@ impl tokio::io::AsyncWrite for AsyncStream {
 
 #[cfg(feature = "tokio1")]
 impl hyper::client::connect::Connection for AsyncStream {
-    #[allow(clippy::match_same_arms)]
     fn connected(&self) -> hyper::client::connect::Connected {
         match self {
             AsyncStream::Tcp(inner) => inner.connected(),

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -50,7 +50,7 @@ impl Incoming {
 
                 // TCP is available in test builds only (not production). Assume current user is root.
                 let server = crate::uid::UidService::new(0, server.clone());
-                tokio::task::spawn(async move {
+                tokio::spawn(async move {
                     if let Err(http_err) = hyper::server::conn::Http::new()
                         .serve_connection(tcp_stream, server)
                         .await
@@ -65,7 +65,7 @@ impl Incoming {
                 let ucred = unix_stream.peer_cred()?;
 
                 let server = crate::uid::UidService::new(ucred.uid(), server.clone());
-                tokio::task::spawn(async move {
+                tokio::spawn(async move {
                     if let Err(http_err) = hyper::server::conn::Http::new()
                         .serve_connection(unix_stream, server)
                         .await

--- a/identity/aziot-identity-common/src/lib.rs
+++ b/identity/aziot-identity-common/src/lib.rs
@@ -40,7 +40,7 @@ pub struct LocalIdSpec {
 }
 
 /// Options for a single local identity.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize)]
 #[serde(tag = "type")]
 pub enum LocalIdOpts {
     /// Options valid when local identities are X.509 credentials. Currently the only

--- a/identity/aziot-identity-common/src/lib.rs
+++ b/identity/aziot-identity-common/src/lib.rs
@@ -92,7 +92,7 @@ impl std::fmt::Display for AuthenticationType {
 
 pub struct Uid(u32);
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum IdType {
     Device,
@@ -101,7 +101,7 @@ pub enum IdType {
 }
 
 /// X.509 extensions given to local identity certificates.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LocalIdAttr {
     /// TLS client certificate.

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -87,17 +87,17 @@ pub enum DpsAttestationMethod {
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub struct Provisioning {
-    // This type used to have the `provisioning` field before the `dynamic_reprovisioning` field. It doesn't matter much except that the fields are
+    // This type used to have the `provisioning` field before the `always_reprovisioning_on_startup` field. It doesn't matter much except that the fields are
     // serialized in the order of definition when generating a new config via `aziot init`, and it would've been nice to serialize
-    // the `provisioning` value before the `dynamic_reprovisioning` value.
+    // the `provisioning` value before the `always_reprovisioning_on_startup` value.
     //
-    // Unfortunately the TOML serializer needs "values" (like `dynamic_reprovisioning`) to come before "tables" (like `provisioning`),
+    // Unfortunately the TOML serializer needs "values" (like `always_reprovisioning_on_startup`) to come before "tables" (like `provisioning`),
     // otherwise it fails to serialize the value. It ought to not matter for this type because the `provisioning` value is flattened,
     // but the TOML serializer doesn't know this.
     //
-    // So we have to move the `dynamic_reprovisioning` field before the `provisioning` field.
+    // So we have to move the `always_reprovisioning_on_startup` field before the `provisioning` field.
     #[serde(default)]
-    pub dynamic_reprovisioning: bool,
+    pub always_reprovisioning_on_startup: bool,
 
     #[serde(flatten)]
     pub provisioning: ProvisioningType,
@@ -165,7 +165,7 @@ mod tests {
     fn manual_sas_provisioning_settings_succeeds() {
         let s = load_settings("test/good_sas_config.toml").unwrap();
 
-        assert_eq!(s.provisioning.dynamic_reprovisioning, false);
+        assert_eq!(s.provisioning.always_reprovisioning_on_startup, false);
 
         if !matches!(
             s.provisioning.provisioning,

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -25,7 +25,7 @@ pub struct Settings {
     pub localid: Option<LocalId>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub struct Principal {
     pub uid: Credentials,

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -87,17 +87,17 @@ pub enum DpsAttestationMethod {
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub struct Provisioning {
-    // This type used to have the `provisioning` field before the `always_reprovisioning_on_startup` field. It doesn't matter much except that the fields are
+    // This type used to have the `provisioning` field before the `always_reprovision_on_startup` field. It doesn't matter much except that the fields are
     // serialized in the order of definition when generating a new config via `aziot init`, and it would've been nice to serialize
-    // the `provisioning` value before the `always_reprovisioning_on_startup` value.
+    // the `provisioning` value before the `always_reprovision_on_startup` value.
     //
-    // Unfortunately the TOML serializer needs "values" (like `always_reprovisioning_on_startup`) to come before "tables" (like `provisioning`),
+    // Unfortunately the TOML serializer needs "values" (like `always_reprovision_on_startup`) to come before "tables" (like `provisioning`),
     // otherwise it fails to serialize the value. It ought to not matter for this type because the `provisioning` value is flattened,
     // but the TOML serializer doesn't know this.
     //
-    // So we have to move the `always_reprovisioning_on_startup` field before the `provisioning` field.
+    // So we have to move the `always_reprovision_on_startup` field before the `provisioning` field.
     #[serde(default)]
-    pub always_reprovisioning_on_startup: bool,
+    pub always_reprovision_on_startup: bool,
 
     #[serde(flatten)]
     pub provisioning: ProvisioningType,
@@ -165,7 +165,7 @@ mod tests {
     fn manual_sas_provisioning_settings_succeeds() {
         let s = load_settings("test/good_sas_config.toml").unwrap();
 
-        assert_eq!(s.provisioning.always_reprovisioning_on_startup, false);
+        assert_eq!(s.provisioning.always_reprovision_on_startup, false);
 
         if !matches!(
             s.provisioning.provisioning,

--- a/identity/aziot-identityd-config/test/good_sas_config.toml
+++ b/identity/aziot-identityd-config/test/good_sas_config.toml
@@ -5,6 +5,7 @@ hostname = "iotedge"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
+always_reprovisioning_on_startup = false
 source = "manual"
 iothub_hostname = "hubname"
 device_id = "deviceid"
@@ -12,4 +13,3 @@ device_id = "deviceid"
 [provisioning.authentication]
 method = "sas"
 device_id_pk = "sas"
-dynamic_reprovisioning = false

--- a/identity/aziot-identityd-config/test/good_sas_config.toml
+++ b/identity/aziot-identityd-config/test/good_sas_config.toml
@@ -5,7 +5,7 @@ hostname = "iotedge"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovisioning_on_startup = false
+always_reprovision_on_startup = false
 source = "manual"
 iothub_hostname = "hubname"
 device_id = "deviceid"

--- a/identity/aziot-identityd/Cargo.toml
+++ b/identity/aziot-identityd/Cargo.toml
@@ -15,7 +15,6 @@ chrono = "0.4"
 futures-util = "0.3"
 http = "0.2"
 hyper = "0.14"
-futures = "0.3"
 lazy_static = "1"
 libc = "0.2"
 log = "0.4"
@@ -26,7 +25,7 @@ regex = "1"
 serde = "1"
 serde_json = "1.0"
 toml = "0.5"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["rt"] }
 url = "2"
 
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }

--- a/identity/aziot-identityd/Cargo.toml
+++ b/identity/aziot-identityd/Cargo.toml
@@ -24,6 +24,7 @@ regex = "1"
 serde = "1"
 serde_json = "1.0"
 toml = "0.5"
+tokio = { version = "1", features = ["macros", "rt"] }
 url = "2"
 
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }
@@ -45,4 +46,3 @@ openssl2 = { path = "../../openssl2" }
 
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt"] }

--- a/identity/aziot-identityd/Cargo.toml
+++ b/identity/aziot-identityd/Cargo.toml
@@ -15,9 +15,11 @@ chrono = "0.4"
 futures-util = "0.3"
 http = "0.2"
 hyper = "0.14"
+futures = "0.3"
 lazy_static = "1"
 libc = "0.2"
 log = "0.4"
+notify = "4"
 openssl = "0.10"
 percent-encoding = "2"
 regex = "1"
@@ -41,6 +43,7 @@ aziot-key-common-http = { path = "../../key/aziot-key-common-http" }
 aziot-key-openssl-engine = { path = "../../key/aziot-key-openssl-engine" }
 aziot-tpm-client-async = { path = "../../tpm/aziot-tpm-client-async" }
 aziot-tpm-common-http = { path = "../../tpm/aziot-tpm-common-http" }
+config-common = { path = "../../config-common" }
 http-common = { path = "../../http-common", features = ["tokio1"] }
 openssl2 = { path = "../../openssl2" }
 

--- a/identity/aziot-identityd/config/unix/default.toml
+++ b/identity/aziot-identityd/config/unix/default.toml
@@ -22,6 +22,7 @@ homedir = "/var/lib/aziot/identityd"
 
 
 # [provisioning]
+# always_reprovisioning_on_startup = false
 # source = "manual"
 # iothub_hostname = "hubname"
 # device_id = "deviceid"
@@ -29,7 +30,6 @@ homedir = "/var/lib/aziot/identityd"
 # [provisioning.authentication]
 # method = "sas"
 # device_id_pk = "device-id"
-# dynamic_reprovisioning = false
 
 # [provisioning.authentication]
 # method = "x509"
@@ -37,7 +37,6 @@ homedir = "/var/lib/aziot/identityd"
 # device_id = "deviceid"
 # device_id_cert = "device-id"
 # device_id_pk = "device-id"
-# dynamic_reprovisioning = false
 
 # [provisioning]
 # "source" = "dps"

--- a/identity/aziot-identityd/config/unix/default.toml
+++ b/identity/aziot-identityd/config/unix/default.toml
@@ -22,7 +22,7 @@ homedir = "/var/lib/aziot/identityd"
 
 
 # [provisioning]
-# always_reprovisioning_on_startup = false
+# always_reprovision_on_startup = false
 # source = "manual"
 # iothub_hostname = "hubname"
 # device_id = "deviceid"

--- a/identity/aziot-identityd/src/auth/authentication.rs
+++ b/identity/aziot-identityd/src/auth/authentication.rs
@@ -59,13 +59,13 @@ mod tests {
 
     #[test]
     fn authenticator_wrapper_around_function() {
-        let authenticator = |_| Ok(AuthId::LocalPrincipal(Uid(1001)));
-        let credentials = Uid(1001);
+        let authenticator = |_| Ok(AuthId::LocalRoot);
+        let credentials = Uid(0);
 
         let auth_id = authenticator.authenticate(credentials);
 
         match auth_id {
-            Ok(AuthId::LocalPrincipal(Uid(1001))) => (),
+            Ok(AuthId::LocalRoot) => (),
             _ => panic!("incorrect auth id selected"),
         }
     }

--- a/identity/aziot-identityd/src/auth/authorization.rs
+++ b/identity/aziot-identityd/src/auth/authorization.rs
@@ -31,7 +31,7 @@ impl Authorizer for DefaultAuthorizer {
     type Error = Error;
 
     fn authorize(&self, _: Operation) -> Result<bool, Self::Error> {
-        Ok(true)
+        Ok(false)
     }
 }
 

--- a/identity/aziot-identityd/src/auth/authorization.rs
+++ b/identity/aziot-identityd/src/auth/authorization.rs
@@ -23,8 +23,7 @@ where
     }
 }
 
-// Default implementation that accepts any operation for all authenticated users.
-// TODO: Remove this implementation once Unix Domain Sockets is ported over.
+// Default implementation that rejects any operation by default.
 pub struct DefaultAuthorizer;
 
 impl Authorizer for DefaultAuthorizer {

--- a/identity/aziot-identityd/src/auth/mod.rs
+++ b/identity/aziot-identityd/src/auth/mod.rs
@@ -10,12 +10,15 @@ pub mod authorization;
 pub enum AuthId {
     Unknown,
 
-    LocalPrincipal(aziot_identityd_config::Credentials),
+    HostProcess(aziot_identityd_config::Principal),
+
+    Daemon,
 
     LocalRoot,
 }
 
 /// Operation types to be authorized
+#[derive(Clone, PartialOrd, PartialEq)]
 pub enum OperationType {
     GetModule(String),
     GetAllHubModules,

--- a/identity/aziot-identityd/src/configext.rs
+++ b/identity/aziot-identityd/src/configext.rs
@@ -14,26 +14,46 @@ pub fn load_file(filename: &Path) -> Result<config::Settings, InternalError> {
     settings.check().map_err(InternalError::BadSettings)
 }
 
-#[derive(Debug, Eq, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize)]
-pub struct HubDeviceInfo {
-    pub hub_name: String,
+pub fn prepare_authorized_principals(
+    principal: &[config::Principal],
+) -> (
+    std::collections::BTreeMap<config::Uid, config::Principal>,
+    std::collections::BTreeSet<aziot_identity_common::ModuleId>,
+    std::collections::BTreeMap<
+        aziot_identity_common::ModuleId,
+        Option<aziot_identity_common::LocalIdOpts>,
+    >,
+) {
+    let mut local_module_map: std::collections::BTreeMap<
+        aziot_identity_common::ModuleId,
+        Option<aziot_identity_common::LocalIdOpts>,
+    > = std::collections::BTreeMap::new();
+    let mut hub_module_set: std::collections::BTreeSet<aziot_identity_common::ModuleId> =
+        std::collections::BTreeSet::new();
+    let mut principal_map: std::collections::BTreeMap<config::Uid, config::Principal> =
+        std::collections::BTreeMap::new();
+    let mut found_daemon = false;
 
-    pub device_id: String,
-}
+    for p in principal {
+        if let Some(id_type) = &p.id_type {
+            for i in id_type {
+                match i {
+                    aziot_identity_common::IdType::Module => hub_module_set.insert(p.name.clone()),
+                    aziot_identity_common::IdType::Local => local_module_map
+                        .insert(p.name.clone(), p.localid.clone())
+                        .is_some(),
+                    _ => true,
+                };
+            }
+        } else if found_daemon {
+            log::warn!("Principal {:?} is not authorized. Please ensure there is only one principal without a type in the config.toml", p.name);
+            continue;
+        } else {
+            found_daemon = true
+        }
 
-impl HubDeviceInfo {
-    pub fn new(filename: &Path) -> Result<Option<Self>, InternalError> {
-        let info = std::fs::read_to_string(filename).map_err(InternalError::LoadDeviceInfo)?;
-
-        let info = match info.as_str() {
-            "unprovisioned" => None,
-            _ => Some(toml::from_str(&info).map_err(InternalError::ParseDeviceInfo)?),
-        };
-
-        Ok(info)
+        principal_map.insert(p.uid, p.clone());
     }
 
-    pub fn unprovisioned() -> String {
-        "unprovisioned".to_owned()
-    }
+    (principal_map, hub_module_set, local_module_map)
 }

--- a/identity/aziot-identityd/src/configext.rs
+++ b/identity/aziot-identityd/src/configext.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use aziot_identityd_config as config;
@@ -17,21 +18,16 @@ pub fn load_file(filename: &Path) -> Result<config::Settings, InternalError> {
 pub fn prepare_authorized_principals(
     principal: &[config::Principal],
 ) -> (
-    std::collections::BTreeMap<config::Uid, config::Principal>,
-    std::collections::BTreeSet<aziot_identity_common::ModuleId>,
-    std::collections::BTreeMap<
-        aziot_identity_common::ModuleId,
-        Option<aziot_identity_common::LocalIdOpts>,
-    >,
+    BTreeMap<config::Uid, config::Principal>,
+    BTreeSet<aziot_identity_common::ModuleId>,
+    BTreeMap<aziot_identity_common::ModuleId, Option<aziot_identity_common::LocalIdOpts>>,
 ) {
-    let mut local_module_map: std::collections::BTreeMap<
+    let mut local_module_map: BTreeMap<
         aziot_identity_common::ModuleId,
         Option<aziot_identity_common::LocalIdOpts>,
-    > = std::collections::BTreeMap::new();
-    let mut hub_module_set: std::collections::BTreeSet<aziot_identity_common::ModuleId> =
-        std::collections::BTreeSet::new();
-    let mut principal_map: std::collections::BTreeMap<config::Uid, config::Principal> =
-        std::collections::BTreeMap::new();
+    > = BTreeMap::new();
+    let mut hub_module_set: BTreeSet<aziot_identity_common::ModuleId> = BTreeSet::new();
+    let mut principal_map: BTreeMap<config::Uid, config::Principal> = BTreeMap::new();
     let mut found_daemon = false;
 
     for p in principal {

--- a/identity/aziot-identityd/src/error.rs
+++ b/identity/aziot-identityd/src/error.rs
@@ -68,6 +68,7 @@ pub enum InternalError {
     ParseDeviceInfo(toml::de::Error),
     ParseSettings(toml::de::Error),
     SaveDeviceInfo(std::io::Error),
+    SerializeDeviceInfo(toml::ser::Error),
     SaveSettings(std::io::Error),
 }
 
@@ -93,6 +94,9 @@ impl std::fmt::Display for InternalError {
             InternalError::SaveDeviceInfo(_) => {
                 f.write_str("could not save device information state")
             }
+            InternalError::SerializeDeviceInfo(_) => {
+                f.write_str("could not serialize device information state")
+            }
             InternalError::SaveSettings(_) => f.write_str("could not save settings"),
         }
     }
@@ -114,6 +118,7 @@ impl std::error::Error for InternalError {
             InternalError::ParseSettings(err) => Some(err),
             InternalError::SaveDeviceInfo(err) => Some(err),
             InternalError::SaveSettings(err) => Some(err),
+            InternalError::SerializeDeviceInfo(err) => Some(err),
         }
     }
 }

--- a/identity/aziot-identityd/src/http/reprovision_device.rs
+++ b/identity/aziot-identityd/src/http/reprovision_device.rs
@@ -50,7 +50,10 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
 
-        match api.reprovision_device(auth_id).await {
+        match api
+            .reprovision_device(auth_id, crate::ReprovisionTrigger::Api)
+            .await
+        {
             Ok(()) => (),
             Err(err) => return Err(super::to_http_error(&err)),
         };

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -689,7 +689,9 @@ impl IdentityManager {
     }
 
     pub async fn reconcile_hub_identities(&self, settings: config::Settings) -> Result<(), Error> {
-        let settings = settings.check().map_err(|err|Error::Internal(InternalError::BadSettings(err)))?;
+        let settings = settings
+            .check()
+            .map_err(|err| Error::Internal(InternalError::BadSettings(err)))?;
 
         let settings_serialized =
             toml::to_vec(&settings).expect("serializing settings cannot fail");

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -689,7 +689,8 @@ impl IdentityManager {
     }
 
     pub async fn reconcile_hub_identities(&self, settings: config::Settings) -> Result<(), Error> {
-        let settings = crate::configext::check(settings).map_err(Error::Internal)?;
+        let settings = settings.check().map_err(|err|Error::Internal(InternalError::BadSettings(err)))?;
+
         let settings_serialized =
             toml::to_vec(&settings).expect("serializing settings cannot fail");
 

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -417,7 +417,7 @@ impl IdentityManager {
 
     pub async fn provision_device(
         &mut self,
-        provisioning: aziot_identityd_config::Provisioning,
+        provisioning: config::Provisioning,
         skip_if_backup_is_valid: bool,
     ) -> Result<aziot_identity_common::ProvisioningStatus, Error> {
         let device = match provisioning.provisioning {
@@ -774,7 +774,7 @@ impl IdentityManager {
                 let () = std::fs::write(prev_settings_path, &settings_serialized)
                     .map_err(|err| Error::Internal(InternalError::SaveSettings(err)))?;
             }
-            None => log::warn!("reconcilation skipped since device is not provisioned"),
+            None => log::info!("reconcilation skipped since device is not provisioned"),
         }
 
         Ok(())

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -85,47 +85,40 @@ pub async fn main(
     });
 
     let api_watcher = api.clone();
-
     let (file_changed_tx, mut file_changed_rx) = tokio::sync::mpsc::channel(10);
-
     let config_directory_path_copy = config_directory_path.clone();
     
-    // Start file watcher
+    // Start file watcher using blocking channel
     std::thread::spawn(move || {
         
-        // Create a channel to receive the events.
         let (file_watcher_tx, file_watcher_rx) = std::sync::mpsc::channel();
 
-        // Create a watcher object, delivering debounced events.
-        // The notification back-end is selected based on the platform.
+        // Create a watcher object, delivering debounced events
         let mut file_watcher = notify::watcher(file_watcher_tx, std::time::Duration::from_secs(10)).unwrap();
 
-        // Add a path to be watched. All files and directories at that path and
-        // below will be monitored for changes.
+        // Add configuration path to be watched
         file_watcher.watch(config_directory_path_copy, notify::RecursiveMode::Recursive).unwrap();
 
         loop {
             let _ = file_watcher_rx.recv();
-            
             let _ = file_changed_tx.blocking_send(());
         }
     });
 
-    // Start file watcher
+    // Start file change listener that asynchronously updates Identity Service
     tokio::task::spawn(async move {
         loop {
             let event = file_changed_rx.recv().await;
             
             match event {
                 Some(_) => {
-                    config_common::read_config(config_path.clone(), config_directory_path.clone())
-                    .map(|new_settings: config::Settings| async {
-                        let mut api_ = api_watcher.lock().await;
-                        let _ = api_
-                            .update_settings(new_settings, ReprovisionTrigger::ConfigurationFileUpdate)
-                            .await;
-                        drop(api_);
-                    });
+                    let new_settings = config_common::read_config(config_path.clone(), config_directory_path.clone()).unwrap();
+                    
+                    let mut api_ = api_watcher.lock().await;
+                    let _ = api_
+                        .update_settings(new_settings, ReprovisionTrigger::ConfigurationFileUpdate)
+                        .await;
+                    drop(api_);
                 },
                 None => {},
             }

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -112,16 +112,14 @@ pub async fn main(
 
     // Start file change listener that asynchronously updates Identity Service
     tokio::task::spawn(async move {
-        loop {
-            while let Some(()) = file_changed_rx.recv().await {
-                let new_settings =
-                    config_common::read_config(&config_path, &config_directory_path).unwrap();
+        while let Some(()) = file_changed_rx.recv().await {
+            let new_settings =
+                config_common::read_config(&config_path, &config_directory_path).unwrap();
 
-                let mut api_ = api_watcher.lock().await;
-                let _ = api_
-                    .update_settings(new_settings, ReprovisionTrigger::ConfigurationFileUpdate)
-                    .await;
-            }
+            let mut api_ = api_watcher.lock().await;
+            let _ = api_
+                .update_settings(new_settings, ReprovisionTrigger::ConfigurationFileUpdate)
+                .await;
         }
     });
 

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -47,21 +47,19 @@ macro_rules! match_id_type {
     };
 }
 
+pub enum ReprovisionTrigger {
+    ConfigurationFileUpdate,
+    Api,
+    Startup,
+}
+
 pub async fn main(
     settings: config::Settings,
 ) -> Result<(http_common::Connector, http::Service), Box<dyn std::error::Error>> {
-    // Written to prev_settings_path if provisioning is successful.
     let settings = settings.check().map_err(InternalError::BadSettings)?;
-    let settings_serialized = toml::to_vec(&settings).expect("serializing settings cannot fail");
 
     let homedir_path = &settings.homedir;
     let connector = settings.endpoints.aziot_identityd.clone();
-
-    let mut prev_settings_path = homedir_path.clone();
-    prev_settings_path.push("prev_state");
-
-    let mut prev_device_info_path = homedir_path.clone();
-    prev_device_info_path.push("device_info");
 
     if !homedir_path.exists() {
         let () =
@@ -79,8 +77,8 @@ pub async fn main(
     //new approach: file notifier and reprovision API do 2 things - authenticator.update() and trigger provision_device (which calls reconcile)
     //todo: Encapsulate into triggered task - triggered by file notification or provision device
     //todo: run this on each file notifier, using snapshot (clone) of new settings.principal
-    let (allowed_users, hub_modules, local_modules) =
-        prepare_authorized_principals(&settings.principal);
+    let (allowed_users, _, local_modules) =
+        configext::prepare_authorized_principals(&settings.principal);
 
     //todo: wrap this up in update_authenticator
     // All uids in the principals are authenticated users to this service
@@ -102,54 +100,15 @@ pub async fn main(
 
     let api = Arc::new(futures_util::lock::Mutex::new(api));
 
-    // {
-    //     let mut api_ = api.lock().await;
+    {
+        let mut api_ = api.lock().await;
 
-    //     log::info!("Provisioning starting.");
-    //     let provisioning = api_.provision_device().await?;
-    //     log::info!("Provisioning complete.");
-
-    //     let device_status = if let aziot_identity_common::ProvisioningStatus::Provisioned(device) =
-    //         provisioning
-    //     {
-    //         let curr_hub_device_info = configext::HubDeviceInfo {
-    //             hub_name: device.iothub_hostname,
-    //             device_id: device.device_id,
-    //         };
-    //         let device_status = toml::to_string(&curr_hub_device_info)?;
-
-    //         // Only consider the previous Hub modules if the current and previous Hub devices match.
-    //         let prev_hub_modules = if prev_settings_path.exists() && prev_device_info_path.exists()
-    //         {
-    //             let prev_hub_device_info = configext::HubDeviceInfo::new(&prev_device_info_path)?;
-
-    //             if prev_hub_device_info == Some(curr_hub_device_info) {
-    //                 let prev_settings = configext::load_file(&prev_settings_path)?;
-    //                 let (_, prev_hub_modules, _) =
-    //                     prepare_authorized_principals(&prev_settings.principal);
-    //                 prev_hub_modules
-    //             } else {
-    //                 std::collections::BTreeSet::default()
-    //             }
-    //         } else {
-    //             std::collections::BTreeSet::default()
-    //         };
-
-    //         let () = api_
-    //             .init_hub_identities(prev_hub_modules, hub_modules)
-    //             .await?;
-    //         log::info!("Identity reconciliation with IoT Hub complete.");
-
-    //         device_status
-    //     } else {
-    //         configext::HubDeviceInfo::unprovisioned()
-    //     };
-
-    //     std::fs::write(prev_device_info_path, device_status)
-    //         .map_err(error::InternalError::SaveDeviceInfo)?;
-    //     let () = std::fs::write(prev_settings_path, &settings_serialized)
-    //         .map_err(error::InternalError::SaveSettings)?;
-    // }
+        log::info!("Provisioning starting.");
+        let _ = api_
+            .reprovision_device(auth::AuthId::LocalRoot, ReprovisionTrigger::Startup)
+            .await?;
+        log::info!("Provisioning complete.");
+    }
 
     let service = http::Service { api };
 
@@ -228,6 +187,7 @@ impl Api {
         };
 
         let id_manager = identity::IdentityManager::new(
+            settings.homedir.clone(),
             key_client.clone(),
             key_engine.clone(),
             cert_client.clone(),
@@ -431,7 +391,15 @@ impl Api {
         })
     }
 
-    pub async fn reprovision_device(&mut self, auth_id: auth::AuthId) -> Result<(), Error> {
+    // pub fn update_settings(&mut self, settings: config::Settings) -> Result<(), Error> {
+    //     Ok(())
+    // }
+
+    pub async fn reprovision_device(
+        &mut self,
+        auth_id: auth::AuthId,
+        operation: ReprovisionTrigger,
+    ) -> Result<(), Error> {
         if !self.authorizer.authorize(auth::Operation {
             auth_id,
             op_type: auth::OperationType::ReprovisionDevice,
@@ -439,7 +407,32 @@ impl Api {
             return Err(Error::Authorization);
         }
 
-        // let _ = self.provision_device().await?;
+        let _ = match operation {
+            ReprovisionTrigger::ConfigurationFileUpdate => {
+                self.id_manager
+                    .provision_device(self.settings.provisioning.clone(), true)
+                    .await?
+            }
+            ReprovisionTrigger::Api => {
+                self.id_manager
+                    .provision_device(self.settings.provisioning.clone(), false)
+                    .await?
+            }
+            ReprovisionTrigger::Startup => {
+                self.id_manager
+                    .provision_device(
+                        self.settings.provisioning.clone(),
+                        !self.settings.provisioning.always_reprovisioning_on_startup,
+                    )
+                    .await?
+            }
+        };
+
+        let _ = self
+            .id_manager
+            .reconcile_hub_identities(self.settings.clone())
+            .await?;
+
         Ok(())
     }
 
@@ -511,8 +504,6 @@ impl Api {
 
         Ok(local_identity)
     }
-
-    
 }
 
 pub(crate) fn create_csr(
@@ -581,12 +572,16 @@ impl auth::authentication::Authenticator for SettingsAuthenticator {
     type Error = Error;
 
     fn authenticate(&self, credentials: config::Uid) -> Result<auth::AuthId, Self::Error> {
+        //DEVNOTE: The authentication logic is ordered to lookup the principals first
+        //         so that a host process can be configured to run as root.
         if let Some(p) = self.allowed_users.get(&credentials) {
-            if let Some(_) = p.id_type {
+            if p.id_type.is_some() {
                 return Ok(auth::AuthId::HostProcess(p.clone()));
             } else {
                 return Ok(auth::AuthId::Daemon);
             }
+        } else if credentials == config::Uid(0) {
+            return Ok(auth::AuthId::LocalRoot);
         }
 
         Ok(auth::AuthId::Unknown)
@@ -604,13 +599,12 @@ impl auth::authorization::Authorizer for SettingsAuthorizer {
             crate::auth::AuthId::HostProcess(p) => Ok(match o.op_type {
                 auth::OperationType::GetModule(m) => {
                     p.name.0 == m
-                        && p.id_type.clone().map_or(false, |i| {
+                        && p.id_type.map_or(false, |i| {
                             i.contains(&aziot_identity_common::IdType::Module)
                         })
                 }
                 auth::OperationType::GetDevice => p
                     .id_type
-                    .clone()
                     .map_or(true, |i| i.contains(&aziot_identity_common::IdType::Device)),
                 auth::OperationType::GetAllHubModules
                 | auth::OperationType::CreateModule(_)
@@ -642,65 +636,18 @@ fn get_cert_expiration(cert: &str) -> Result<String, Error> {
     Ok(expiration)
 }
 
-fn prepare_authorized_principals(
-    principal: &[config::Principal],
-) -> (
-    std::collections::BTreeMap<config::Uid, config::Principal>,
-    std::collections::BTreeSet<aziot_identity_common::ModuleId>,
-    std::collections::BTreeMap<
-        aziot_identity_common::ModuleId,
-        Option<aziot_identity_common::LocalIdOpts>,
-    >,
-) {
-    let mut local_module_map: std::collections::BTreeMap<
-        aziot_identity_common::ModuleId,
-        Option<aziot_identity_common::LocalIdOpts>,
-    > = std::collections::BTreeMap::new();
-    let mut hub_module_set: std::collections::BTreeSet<aziot_identity_common::ModuleId> =
-        std::collections::BTreeSet::new();
-    let mut principal_map: std::collections::BTreeMap<config::Uid, config::Principal> =
-        std::collections::BTreeMap::new();
-    let mut found_daemon = false;
-
-    for p in principal {
-        if let Some(id_type) = &p.id_type {
-            for i in id_type {
-                match i {
-                    aziot_identity_common::IdType::Module => hub_module_set.insert(p.name.clone()),
-                    aziot_identity_common::IdType::Local => local_module_map
-                        .insert(p.name.clone(), p.localid.clone())
-                        .is_some(),
-                    _ => true,
-                };
-            }
-        } else if found_daemon {
-            log::warn!("Principal {:?} is not authorized. Please ensure there is only one principal without a type in the config.toml", p.name);
-            continue;
-        } else {
-            found_daemon = true
-        }
-
-        principal_map.insert(p.uid, p.clone());
-    }
-
-    (principal_map, hub_module_set, local_module_map)
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::Path;
 
     use aziot_identity_common::{IdType, LocalIdAttr, LocalIdOpts, ModuleId};
-    use aziot_identityd_config::{
-        LocalId, Principal,
-        Uid,
-    };
+    use aziot_identityd_config::{LocalId, Principal, Uid};
 
     use crate::auth::authorization::Authorizer;
     use crate::auth::{AuthId, Operation, OperationType};
     use crate::SettingsAuthorizer;
 
-    use super::prepare_authorized_principals;
+    use crate::configext::prepare_authorized_principals;
 
     #[test]
     fn convert_to_map_creates_principal_lookup() {
@@ -822,8 +769,7 @@ mod tests {
 
     #[test]
     fn empty_auth_settings_deny_any_action() {
-        let auth = SettingsAuthorizer {
-        };
+        let auth = SettingsAuthorizer {};
         let operation = Operation {
             auth_id: AuthId::Unknown,
             op_type: OperationType::CreateModule(String::default()),

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -461,8 +461,14 @@ impl Api {
                         self.id_manager.delete_module_identity(&m.0).await?;
                         log::info!("Hub identity {:?} removed", &m.0);
                     } else if current_module_set.contains(&m) {
-                        current_module_set.remove(&m);
-                        log::info!("Hub identity {:?} already exists", &m.0);
+                        if !prev_module_set.contains(&m) {
+                            self.id_manager.delete_module_identity(&m.0).await?;
+                            log::info!("Hub identity {:?} will be recreated", &m.0);
+                        } 
+                        else {
+                            current_module_set.remove(&m);
+                            log::info!("Hub identity {:?} already exists", &m.0);
+                        }
                     }
                 } else {
                     log::warn!("invalid identity type returned by get_module_identities");

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -110,9 +110,7 @@ pub async fn main(
     // Start file change listener that asynchronously updates Identity Service
     tokio::task::spawn(async move {
         loop {
-            let event = file_changed_rx.recv().await;
-
-            if event.is_some() {
+            while let Some(()) = file_changed_rx.recv().await {
                 let new_settings =
                     config_common::read_config(config_path.clone(), config_directory_path.clone())
                         .unwrap();
@@ -121,7 +119,6 @@ pub async fn main(
                 let _ = api_
                     .update_settings(new_settings, ReprovisionTrigger::ConfigurationFileUpdate)
                     .await;
-                drop(api_);
             }
         }
     });

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -452,7 +452,7 @@ impl Api {
                 self.id_manager
                     .provision_device(
                         self.settings.provisioning.clone(),
-                        !self.settings.provisioning.always_reprovisioning_on_startup,
+                        !self.settings.provisioning.always_reprovision_on_startup,
                     )
                     .await?
             }

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -87,17 +87,19 @@ pub async fn main(
     let api_watcher = api.clone();
     let (file_changed_tx, mut file_changed_rx) = tokio::sync::mpsc::channel(10);
     let config_directory_path_copy = config_directory_path.clone();
-    
+
     // Start file watcher using blocking channel
     std::thread::spawn(move || {
-        
         let (file_watcher_tx, file_watcher_rx) = std::sync::mpsc::channel();
 
         // Create a watcher object, delivering debounced events
-        let mut file_watcher = notify::watcher(file_watcher_tx, std::time::Duration::from_secs(10)).unwrap();
+        let mut file_watcher =
+            notify::watcher(file_watcher_tx, std::time::Duration::from_secs(10)).unwrap();
 
         // Add configuration path to be watched
-        file_watcher.watch(config_directory_path_copy, notify::RecursiveMode::Recursive).unwrap();
+        file_watcher
+            .watch(config_directory_path_copy, notify::RecursiveMode::Recursive)
+            .unwrap();
 
         loop {
             let _ = file_watcher_rx.recv();
@@ -109,22 +111,21 @@ pub async fn main(
     tokio::task::spawn(async move {
         loop {
             let event = file_changed_rx.recv().await;
-            
-            match event {
-                Some(_) => {
-                    let new_settings = config_common::read_config(config_path.clone(), config_directory_path.clone()).unwrap();
-                    
-                    let mut api_ = api_watcher.lock().await;
-                    let _ = api_
-                        .update_settings(new_settings, ReprovisionTrigger::ConfigurationFileUpdate)
-                        .await;
-                    drop(api_);
-                },
-                None => {},
+
+            if event.is_some() {
+                let new_settings =
+                    config_common::read_config(config_path.clone(), config_directory_path.clone())
+                        .unwrap();
+
+                let mut api_ = api_watcher.lock().await;
+                let _ = api_
+                    .update_settings(new_settings, ReprovisionTrigger::ConfigurationFileUpdate)
+                    .await;
+                drop(api_);
             }
         }
     });
-    
+
     let service = http::Service { api };
 
     Ok((connector, service))

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -357,6 +357,9 @@ impl Api {
         let (allowed_users, _, local_modules) =
             configext::prepare_authorized_principals(&settings.principal);
 
+        let authorizer = Box::new(SettingsAuthorizer {});
+        self.authorizer = authorizer;
+
         // All uids in the principals are authenticated users to this service
         let authenticator = Box::new(SettingsAuthenticator {
             allowed_users: allowed_users.clone(),

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -77,7 +77,7 @@ pub async fn main(
 
     let settings_copy = settings.clone();
 
-    tokio::task::spawn(async move {
+    tokio::spawn(async move {
         let mut api_ = api_startup.lock().await;
         let _ = api_
             .update_settings(settings_copy, ReprovisionTrigger::Startup)
@@ -116,7 +116,7 @@ pub async fn main(
     });
 
     // Start file change listener that asynchronously updates Identity Service
-    tokio::task::spawn(async move {
+    tokio::spawn(async move {
         while let Some(()) = file_changed_rx.recv().await {
             let new_settings =
                 config_common::read_config(&config_path, &config_directory_path).unwrap();

--- a/identity/aziot-identityd/test/good_auth_settings.toml
+++ b/identity/aziot-identityd/test/good_auth_settings.toml
@@ -25,6 +25,7 @@ idtype = ["module", "local"]
 uid = 1003
 
 [provisioning]
+always_reprovisioning_on_startup = false
 source = "manual"
 iothub_hostname = "hubname"
 device_id = "deviceid"
@@ -32,7 +33,6 @@ device_id = "deviceid"
 [provisioning.authentication]
 method = "sas"
 device_id_pk = "sas"
-dynamic_reprovisioning = false
 
 # [provisioning]
 # "source" = "dps"

--- a/identity/aziot-identityd/test/good_auth_settings.toml
+++ b/identity/aziot-identityd/test/good_auth_settings.toml
@@ -25,7 +25,7 @@ idtype = ["module", "local"]
 uid = 1003
 
 [provisioning]
-always_reprovisioning_on_startup = false
+always_reprovision_on_startup = false
 source = "manual"
 iothub_hostname = "hubname"
 device_id = "deviceid"

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -20,6 +20,8 @@ use aziot_keyd_config::{Config, Endpoints};
 
 pub async fn main(
     config: Config,
+    _: std::path::PathBuf,
+    _: std::path::PathBuf,
 ) -> Result<(http_common::Connector, http::Service), Box<dyn std::error::Error>> {
     let Config {
         aziot_keys,

--- a/tpm/aziot-tpmd/src/lib.rs
+++ b/tpm/aziot-tpmd/src/lib.rs
@@ -20,6 +20,8 @@ use error::{Error, InternalError};
 
 pub async fn main(
     config: Config,
+    _: std::path::PathBuf,
+    _: std::path::PathBuf,
 ) -> Result<(http_common::Connector, http::Service), Box<dyn std::error::Error>> {
     let Config {
         endpoints: Endpoints {


### PR DESCRIPTION
- Add file watcher functionality to detect settings file change and trigger automatic identity reconciliation. Reconciliation is now triggered by 3 methods - `aziot-identityd` startup, `/identities/device/reprovision` API invocation, and settings file change triggered by file watcher
- Add `always_provision_on_startup` support in `[provisioning]` settings and remove `dynamic_provisioning` flag (which is relevant for Edge only)
- Refactor authorization policies to become truly static (i.e. not dependent on configuration) and rework authorization to simpler types of users
- Refactor configuration functions into common crate, which is accessible by `aziot-identityd` and `aziotd` crates
- Fix: Provisioning no longer blocks API server start up in `aziot-identityd`

How verified:
Manually packaged and ran the script as follows:
```
docker run -it --rm -v "$(realpath ~/iot-identity-service):/src" -e 'ARCH=amd64' -e 'PACKAGE_VERSION=1.1.0' -e 'PACKAGE_RELEASE=0' ubuntu:18.04 '/src/ci/package.sh'
./ci/e2e-tests.sh 'manual-symmetric-key'
```

TODO:

- [x] Figure out inclusion of third-party licensing for `inotify` crate (uses ISC which isn't allowed in `contrib\third-party-notices.sh` yet)
- [x] Run automated e2e test (blocked by dist package building due to third-party licensing error)