### PR TITLE
Make aziot-identity-service conflict with libiothsm-std

### DIFF
--- a/contrib/centos/aziot-identity-service.spec
+++ b/contrib/centos/aziot-identity-service.spec
@@ -17,7 +17,7 @@ License: MIT
 URL: https://github.com/azure/iot-identity-service
 Source: aziot-identity-service-%{version}-%{release}.tar.gz
 
-Conflicts: iotedge
+Conflicts: iotedge, libiothsm-std
 
 BuildRequires: clang
 BuildRequires: gcc

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -12,7 +12,7 @@ Vcs-Git: https://github.com/azure/iot-identity-service
 Package: aziot-identity-service
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Conflicts: iotedge
+Conflicts: iotedge, libiothsm-std
 Description: Azure IoT Identity Service and related services
  This package contains the Azure IoT device runtime, comprised of the following services:
  .


### PR DESCRIPTION
Make aziot-identity-service conflict with libiothsm-std so that libiothsm-std is removed when aziot-identity-service is installed.