### PR TITLE
Abort IS if a runtime config update fails

### DIFF
--- a/config-common/src/watcher.rs
+++ b/config-common/src/watcher.rs
@@ -69,8 +69,11 @@ pub fn start_watcher<TApi>(
                 }
             };
 
-            let mut api_ = api.lock().await;
-            let _ = api_.update_config(new_config).await;
+            let mut api = api.lock().await;
+
+            if let Err(err) = api.update_config(new_config).await {
+                log::warn!("Config update failed. Error: {}", err);
+            }
         }
     });
 }

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -514,14 +514,8 @@ impl UpdateConfig for Api {
     type Error = Error;
 
     async fn update_config(&mut self, new_config: config::Settings) -> Result<(), Self::Error> {
-        // Abort if update fails; i.e. if reconciling identities fails. This may happen if there's
-        // an error in the config or IoT Hub. The user will have to fix the config or IoT Hub and
-        // restart IS.
         self.update_config_inner(new_config, ReprovisionTrigger::ConfigurationFileUpdate)
             .await
-            .expect("failed to reprovision");
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Identity Service config updates may require reprovisioning with IoT Hub and updating Hub identities. If reprovisioning fails, IS cannot fall back on the old config because the old config may no longer be valid (e.g. the user created a new IoT Hub and deleted the old one). So, IS will abort and the user will need to fix the config and restart IS.