### PR TITLE
Remove Iot Hub request/response logging

### DIFF
--- a/identity/aziot-hub-client-async/src/lib.rs
+++ b/identity/aziot-hub-client-async/src/lib.rs
@@ -243,7 +243,6 @@ impl Client {
         };
 
         let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);
-        log::debug!("IoTHub request {:?}", req);
 
         let res = client
             .request(req)
@@ -276,7 +275,6 @@ impl Client {
         let body = hyper::body::to_bytes(body)
             .await
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-        log::debug!("IoTHub response body {:?}", body);
 
         let res: TResponse = match res_status_code {
             hyper::StatusCode::OK | hyper::StatusCode::CREATED => {


### PR DESCRIPTION
The IoT Hub HTTP request/response logging can reveal key material for module identities. While sanitizing is possible, I cannot think of any scenarios where this sort of logging is helpful, since there are other methods of achieving the same.