### PR TITLE
[aziotctl check] ignore (instead of skip) tpmd check

### DIFF
--- a/aziotctl/src/internal/check/checks/daemons_running.rs
+++ b/aziotctl/src/internal/check/checks/daemons_running.rs
@@ -117,7 +117,7 @@ impl Checker for DaemonRunningTpmd {
         };
 
         if !using_tpmd {
-            return CheckResult::Skipped;
+            return CheckResult::Ignored;
         }
 
         let mut connector = aziot_identityd_config::Endpoints::default().aziot_tpmd;


### PR DESCRIPTION
Skipped implies that the test didn't run due to a failure, which isn't the case here.