### PR TITLE
Fix various issues found while testing with tpm2-pkcs11.

### DIFF
--- a/docs/dev/running/pkcs11/index.md
+++ b/docs/dev/running/pkcs11/index.md
@@ -45,6 +45,7 @@ Follow the steps corresponding to your hardware:
         ```sh
         # Path of the PKCS#11 library
         export PKCS11_LIB_PATH='/usr/local/lib/libtpm2_pkcs11.so'
+        # export PKCS11_LIB_PATH='/usr/lib/arm-linux-gnueabihf/pkcs11/libtpm2_pkcs11.so'
 
         # Variables to identify and log in to the PKCS#11 token
         TOKEN='Key pairs'

--- a/docs/dev/running/pkcs11/tpm2-pkcs11/index.md
+++ b/docs/dev/running/pkcs11/tpm2-pkcs11/index.md
@@ -167,7 +167,10 @@ wait $(jobs -pr)
     sudo chown "$(id -u):$(id -g)" /opt/tpm2-pkcs11
     sudo chmod 0700 /opt/tpm2-pkcs11
 
+    # --enable-debug=!yes is needed to disable assert() in
+    # CKR_FUNCTION_NOT_SUPPORTED-returning unimplemented functions.
     ./configure \
+        --enable-debug=info \
         --enable-esapi-session-manage-flags \
         --with-storedir=/opt/tpm2-pkcs11
     make "-j$(nproc)"

--- a/key/aziot-keys/src/key.rs
+++ b/key/aziot-keys/src/key.rs
@@ -548,6 +548,9 @@ fn create_inner(
                         match result {
                             Ok(_) => return Ok(()),
 
+                            Err(pkcs11::GenerateKeyError::GenerateKeyFailed(
+                                pkcs11_sys::CKR_FUNCTION_NOT_SUPPORTED,
+                            )) |
                             // Some PKCS#11 implementations like Cryptoauthlib don't support `C_GenerateKey(CKM_GENERIC_SECRET_KEY_GEN)`
                             Err(pkcs11::GenerateKeyError::GenerateKeyFailed(
                                 pkcs11_sys::CKR_MECHANISM_INVALID,

--- a/pkcs11/pkcs11/src/session.rs
+++ b/pkcs11/pkcs11/src/session.rs
@@ -517,7 +517,7 @@ impl std::fmt::Display for GenerateKeyError {
             GenerateKeyError::DeleteExistingKeyFailed(result) => write!(f, "C_DestroyObject failed with {}", result),
             GenerateKeyError::GenerateKeyDidNotReturnHandle =>
                 f.write_str("could not generate key pair: C_GenerateKey succeeded but key handle is still CK_INVALID_HANDLE"),
-            GenerateKeyError::GenerateKeyFailed(result) => write!(f, "could not generate key pair: C_GenerateKey failed with {}", result),
+            GenerateKeyError::GenerateKeyFailed(result) => write!(f, "could not generate key: C_GenerateKey failed with {}", result),
             GenerateKeyError::GetExistingKeyFailed(_) => write!(f, "could not get existing key object"),
             GenerateKeyError::LoginFailed(_) => f.write_str("could not log in to the token"),
         }


### PR DESCRIPTION
- Document Debian arm32v7 location of self-compiled `tpm2-pkcs11 .so`

- Configure tpm2-pkcs11 with `--enable-debug=info`. The default is
  `--enable-debug=yes`, which cases any `CKR_FUNCTION_NOT_SUPPORTED`-returning
  unimplemented function to call `assert(0)` and `abort()`. We want to handle
  this error ourselves.

- Also treat `CKR_FUNCTION_NOT_SUPPORTED` from `C_GenerateKey` as
  a fallible error, so that creating a symmetric key can fall back to
  the filesystem.

- Fix typo in "C_GenerateKey failed with" error message.