### PR TITLE
Fix for DPS provisioning

### DIFF
--- a/identity/aziot-dps-client-async/src/lib.rs
+++ b/identity/aziot-dps-client-async/src/lib.rs
@@ -86,7 +86,7 @@ impl Client {
         auth_kind: &DpsAuthKind,
     ) -> Result<model::RegistrationOperationStatus, std::io::Error> {
         let resource_uri = format!(
-            "/{}/registrations/{}/register?api-version=2018-11-01",
+            "{}/registrations/{}/register?api-version=2018-11-01",
             self.scope_id, registration_id
         );
 
@@ -126,7 +126,7 @@ impl Client {
 
         // spin until the registration has completed successfully
         let resource_uri = format!(
-            "/{}/registrations/{}/operations/{}?api-version=2018-11-01",
+            "{}/registrations/{}/operations/{}?api-version=2018-11-01",
             self.scope_id, registration_id, res.operation_id
         );
 


### PR DESCRIPTION
After the switch from string urls to typed urls, the additional slash caused DPS to receive empty registration IDs in registration requests.
This fix removes the slash preceding the registration ID.