### PR TITLE
Change PACKAGE_VERSION to 1.2.0~rc4

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -45,8 +45,8 @@ jobs:
           '/src/ci/package.sh'
       env:
         ARCH: "${{ matrix.arch }}"
-        PACKAGE_VERSION: '1.2.0'
-        PACKAGE_RELEASE: 'rc4'
+        PACKAGE_VERSION: '1.2.0~rc4'
+        PACKAGE_RELEASE: '1'
     - name: 'Generate artifact properties'
       id: 'generate-artifact-properties'
       run: |


### PR DESCRIPTION
For consistency with the aziot-edge package, change the package version and revision to `1.2.0~rc4` and `1`, respectively.