### PR TITLE
[e2e tests] dps-x509

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -27,6 +27,7 @@ jobs:
         test_name:
         - 'manual-symmetric-key'
         - 'manual-x509'
+        - 'dps-x509'
 
     steps:
     - uses: 'actions/checkout@v1'

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -32,6 +32,7 @@ jobs:
         test_name:
         - 'manual-symmetric-key'
         - 'manual-x509'
+        - 'dps-x509'
 
     steps:
     - uses: 'actions/checkout@v1'

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -338,11 +338,12 @@ trap "
     case "$test_name" in
         dps-*)
             echo 'Creating DPS...' >&2
-            dps_scope_id="$(az iot dps create \
-                --resource-group "$AZURE_RESOURCE_GROUP_NAME" \
-                --name "$common_resource_name" \
-                --tags "$resource_tag" \
-                --query 'properties.idScope' --output tsv
+            dps_scope_id="$(
+                az iot dps create \
+                    --resource-group "$AZURE_RESOURCE_GROUP_NAME" \
+                    --name "$common_resource_name" \
+                    --tags "$resource_tag" \
+                    --query 'properties.idScope' --output tsv
             )"
 
             az iot dps linked-hub create \


### PR DESCRIPTION
While working on this test, I ran into the issue where I'd set the `provisioning.attestation.registration_id` to something other than the device cert's CN, causing provisioning to fail.

I have a sneaking suspicion that I might have made a similar mistake while trying to get manual-x509 CA working, so I might double-back and make sure that x509 CA auth works as intended at some point in the future.

Kicked off a manual workflow run on my fork: https://github.com/daprilik/iot-identity-service/actions/runs/548813390