### PR TITLE
Set hyper-proxy to official 0.9 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,8 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-proxy"
-version = "0.8.0"
-source = "git+https://github.com/Azure/hyper-proxy.git#1d30a8826ddb78f75bfc3e3ae1369ec1d502a928"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9617035cdc5cbfcf18d9ed5e28eef45a5612d2ce11fc3be9952bdc626b984399"
 dependencies = [
  "bytes",
  "futures",

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -12,7 +12,7 @@ headers = { version = "0.3", optional = true }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "server", "tcp"], optional = true }
 hyper-openssl = { version = "0.9", optional = true }
-hyper-proxy = { git = "https://github.com/Azure/hyper-proxy.git", features = ["openssl-tls"], default-features = false, optional = true }
+hyper-proxy = { version = "0.9", features = ["openssl-tls"], default-features = false, optional = true }
 libc = "0.2"
 log = "0.4"
 nix = "0.18"


### PR DESCRIPTION
Updating hyper-proxy dependency to the official repo, since the tokio 1.0 update and openssl-tls feature are now merged into the main repo.