### PR TITLE
Fix for identity reconciliation

### DIFF
--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -497,12 +497,11 @@ impl Api {
         });
         self.authenticator = authenticator;
         self.local_identities = local_modules;
+        self.settings = settings;
 
         let _ = self
             .reprovision_device(auth::AuthId::LocalRoot, trigger)
             .await?;
-
-        self.settings = settings;
 
         Ok(())
     }


### PR DESCRIPTION
Fixed the order of assignment, during file watcher events, for active settings in IS to correctly occur before module identity reconciliation is executed.
Also, added debug logging for file watcher events.

Manually tested on Ubuntu 18.04.