### PR TITLE
Allow runtime reconfiguration of KS and CS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "aziot-key-common-http",
  "aziot-keyd-config",
  "base64",
+ "config-common",
  "futures-util",
  "http",
  "http-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "aziot-key-common-http",
  "aziot-key-openssl-engine",
  "base64",
+ "config-common",
  "foreign-types-shared",
  "futures-util",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,14 +281,12 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "notify",
  "openssl",
  "openssl2",
  "percent-encoding",
  "regex",
  "serde",
  "serde_json",
- "tokio",
  "toml",
  "url",
 ]
@@ -711,8 +709,12 @@ dependencies = [
 name = "config-common"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "backtrace",
+ "futures-util",
+ "notify",
  "serde",
+ "tokio",
  "toml",
 ]
 

--- a/cert/aziot-certd/Cargo.toml
+++ b/cert/aziot-certd/Cargo.toml
@@ -31,6 +31,7 @@ aziot-key-client = { path = "../../key/aziot-key-client" }
 aziot-key-common = { path = "../../key/aziot-key-common" }
 aziot-key-common-http = { path = "../../key/aziot-key-common-http" }
 aziot-key-openssl-engine = { path = "../../key/aziot-key-openssl-engine" }
+config-common = { path = "../../config-common" }
 http-common = { path = "../../http-common", features = ["tokio1"] }
 openssl2 = { path = "../../openssl2" }
 

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -143,8 +143,8 @@ impl UpdateConfig for Api {
     ) -> Result<(), Self::Error> {
         log::info!("Updating config due to {:?}.", trigger);
 
-        // Don't allow changes to homedir path while daemon is running. Only update
-        // cert issuance method and preloaded certs.
+        // Don't allow changes to homedir path or endpoints while daemon is running.
+        // Only update other fields.
         self.cert_issuance = new_config.cert_issuance;
         self.preloaded_certs = new_config.preloaded_certs;
 

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -24,7 +24,7 @@ use aziot_certd_config::{
 };
 
 use async_trait::async_trait;
-use config_common::watcher::{UpdateConfig, ReprovisionTrigger};
+use config_common::watcher::{ReprovisionTrigger, UpdateConfig};
 
 pub async fn main(
     config: Config,

--- a/config-common/Cargo.toml
+++ b/config-common/Cargo.toml
@@ -11,5 +11,5 @@ backtrace = "0.3"
 futures-util = "0.3"
 notify = "4"
 serde = "1"
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1", features = ["rt", "sync"] }
 toml = "0.5"

--- a/config-common/Cargo.toml
+++ b/config-common/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2018"
 
 
 [dependencies]
+async-trait = "0.1"
 backtrace = "0.3"
+futures-util = "0.3"
+notify = "4"
 serde = "1"
+tokio = { version = "1", features = ["rt"] }
 toml = "0.5"

--- a/config-common/src/lib.rs
+++ b/config-common/src/lib.rs
@@ -9,6 +9,7 @@
 )]
 
 pub mod error;
+pub mod watcher;
 
 use crate::error::{Error, ErrorKind};
 

--- a/config-common/src/watcher.rs
+++ b/config-common/src/watcher.rs
@@ -42,18 +42,22 @@ pub fn start_watcher<TConfig: 'static, TError: 'static>(
 
     // Start file watcher using blocking channel.
     std::thread::spawn({
+        let config_path = config_path.clone();
         let config_directory_path = config_directory_path.clone();
 
         move || {
             let (file_watcher_tx, file_watcher_rx) = std::sync::mpsc::channel();
 
-            // Create a watcher object, delivering debounced events
+            // Create a watcher object, delivering debounced events.
             let mut file_watcher =
                 notify::watcher(file_watcher_tx, std::time::Duration::from_secs(10)).unwrap();
 
-            // Add configuration path to be watched
+            // Add configuration paths to be watched.
             file_watcher
                 .watch(config_directory_path, notify::RecursiveMode::Recursive)
+                .unwrap();
+            file_watcher.
+                watch(config_path, notify::RecursiveMode::NonRecursive)
                 .unwrap();
 
             loop {

--- a/config-common/src/watcher.rs
+++ b/config-common/src/watcher.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use async_trait::async_trait;
+use notify::Watcher;
+use std::path::PathBuf;
+
+type Api<TConfig, TError> = std::sync::Arc<
+    futures_util::lock::Mutex<dyn UpdateConfig<Config = TConfig, Error = TError> + Send>,
+>;
+
+#[derive(Debug)]
+pub enum ReprovisionTrigger {
+    ConfigurationFileUpdate,
+    Api,
+    Startup,
+}
+
+#[async_trait]
+pub trait UpdateConfig {
+    type Config: serde::de::DeserializeOwned;
+    type Error: std::error::Error;
+
+    async fn update_config(
+        &mut self,
+        new_config: Self::Config,
+        trigger: ReprovisionTrigger,
+    ) -> Result<(), Self::Error>;
+}
+
+pub fn start_watcher<TConfig: 'static, TError: 'static>(
+    config_path: PathBuf,
+    config_directory_path: PathBuf,
+    api: Api<TConfig, TError>,
+) where
+    TConfig: serde::de::DeserializeOwned + Send,
+    TError: std::error::Error,
+{
+    // DEVNOTE: The channel created for file watcher receiver needs to address up to two messages,
+    // since the message is resent to file change receiver using a blocking send.
+    // When the number of messages is set to 1, then main thread appears to block.
+    let (file_changed_tx, mut file_changed_rx) = tokio::sync::mpsc::channel(2);
+
+    // Start file watcher using blocking channel.
+    std::thread::spawn({
+        let config_directory_path = config_directory_path.clone();
+
+        move || {
+            let (file_watcher_tx, file_watcher_rx) = std::sync::mpsc::channel();
+
+            // Create a watcher object, delivering debounced events
+            let mut file_watcher =
+                notify::watcher(file_watcher_tx, std::time::Duration::from_secs(10)).unwrap();
+
+            // Add configuration path to be watched
+            file_watcher
+                .watch(config_directory_path, notify::RecursiveMode::Recursive)
+                .unwrap();
+
+            loop {
+                let _ = file_watcher_rx.recv();
+                let _ = file_changed_tx.blocking_send(());
+            }
+        }
+    });
+
+    // Start file change listener that asynchronously updates service config.
+    tokio::spawn(async move {
+        while let Some(()) = file_changed_rx.recv().await {
+            let new_config = crate::read_config(&config_path, &config_directory_path).unwrap();
+
+            let mut api_ = api.lock().await;
+            let _ = api_
+                .update_config(new_config, ReprovisionTrigger::ConfigurationFileUpdate)
+                .await;
+        }
+    });
+}

--- a/config-common/src/watcher.rs
+++ b/config-common/src/watcher.rs
@@ -56,8 +56,8 @@ pub fn start_watcher<TConfig: 'static, TError: 'static>(
             file_watcher
                 .watch(config_directory_path, notify::RecursiveMode::Recursive)
                 .unwrap();
-            file_watcher.
-                watch(config_path, notify::RecursiveMode::NonRecursive)
+            file_watcher
+                .watch(config_path, notify::RecursiveMode::NonRecursive)
                 .unwrap();
 
             loop {

--- a/identity/aziot-identityd/Cargo.toml
+++ b/identity/aziot-identityd/Cargo.toml
@@ -18,14 +18,12 @@ hyper = "0.14"
 lazy_static = "1"
 libc = "0.2"
 log = "0.4"
-notify = "4"
 openssl = "0.10"
 percent-encoding = "2"
 regex = "1"
 serde = "1"
 serde_json = "1.0"
 toml = "0.5"
-tokio = { version = "1", features = ["rt"] }
 url = "2"
 
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }

--- a/key/aziot-keyd/Cargo.toml
+++ b/key/aziot-keyd/Cargo.toml
@@ -24,4 +24,5 @@ url = "2"
 aziot-key-common = { path = "../aziot-key-common" }
 aziot-key-common-http = { path = "../aziot-key-common-http" }
 aziot-keyd-config = { path = "../aziot-keyd-config" }
+config-common = { path = "../../config-common" }
 http-common = { path = "../../http-common", features = ["tokio1"] }

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -9,6 +9,8 @@
     clippy::missing_errors_doc
 )]
 
+use async_trait::async_trait;
+
 mod error;
 pub use error::{Error, InternalError};
 
@@ -18,8 +20,7 @@ mod http;
 
 use aziot_keyd_config::{Config, Endpoints};
 
-use async_trait::async_trait;
-use config_common::watcher::{ReprovisionTrigger, UpdateConfig};
+use config_common::watcher::UpdateConfig;
 
 pub async fn main(
     config: Config,
@@ -454,16 +455,12 @@ impl UpdateConfig for Api {
     type Config = Config;
     type Error = Error;
 
-    async fn update_config(
-        &mut self,
-        _new_config: Self::Config,
-        trigger: ReprovisionTrigger,
-    ) -> Result<(), Self::Error> {
-        log::info!("Updating config due to {:?}.", trigger);
+    async fn update_config(&mut self, _new_config: Self::Config) -> Result<(), Self::Error> {
+        // log::info!("Detected change in config files. Updating config.");
 
         // TODO: implement update to authorization.
 
-        log::info!("Config update finished.");
+        // log::info!("Config update finished.");
         Ok(())
     }
 }

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -9,8 +9,6 @@
     clippy::missing_errors_doc
 )]
 
-use async_trait::async_trait;
-
 mod error;
 pub use error::{Error, InternalError};
 
@@ -20,12 +18,10 @@ mod http;
 
 use aziot_keyd_config::{Config, Endpoints};
 
-use config_common::watcher::UpdateConfig;
-
 pub async fn main(
     config: Config,
-    config_path: std::path::PathBuf,
-    config_directory_path: std::path::PathBuf,
+    _: std::path::PathBuf,
+    _: std::path::PathBuf,
 ) -> Result<(http_common::Connector, http::Service), Box<dyn std::error::Error>> {
     let Config {
         aziot_keys,
@@ -78,8 +74,6 @@ pub async fn main(
         Api { keys }
     };
     let api = std::sync::Arc::new(futures_util::lock::Mutex::new(api));
-
-    config_common::watcher::start_watcher(config_path, config_directory_path, api.clone());
 
     let service = http::Service { api };
 
@@ -447,21 +441,6 @@ impl Api {
         };
 
         Ok(plaintext)
-    }
-}
-
-#[async_trait]
-impl UpdateConfig for Api {
-    type Config = Config;
-    type Error = Error;
-
-    async fn update_config(&mut self, _new_config: Self::Config) -> Result<(), Self::Error> {
-        // log::info!("Detected change in config files. Updating config.");
-
-        // TODO: implement update to authorization.
-
-        // log::info!("Config update finished.");
-        Ok(())
     }
 }
 

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -19,7 +19,7 @@ mod http;
 use aziot_keyd_config::{Config, Endpoints};
 
 use async_trait::async_trait;
-use config_common::watcher::{UpdateConfig, ReprovisionTrigger};
+use config_common::watcher::{ReprovisionTrigger, UpdateConfig};
 
 pub async fn main(
     config: Config,


### PR DESCRIPTION
- Moves Identity Service config file watcher code to config-common.
- Shares watcher code with CS and KS so that they can update their configs at runtime. This will be needed to support runtime authorization policy updates.

I updated CS to also update cert_issuance and preloaded_certs at runtime. This will allow reconfiguration of EST and other cert issuance methods. I didn't update KS to do anything because any updates to its preloaded keys can just be done by importing the key.