### PR TITLE
Fix for missing NSG id in new e2e VMs

### DIFF
--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -407,7 +407,7 @@ nsg_id="$(
         --resource-group "$AZURE_RESOURCE_GROUP_NAME" \
         --name "$common_resource_name" \
         --tags "$resource_tag" \
-        --query 'id' --output tsv
+        --query 'NewNSG.id' --output tsv
 )"
 echo 'Created NSG' >&2
 


### PR DESCRIPTION
Previously, the script ran the NSG creation command and incorrectly expected an output 'id' in response. Correct jmespath is NewNSG.id.

Manually validated by running script that NSG is applied to the VM.