### PR TITLE
Add authorization to CS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ version = "0.1.0"
 dependencies = [
  "hex",
  "http-common",
+ "libc",
  "openssl",
  "serde",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "futures-util",
+ "log",
  "notify",
  "serde",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "hyper",
  "hyper-openssl",
  "lazy_static",
+ "libc",
  "log",
  "openssl",
  "openssl-build",
@@ -135,6 +136,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+ "wildmatch",
 ]
 
 [[package]]
@@ -2324,6 +2326,12 @@ name = "wasi"
 version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
+
+[[package]]
+name = "wildmatch"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2399814fda0d6999a6bfe9b5c7660d836334deb162a09db8b73d5b38fd8c40a"
 
 [[package]]
 name = "winapi"

--- a/aziotctl/src/init.rs
+++ b/aziotctl/src/init.rs
@@ -423,7 +423,7 @@ fn run_inner(stdin: &mut impl Reader) -> Result<RunOutput> {
             homedir_path: AZIOT_CERTD_HOMEDIR_PATH.into(),
             cert_issuance: Default::default(),
             preloaded_certs: Default::default(),
-            principals: Default::default(),
+            principal: Default::default(),
             endpoints: Default::default(),
         };
 

--- a/aziotctl/src/init.rs
+++ b/aziotctl/src/init.rs
@@ -423,6 +423,7 @@ fn run_inner(stdin: &mut impl Reader) -> Result<RunOutput> {
             homedir_path: AZIOT_CERTD_HOMEDIR_PATH.into(),
             cert_issuance: Default::default(),
             preloaded_certs: Default::default(),
+            principals: Default::default(),
             endpoints: Default::default(),
         };
 

--- a/aziotctl/src/init.rs
+++ b/aziotctl/src/init.rs
@@ -423,8 +423,8 @@ fn run_inner(stdin: &mut impl Reader) -> Result<RunOutput> {
             homedir_path: AZIOT_CERTD_HOMEDIR_PATH.into(),
             cert_issuance: Default::default(),
             preloaded_certs: Default::default(),
-            principal: Default::default(),
             endpoints: Default::default(),
+            principal: Default::default(),
         };
 
         match device_id_source {

--- a/cert/aziot-certd-config/Cargo.toml
+++ b/cert/aziot-certd-config/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2018"
 
 
 [dependencies]
-http-common = { path = "../../http-common" }
+hex = "0.4"
+libc = "0.2"
+openssl = "0.10"
 serde = { version = "1", features = ["derive"] }
 url = { version = "2", features = ["serde"] }
-openssl = "0.10"
-hex = "0.4"
+
+http-common = { path = "../../http-common" }
 
 [dev-dependencies]
 toml = "0.5"

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -9,6 +9,8 @@
     clippy::missing_errors_doc
 )]
 
+use libc::uid_t as Uid;
+
 pub mod util;
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -30,6 +32,16 @@ pub struct Config {
     #[serde(default, skip_serializing)]
     #[cfg_attr(not(debug_assertions), serde(skip_deserializing))]
     pub endpoints: Endpoints,
+
+    /// Authorized Unix users and the corresponding certificates.
+    ///
+    /// A Unix user with the given UID is granted write access to the certificates
+    /// specified. Wildcards may be used for certificate names.
+    ///
+    /// This authorization only affects write access. Read access for certificates is
+    /// granted to all users.
+    #[serde(default)]
+    pub principals: Vec<Principal>,
 }
 
 /// Configuration of how new certificates should be issued.
@@ -303,6 +315,16 @@ impl Default for Endpoints {
             },
         }
     }
+}
+
+/// Map of a Unix UID to certificates with write access.
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct Principal {
+    /// Unix UID.
+    uid: Uid,
+
+    /// Certificates for which the given UID has write access.
+    certs: Vec<String>,
 }
 
 #[cfg(test)]

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -9,8 +9,6 @@
     clippy::missing_errors_doc
 )]
 
-use libc::uid_t as Uid;
-
 pub mod util;
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -41,7 +39,7 @@ pub struct Config {
     /// This authorization only affects write access. Read access for certificates is
     /// granted to all users.
     #[serde(default)]
-    pub principals: Vec<Principal>,
+    pub principal: Vec<Principal>,
 }
 
 /// Configuration of how new certificates should be issued.
@@ -321,10 +319,10 @@ impl Default for Endpoints {
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Principal {
     /// Unix UID.
-    uid: Uid,
+    pub uid: libc::uid_t,
 
-    /// Certificates for which the given UID has write access.
-    certs: Vec<String>,
+    /// Certificates for which the given UID has write access. Wildcards may be used.
+    pub certs: Vec<String>,
 }
 
 #[cfg(test)]

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -24,6 +24,13 @@ pub struct Config {
     #[serde(default)]
     pub preloaded_certs: std::collections::BTreeMap<String, PreloadedCert>,
 
+    /// Map of service names to endpoint URIs.
+    ///
+    /// Only configurable in debug builds for the sake of tests.
+    #[serde(default, skip_serializing)]
+    #[cfg_attr(not(debug_assertions), serde(skip_deserializing))]
+    pub endpoints: Endpoints,
+
     /// Authorized Unix users and the corresponding certificate IDs.
     ///
     /// A Unix user with the given UID is granted write access to the certificate IDs
@@ -31,15 +38,8 @@ pub struct Config {
     ///
     /// This authorization only affects write access. Read access for all certificate IDs is
     /// granted to all users.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub principal: Vec<Principal>,
-
-    /// Map of service names to endpoint URIs.
-    ///
-    /// Only configurable in debug builds for the sake of tests.
-    #[serde(default, skip_serializing)]
-    #[cfg_attr(not(debug_assertions), serde(skip_deserializing))]
-    pub endpoints: Endpoints,
 }
 
 /// Configuration of how new certificates should be issued.
@@ -477,11 +477,6 @@ certs = ["test"]
                 .into_iter()
                 .collect(),
 
-                principal: vec![super::Principal {
-                    uid: 1000,
-                    certs: vec!["test".to_string()]
-                }],
-
                 endpoints: super::Endpoints {
                     aziot_certd: http_common::Connector::Unix {
                         socket_path: std::path::Path::new("/run/aziot/certd.sock").into()
@@ -489,7 +484,12 @@ certs = ["test"]
                     aziot_keyd: http_common::Connector::Unix {
                         socket_path: std::path::Path::new("/run/aziot/keyd.sock").into()
                     },
-                }
+                },
+
+                principal: vec![super::Principal {
+                    uid: 1000,
+                    certs: vec!["test".to_string()]
+                }],
             }
         );
     }
@@ -515,8 +515,6 @@ aziot_certd = "unix:///run/aziot/certd.sock"
 
                 preloaded_certs: Default::default(),
 
-                principal: Default::default(),
-
                 endpoints: super::Endpoints {
                     aziot_certd: http_common::Connector::Unix {
                         socket_path: std::path::Path::new("/run/aziot/certd.sock").into()
@@ -525,6 +523,8 @@ aziot_certd = "unix:///run/aziot/certd.sock"
                         socket_path: std::path::Path::new("/run/aziot/keyd.sock").into()
                     },
                 },
+
+                principal: Default::default(),
             }
         );
     }

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -360,6 +360,10 @@ est-ca = "file:///var/secrets/est-ca.cer"
 trust-bundle = [
 	"est-ca",
 ]
+
+[[principal]]
+uid = 1000
+certs = ["test"]
 "#;
 
         let actual: super::Config = toml::from_str(actual).unwrap();
@@ -481,6 +485,11 @@ trust-bundle = [
                         socket_path: std::path::Path::new("/run/aziot/keyd.sock").into()
                     },
                 },
+
+                principal: vec![super::Principal {
+                    uid: 1000,
+                    certs: vec!["test".to_string()]
+                }]
             }
         );
     }
@@ -514,6 +523,8 @@ aziot_certd = "unix:///run/aziot/certd.sock"
                         socket_path: std::path::Path::new("/run/aziot/keyd.sock").into()
                     },
                 },
+
+                principal: Default::default(),
             }
         );
     }

--- a/cert/aziot-certd/Cargo.toml
+++ b/cert/aziot-certd/Cargo.toml
@@ -16,6 +16,7 @@ http = "0.2"
 hyper = "0.14"
 hyper-openssl = "0.9"
 lazy_static = "1"
+libc = "0.2"
 log = "0.4"
 openssl = "0.10"
 openssl-sys = "0.9"
@@ -24,6 +25,7 @@ regex = "1"
 serde = "1"
 serde_json = "1"
 url = "2"
+wildmatch = "1"
 
 aziot-cert-common-http = { path = "../aziot-cert-common-http" }
 aziot-certd-config = { path = "../aziot-certd-config" }

--- a/cert/aziot-certd/src/error.rs
+++ b/cert/aziot-certd/src/error.rs
@@ -4,6 +4,7 @@
 pub enum Error {
     Internal(InternalError),
     InvalidParameter(&'static str, Box<dyn std::error::Error + Send + Sync>),
+    Unauthorized(libc::uid_t, String),
 }
 
 impl Error {
@@ -22,6 +23,9 @@ impl std::fmt::Display for Error {
             Error::InvalidParameter(name, _) => {
                 write!(f, "parameter {:?} has an invalid value", name)
             }
+            Error::Unauthorized(user, id) => {
+                write!(f, "User {} not authorized to modify cert {}.", user, id)
+            }
         }
     }
 }
@@ -31,6 +35,7 @@ impl std::error::Error for Error {
         match self {
             Error::Internal(err) => Some(err),
             Error::InvalidParameter(_, err) => Some(&**err),
+            Error::Unauthorized(_, _) => None,
         }
     }
 }

--- a/cert/aziot-certd/src/error.rs
+++ b/cert/aziot-certd/src/error.rs
@@ -24,7 +24,11 @@ impl std::fmt::Display for Error {
                 write!(f, "parameter {:?} has an invalid value", name)
             }
             Error::Unauthorized(user, id) => {
-                write!(f, "User {} not authorized to modify cert {}.", user, id)
+                write!(
+                    f,
+                    "user {} is not authorized to modify the cert {}",
+                    user, id
+                )
             }
         }
     }

--- a/cert/aziot-certd/src/http/create.rs
+++ b/cert/aziot-certd/src/http/create.rs
@@ -2,6 +2,7 @@
 
 pub(super) struct Route {
     api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    user: libc::uid_t,
 }
 
 #[async_trait::async_trait]
@@ -16,14 +17,17 @@ impl http_common::server::Route for Route {
         service: &Self::Service,
         path: &str,
         _query: &[(std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>)],
-        _extensions: &http::Extensions,
+        extensions: &http::Extensions,
     ) -> Option<Self> {
         if path != "/certificates" {
             return None;
         }
 
+        let uid = extensions.get::<libc::uid_t>().cloned()?;
+
         Some(Route {
             api: service.api.clone(),
+            user: uid,
         })
     }
 
@@ -53,6 +57,7 @@ impl http_common::server::Route for Route {
                      private_key_handle,
                  }| (cert_id, private_key_handle),
             ),
+            self.user,
         )
         .await;
         let pem = match pem {

--- a/cert/aziot-certd/src/http/create.rs
+++ b/cert/aziot-certd/src/http/create.rs
@@ -23,7 +23,7 @@ impl http_common::server::Route for Route {
             return None;
         }
 
-        let uid = extensions.get::<libc::uid_t>().cloned()?;
+        let uid = extensions.get::<libc::uid_t>().copied()?;
 
         Some(Route {
             api: service.api.clone(),

--- a/cert/aziot-certd/src/http/get_or_import_or_delete.rs
+++ b/cert/aziot-certd/src/http/get_or_import_or_delete.rs
@@ -33,7 +33,7 @@ impl http_common::server::Route for Route {
             .decode_utf8()
             .ok()?;
 
-        let uid = extensions.get::<libc::uid_t>().cloned()?;
+        let uid = extensions.get::<libc::uid_t>().copied()?;
 
         Some(Route {
             api: service.api.clone(),

--- a/cert/aziot-certd/src/http/get_or_import_or_delete.rs
+++ b/cert/aziot-certd/src/http/get_or_import_or_delete.rs
@@ -9,6 +9,7 @@ lazy_static::lazy_static! {
 pub(super) struct Route {
     api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
     cert_id: String,
+    user: libc::uid_t,
 }
 
 #[async_trait::async_trait]
@@ -23,7 +24,7 @@ impl http_common::server::Route for Route {
         service: &Self::Service,
         path: &str,
         _query: &[(std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>)],
-        _extensions: &http::Extensions,
+        extensions: &http::Extensions,
     ) -> Option<Self> {
         let captures = URI_REGEX.captures(path)?;
 
@@ -32,9 +33,12 @@ impl http_common::server::Route for Route {
             .decode_utf8()
             .ok()?;
 
+        let uid = extensions.get::<libc::uid_t>().cloned()?;
+
         Some(Route {
             api: service.api.clone(),
             cert_id: cert_id.into_owned(),
+            user: uid,
         })
     }
 
@@ -47,7 +51,7 @@ impl http_common::server::Route for Route {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
-        if let Err(err) = api.delete_cert(&self.cert_id) {
+        if let Err(err) = api.delete_cert(&self.cert_id, self.user) {
             return Err(super::to_http_error(&err));
         }
 
@@ -83,7 +87,7 @@ impl http_common::server::Route for Route {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
-        match api.import_cert(&self.cert_id, &body.pem.0) {
+        match api.import_cert(&self.cert_id, &body.pem.0, self.user) {
             Ok(()) => (),
             Err(err) => return Err(super::to_http_error(&err)),
         };

--- a/cert/aziot-certd/src/http/mod.rs
+++ b/cert/aziot-certd/src/http/mod.rs
@@ -44,5 +44,10 @@ fn to_http_error(err: &crate::Error) -> http_common::server::Error {
             status_code: hyper::StatusCode::BAD_REQUEST,
             message: error_message.into(),
         },
+
+        crate::Error::Unauthorized(_, _) => http_common::server::Error {
+            status_code: hyper::StatusCode::UNAUTHORIZED,
+            message: err.to_string().into(),
+        },
     }
 }

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -22,7 +22,7 @@ mod http;
 
 use aziot_certd_config::{
     CertIssuance, CertIssuanceMethod, CertIssuanceOptions, Config, Endpoints, Est, EstAuthBasic,
-    EstAuthX509, LocalCa, PreloadedCert,
+    EstAuthX509, LocalCa, PreloadedCert, Principal,
 };
 
 use config_common::watcher::UpdateConfig;
@@ -41,6 +41,7 @@ pub async fn main(
                 aziot_certd: connector,
                 aziot_keyd: key_connector,
             },
+        principals,
     } = config;
 
     let api = {
@@ -60,6 +61,7 @@ pub async fn main(
             homedir_path,
             cert_issuance,
             preloaded_certs,
+            principals,
 
             key_client,
             key_engine,
@@ -78,6 +80,7 @@ struct Api {
     homedir_path: std::path::PathBuf,
     cert_issuance: CertIssuance,
     preloaded_certs: std::collections::BTreeMap<String, PreloadedCert>,
+    principals: Vec<Principal>,
 
     key_client: std::sync::Arc<aziot_key_client::Client>,
     key_engine: openssl2::FunctionalEngine,
@@ -147,9 +150,11 @@ impl UpdateConfig for Api {
             cert_issuance,
             preloaded_certs,
             endpoints: _,
+            principals,
         } = new_config;
         self.cert_issuance = cert_issuance;
         self.preloaded_certs = preloaded_certs;
+        self.principals = principals;
 
         log::info!("Config update finished.");
         Ok(())

--- a/config-common/Cargo.toml
+++ b/config-common/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 async-trait = "0.1"
 backtrace = "0.3"
 futures-util = "0.3"
+log = "0.4"
 notify = "4"
 serde = "1"
 tokio = { version = "1", features = ["rt", "sync"] }


### PR DESCRIPTION
- Requires a principal specified in config.toml to modify certificates.
- Retrieving certificates is still available to everyone.
- Root has universal access.

Example authorization principal:
```
[[principal]]
uid = 1000
certs = ["aziot-edged-ca", "test*"]
```