### PR TITLE
Enable `hyper::Client` to talk to HTTP/2 servers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,6 +1119,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "h2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
 name = "headers"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1275,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1307,6 +1333,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2244,6 +2280,20 @@ dependencies = [
  "futures",
  "openssl",
  "pin-project",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/cert/aziot-certd/src/est.rs
+++ b/cert/aziot-certd/src/est.rs
@@ -13,7 +13,7 @@ pub(crate) async fn create_cert(
     let proxy_connector = match client_cert {
         Some((device_id_certs, device_id_private_key)) => MaybeProxyConnector::new(
             proxy_uri,
-            Some((&device_id_private_key.to_owned(), &device_id_certs.to_vec())),
+            Some((&device_id_private_key, &device_id_certs)),
             &trusted_certs,
         )
         .map_err(|err| crate::Error::Internal(crate::InternalError::CreateCert(Box::new(err))))?,

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -10,7 +10,7 @@ base64 = "0.13"
 futures-util = "0.3"
 headers = { version = "0.3", optional = true }
 http = "0.2"
-hyper = { version = "0.14", features = ["client", "http1", "server", "tcp"], optional = true }
+hyper = { version = "0.14", features = ["client", "http1", "http2", "server", "tcp"], optional = true }
 hyper-openssl = { version = "0.9", optional = true }
 hyper-proxy = { version = "0.9", features = ["openssl-tls"], default-features = false, optional = true }
 libc = "0.2"

--- a/http-common/src/proxy.rs
+++ b/http-common/src/proxy.rs
@@ -85,7 +85,7 @@ where
     fn connected(&self) -> hyper::client::connect::Connected {
         match self {
             MaybeProxyStream::NoProxy(stream) => stream.connected(),
-            MaybeProxyStream::Proxy(stream) => stream.connected().proxy(true),
+            MaybeProxyStream::Proxy(stream) => stream.connected(),
         }
     }
 }


### PR DESCRIPTION
- Enable the `http2` feature of the `hyper` crate.

- Fix `MaybeProxyStream::connected()` to correctly forward to the inner stream's
  `connected()`. In particular, the inner `hyper_openssl::MaybeHttpsStream`
  notices that the server negotiated HTTP/2 via ALPN and creates a `Connected`
  with that bit set.

  Before this change, the old code was ignoring the `Connected` created by
  `hyper_openssl::MaybeHttpsStream` and always creating a new one.
  Thus the inner `hyper::Client` would attempt to parse the server's
  HTTP/2 response as HTTP/1.1 and fail.

- Remove code that disabled HTTP/2 in the ALPN request that was added as
  a workaround in 8630d84b4615fe0f3efc9a31dd50a9f225cc923b