### PR TITLE
Also initialize an env_logger::Logger in libaziot-keys. (#140)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "hmac",
  "lazy_static",
  "log",
+ "logger",
  "openssl",
  "openssl-sys",
  "openssl-sys2",
@@ -605,10 +606,10 @@ dependencies = [
  "aziot-tpmd",
  "backtrace",
  "config-common",
- "env_logger",
  "http-common",
  "hyper",
  "log",
+ "logger",
  "serde",
  "tokio",
 ]
@@ -1491,6 +1492,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "logger"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "log",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,13 @@ dist:
 
 	# Copy source files
 	cp -R \
-		./aziotctl ./aziotd ./cert ./config-common ./http-common ./identity ./iotedged ./key ./mini-sntp ./openssl-build ./openssl-sys2 ./openssl2 ./pkcs11 ./tpm \
+		./config-common ./http-common ./logger ./openssl-build ./openssl-sys2 ./openssl2 ./pkcs11 \
+		./aziotctl ./aziotd ./mini-sntp \
+		./cert \
+		./identity \
+		./key \
+		./tpm \
+		./iotedged \
 		/tmp/aziot-identity-service-$(PACKAGE_VERSION)
 	cp ./Cargo.toml ./Cargo.lock ./CODE_OF_CONDUCT.md ./CONTRIBUTING.md ./LICENSE ./Makefile ./README.md ./rust-toolchain ./SECURITY.md /tmp/aziot-identity-service-$(PACKAGE_VERSION)
 

--- a/aziotd/Cargo.toml
+++ b/aziotd/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 backtrace = "0.3"
-env_logger = "0.8"
 hyper = "0.14"
 log = "0.4"
 serde = "1"
@@ -19,3 +18,4 @@ aziot-keyd = { path = "../key/aziot-keyd" }
 aziot-tpmd = { path = "../tpm/aziot-tpmd" }
 config-common = { path = "../config-common" }
 http-common = { path = "../http-common", features = ["tokio1"] }
+logger = { path = "../logger" }

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -10,13 +10,13 @@
 #![allow(clippy::default_trait_access, clippy::let_unit_value)]
 
 mod error;
-mod logging;
 
 use error::{Error, ErrorKind};
 
 #[tokio::main]
 async fn main() {
-    logging::init();
+    logger::try_init()
+        .expect("cannot fail to initialize global logger from the process entrypoint");
 
     if let Err(err) = main_inner().await {
         log::error!("{}", err.0);

--- a/key/aziot-keys/Cargo.toml
+++ b/key/aziot-keys/Cargo.toml
@@ -21,6 +21,7 @@ sha2 = "0.9"
 url = "2"
 
 aziot-keys-common = { path = "../aziot-keys-common" }
+logger = { path = "../../logger" }
 openssl2 = { path = "../../openssl2" }
 openssl-sys2 = { path = "../../openssl-sys2" }
 pkcs11 = { path = "../../pkcs11/pkcs11" }

--- a/key/aziot-keys/src/implementation.rs
+++ b/key/aziot-keys/src/implementation.rs
@@ -17,6 +17,10 @@ pub(crate) unsafe fn get_function_list(
     version: crate::AZIOT_KEYS_VERSION,
     pfunction_list: *mut *const crate::AZIOT_KEYS_FUNCTION_LIST,
 ) -> crate::AZIOT_KEYS_RC {
+    // Ignore the error from `try_init`. The error indicates a global logger was already set,
+    // which is because `get_function_list` is being called a second time. That's fine.
+    let _ = logger::try_init();
+
     crate::r#catch(|| {
         static AZIOT_KEYS_FUNCTION_LIST_2_0_0_0: crate::AZIOT_KEYS_FUNCTION_LIST_2_0_0_0 =
             crate::AZIOT_KEYS_FUNCTION_LIST_2_0_0_0 {

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "logger"
+version = "0.1.0"
+authors = ["Azure IoT Edge Devs"]
+edition = "2018"
+
+
+[dependencies]
+env_logger = "0.8"
+log = "0.4"

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::missing_errors_doc)]
+
 const LOG_LEVEL_ENV_VAR: &str = "AZIOT_LOG";
 
-pub(crate) fn init() {
+pub fn try_init() -> Result<(), log::SetLoggerError> {
     env_logger::Builder::new()
         .format(|fmt, record| {
             use std::io::Write;
@@ -39,7 +43,7 @@ pub(crate) fn init() {
         })
         .filter_level(log::LevelFilter::Info)
         .parse_env(LOG_LEVEL_ENV_VAR)
-        .init();
+        .try_init()
 }
 
 fn to_syslog_level(level: log::Level) -> i8 {


### PR DESCRIPTION
Cherry-pick from master of ba79ffbfc62feaa5d94448bb02f4b3e7314ccbbc

It's compiled as a cdylib so it doesn't share the global logger of
the host process (keyd).

Ref: #120