### PR TITLE
[e2e tests] tag DPS after creation

### DIFF
--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -359,9 +359,8 @@ trap "
                         --query 'location' --output tsv
                 )"
 
-            # `az iot dps create` doesn't have `--tags`, so tag it manually.
-            #
-            # Ref: https://github.com/Azure/azure-cli/issues/13497
+            # For some reason, `az resource tag` must come after
+            # `az iot dps linked-hub create`, or else the tags won't "stick"
             >/dev/null az resource tag \
                 --ids "$dps_resource_id" \
                 --tags "$resource_tag"


### PR DESCRIPTION
I realized that `az iot dps create` is also impacted by https://github.com/Azure/azure-cli/issues/13497

Two observations I had while fixing this:

- Why does `az iot dps create` silently accept invalid CLI flags?? I passed `--tags`, and instead of failing, it just silently succeeded? :roll_eyes: 
- For some reason, `az resource tag` _must_ come after `az iot dps linked-hub create`, or else the tag won't "stick"