### PR TITLE
Fix KS authorization error message

### DIFF
--- a/key/aziot-keyd/src/error.rs
+++ b/key/aziot-keyd/src/error.rs
@@ -27,7 +27,7 @@ impl std::fmt::Display for Error {
             Error::Unauthorized(user, id) => {
                 write!(
                     f,
-                    "user {} is not authorized to modify the key {}",
+                    "user {} is not authorized to access the key {}",
                     user, id
                 )
             }


### PR DESCRIPTION
In CS, authorization is required to modify certs, but reading certs is always permitted. In KS, authorization is required to read or modify keys. Fix error message in KS to reflect this.