### PR TITLE
Fixes from bugbash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "libc",
  "serde",
  "toml",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2335,8 +2336,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
 dependencies = [
  "cfg-if 1.0.0",
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -68,7 +68,7 @@ pub enum ProvisioningType {
     },
 
     Dps {
-        global_endpoint: String,
+        global_endpoint: Url,
         id_scope: String,
         attestation: DpsAttestationMethod,
     },

--- a/aziotctl/aziotctl-common/src/config/wizard.rs
+++ b/aziotctl/aziotctl-common/src/config/wizard.rs
@@ -115,7 +115,7 @@ pub fn run(
 
             (
                 aziot_identityd_config::ProvisioningType::Dps {
-                    global_endpoint: super::DPS_GLOBAL_ENDPOINT.to_owned(),
+                    global_endpoint: super::DPS_GLOBAL_ENDPOINT.parse().expect("hard-coded endpoint must parse successfully"),
                     scope_id,
                     attestation: aziot_identityd_config::DpsAttestationMethod::SymmetricKey {
                         registration_id,
@@ -132,7 +132,7 @@ pub fn run(
 
             (
                 aziot_identityd_config::ProvisioningType::Dps {
-                    global_endpoint: super::DPS_GLOBAL_ENDPOINT.to_owned(),
+                    global_endpoint: super::DPS_GLOBAL_ENDPOINT.parse().expect("hard-coded endpoint must parse successfully"),
                     scope_id,
                     attestation: aziot_identityd_config::DpsAttestationMethod::X509 {
                         registration_id,
@@ -150,7 +150,7 @@ pub fn run(
 
             (
                 aziot_identityd_config::ProvisioningType::Dps {
-                    global_endpoint: super::DPS_GLOBAL_ENDPOINT.to_owned(),
+                    global_endpoint: super::DPS_GLOBAL_ENDPOINT.parse().expect("hard-coded endpoint must parse successfully"),
                     scope_id,
                     attestation: aziot_identityd_config::DpsAttestationMethod::Tpm {
                         registration_id,

--- a/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key/config.toml
@@ -1,6 +1,6 @@
 [provisioning]
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 id_scope = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = false
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-tpm/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-tpm/config.toml
@@ -1,6 +1,6 @@
 [provisioning]
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 id_scope = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-tpm/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-tpm/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = false
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/config.toml
@@ -1,6 +1,6 @@
 [provisioning]
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 id_scope = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = false
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/config.toml
@@ -1,6 +1,6 @@
 [provisioning]
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 id_scope = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = false
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/config.toml
@@ -1,6 +1,6 @@
 [provisioning]
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 id_scope = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = false
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/config.toml
@@ -1,6 +1,6 @@
 [provisioning]
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 id_scope = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = false
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509/config.toml
@@ -1,6 +1,6 @@
 [provisioning]
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 id_scope = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = false
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/wizard/dps-symmetric-key/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/wizard/dps-symmetric-key/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = true
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/wizard/dps-tpm/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/wizard/dps-tpm/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = true
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/wizard/dps-x509-pkcs11-est-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/wizard/dps-x509-pkcs11-est-bootstrap/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = true
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/wizard/dps-x509-pkcs11-est/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/wizard/dps-x509-pkcs11-est/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = true
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/wizard/dps-x509-pkcs11-localca/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/wizard/dps-x509-pkcs11-localca/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = true
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/wizard/dps-x509-pkcs11/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/wizard/dps-x509-pkcs11/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = true
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/aziotctl-common/test-files/wizard/dps-x509/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/wizard/dps-x509/identityd.toml
@@ -4,7 +4,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = true
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]

--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -55,7 +55,7 @@
 ## DPS provisioning with symmetric key
 # [provisioning]
 # source = "dps"
-# global_endpoint = "https://global.azure-devices-provisioning.net"
+# global_endpoint = "https://global.azure-devices-provisioning.net/"
 # id_scope = "0ab1234C5D6"
 # 
 # [provisioning.attestation]
@@ -70,7 +70,7 @@
 ## DPS provisioning with X.509 certificate
 # [provisioning]
 # source = "dps"
-# global_endpoint = "https://global.azure-devices-provisioning.net"
+# global_endpoint = "https://global.azure-devices-provisioning.net/"
 # id_scope = "0ab1234C5D6"
 # 
 # [provisioning.attestation]
@@ -88,7 +88,7 @@
 ## DPS provisioning with TPM
 # [provisioning]
 # source = "dps"
-# global_endpoint = "https://global.azure-devices-provisioning.net"
+# global_endpoint = "https://global.azure-devices-provisioning.net/"
 # id_scope = "0ab1234C5D6"
 # 
 # [provisioning.attestation]

--- a/aziotctl/src/internal/check/checks/host_connect_dps_endpoint.rs
+++ b/aziotctl/src/internal/check/checks/host_connect_dps_endpoint.rs
@@ -2,12 +2,13 @@
 
 use anyhow::{anyhow, Context, Result};
 use serde::Serialize;
+use url::Url;
 
 use crate::internal::check::{CheckResult, Checker, CheckerCache, CheckerMeta, CheckerShared};
 
 #[derive(Serialize, Default)]
 pub struct HostConnectDpsEndpoint {
-    dps_endpoint: Option<String>,
+    dps_endpoint: Option<Url>,
     dps_hostname: Option<String>,
     proxy: Option<String>,
 }
@@ -48,20 +49,23 @@ impl HostConnectDpsEndpoint {
 
         self.dps_endpoint = Some(dps_endpoint.clone());
 
-        let dps_endpoint = dps_endpoint
-            .parse::<hyper::Uri>()
-            .context("Invalid URL specified in provisioning.global_endpoint")?;
+        let dps_hostname = dps_endpoint.host_str().ok_or_else(|| {
+            anyhow!("URL specified in provisioning.global_endpoint does not have a host")
+        })?;
+        self.dps_hostname = Some(dps_hostname.to_owned());
 
-        let dps_hostname = dps_endpoint
-            .host()
-            .ok_or_else(|| {
-                anyhow!("URL specified in provisioning.global_endpoint does not have a host")
-            })?
-            .to_owned();
-        self.dps_hostname = Some(dps_hostname.clone());
+        let dps_endpoint = dps_endpoint
+            .to_string()
+            .parse::<hyper::Uri>()
+            .with_context(|| {
+                format!(
+                    "url::Url {:?} could not be parsed as hyper::Uri",
+                    dps_endpoint
+                )
+            })?;
 
         // TODO: add proxy support once is supported in identityd
-        crate::internal::common::resolve_and_tls_handshake(dps_endpoint, &dps_hostname).await?;
+        crate::internal::common::resolve_and_tls_handshake(dps_endpoint, dps_hostname).await?;
 
         Ok(CheckResult::Ok)
     }

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -837,15 +837,15 @@ fn get_cert_inner(
 fn principal_to_map(
     principal: Vec<Principal>,
 ) -> std::collections::BTreeMap<libc::uid_t, Vec<wildmatch::WildMatch>> {
-    principal
-        .into_iter()
-        .map(|principal| {
-            let certs = principal
-                .certs
+    let mut result: std::collections::BTreeMap<_, Vec<_>> = Default::default();
+
+    for Principal { uid, certs } in principal {
+        result.entry(uid).or_default().extend(
+            certs
                 .into_iter()
-                .map(|cert| wildmatch::WildMatch::new(&cert))
-                .collect();
-            (principal.uid, certs)
-        })
-        .collect()
+                .map(|cert| wildmatch::WildMatch::new(&cert)),
+        );
+    }
+
+    result
 }

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -536,7 +536,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = true
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "$dps_scope_id"
 
 [provisioning.attestation]
@@ -658,7 +658,7 @@ homedir = "/var/lib/aziot/identityd"
 [provisioning]
 always_reprovision_on_startup = true
 source = "dps"
-global_endpoint = "https://global.azure-devices-provisioning.net"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "$dps_scope_id"
 
 [provisioning.attestation]

--- a/contrib/centos/aziot-identity-service.spec
+++ b/contrib/centos/aziot-identity-service.spec
@@ -174,7 +174,7 @@ fi
 %attr(400, aziottpm, aziottpm) %{_sysconfdir}/aziot/tpmd/config.toml.default
 %attr(700, aziottpm, aziottpm) %dir %{_sysconfdir}/aziot/tpmd/config.d
 
-%attr(700, root, root) %{_sysconfdir}/aziot/config.toml.template
+%attr(600, root, root) %{_sysconfdir}/aziot/config.toml.template
 
 # Home directories
 %attr(-, aziotcs, aziotcs) %dir /var/lib/aziot/certd

--- a/contrib/centos/aziot-identity-service.spec
+++ b/contrib/centos/aziot-identity-service.spec
@@ -174,7 +174,7 @@ fi
 %attr(400, aziottpm, aziottpm) %{_sysconfdir}/aziot/tpmd/config.toml.default
 %attr(700, aziottpm, aziottpm) %dir %{_sysconfdir}/aziot/tpmd/config.d
 
-%attr(400, root, root) %{_sysconfdir}/aziot/config.toml.template
+%attr(700, root, root) %{_sysconfdir}/aziot/config.toml.template
 
 # Home directories
 %attr(-, aziotcs, aziotcs) %dir /var/lib/aziot/certd

--- a/contrib/debian/postinst
+++ b/contrib/debian/postinst
@@ -33,7 +33,7 @@ case "$1" in
 		do
 			chmod 0400 "$f"
 		done
-		chmod 0700 /etc/aziot/config.toml.template
+		chmod 0600 /etc/aziot/config.toml.template
 
 		if [ -d /var/lib/aziot/certd ]; then
 			chown aziotcs:aziotcs /var/lib/aziot/certd

--- a/contrib/debian/postinst
+++ b/contrib/debian/postinst
@@ -29,11 +29,11 @@ case "$1" in
 			/etc/aziot/certd/config.toml.default \
 			/etc/aziot/identityd/config.toml.default \
 			/etc/aziot/keyd/config.toml.default \
-			/etc/aziot/tpmd/config.toml.default \
-			/etc/aziot/config.toml.template
+			/etc/aziot/tpmd/config.toml.default
 		do
 			chmod 0400 "$f"
 		done
+		chmod 0700 /etc/aziot/config.toml.template
 
 		if [ -d /var/lib/aziot/certd ]; then
 			chown aziotcs:aziotcs /var/lib/aziot/certd

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -21,6 +21,7 @@ percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["net", "rt-multi-thread"], optional = true }
+tracing = { version = "0.1", features = ["log"] }
 url = { version = "2", features = ["serde"] }
 
 [dev-dependencies]

--- a/identity/aziot-dps-client-async/src/lib.rs
+++ b/identity/aziot-dps-client-async/src/lib.rs
@@ -47,7 +47,7 @@ pub enum DpsAuthKind {
 }
 
 pub struct Client {
-    global_endpoint: String,
+    global_endpoint: url::Url,
     scope_id: String,
 
     key_client: Arc<aziot_key_client_async::Client>,
@@ -60,7 +60,7 @@ pub struct Client {
 impl Client {
     #[must_use]
     pub fn new(
-        global_endpoint: &str,
+        global_endpoint: &url::Url,
         scope_id: &str,
         key_client: Arc<aziot_key_client_async::Client>,
         key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
@@ -69,7 +69,7 @@ impl Client {
         proxy_uri: Option<hyper::Uri>,
     ) -> Self {
         Client {
-            global_endpoint: global_endpoint.to_owned(),
+            global_endpoint: global_endpoint.clone(),
             scope_id: scope_id.to_owned(),
 
             key_client,

--- a/identity/aziot-identityd-config/Cargo.toml
+++ b/identity/aziot-identityd-config/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 http-common = { path = "../../http-common" }
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
+url = { version = "2", features = ["serde"] }
 
 aziot-identity-common = { path = "../aziot-identity-common" }
 

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -114,7 +114,7 @@ pub enum ProvisioningType {
         authentication: ManualAuthMethod,
     },
     Dps {
-        global_endpoint: String,
+        global_endpoint: url::Url,
         scope_id: String,
         attestation: DpsAttestationMethod,
     },

--- a/identity/aziot-identityd/config/unix/default.toml
+++ b/identity/aziot-identityd/config/unix/default.toml
@@ -40,7 +40,7 @@ homedir = "/var/lib/aziot/identityd"
 
 # [provisioning]
 # "source" = "dps"
-# "global_endpoint" = "https://global.azure-devices-provisioning.net"
+# "global_endpoint" = "https://global.azure-devices-provisioning.net/"
 # "scope_id" = "<ADD DPS SCOPE ID HERE>"
 
 # [provisioning.attestation]

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -630,15 +630,14 @@ fn key_id_to_handle(
 fn principal_to_map(
     principal: Vec<Principal>,
 ) -> std::collections::BTreeMap<libc::uid_t, Vec<wildmatch::WildMatch>> {
-    principal
-        .into_iter()
-        .map(|principal| {
-            let keys = principal
-                .keys
-                .into_iter()
-                .map(|key| wildmatch::WildMatch::new(&key))
-                .collect();
-            (principal.uid, keys)
-        })
-        .collect()
+    let mut result: std::collections::BTreeMap<_, Vec<_>> = Default::default();
+
+    for Principal { uid, keys } in principal {
+        result
+            .entry(uid)
+            .or_default()
+            .extend(keys.into_iter().map(|key| wildmatch::WildMatch::new(&key)));
+    }
+
+    result
 }


### PR DESCRIPTION
- Change config.toml.template from `r--` to `rw-`

  This allows the user's editor to write it in-place instead of overwriting it.

- Enable logging for `hyper` via `env_logger`.

- Disable HTTP/2 via ALPN.

  This is a temporary workaround until we figure out why IS can't talk HTTP/2
  to Edge Hub even after enabling the `http2` feature of `hyper`.

- Parse DPS global endpoint as a `url::Url` so that invalid values
  are rejected at config parse time.

- Allow duplicate principals and merge them at runtime.