### PR TITLE
Add optional proxy argument to aziotctl

### DIFF
--- a/aziotctl/src/internal/check/checks/host_connect_dps_endpoint.rs
+++ b/aziotctl/src/internal/check/checks/host_connect_dps_endpoint.rs
@@ -32,7 +32,7 @@ impl Checker for HostConnectDpsEndpoint {
 impl HostConnectDpsEndpoint {
     async fn inner_execute(
         &mut self,
-        _shared: &CheckerShared,
+        shared: &CheckerShared,
         cache: &mut CheckerCache,
     ) -> Result<CheckResult> {
         use aziot_identityd_config::ProvisioningType;
@@ -64,8 +64,12 @@ impl HostConnectDpsEndpoint {
                 )
             })?;
 
-        // TODO: add proxy support once is supported in identityd
-        crate::internal::common::resolve_and_tls_handshake(dps_endpoint, dps_hostname).await?;
+        crate::internal::common::resolve_and_tls_handshake(
+            dps_endpoint,
+            dps_hostname,
+            shared.cfg.proxy_uri.clone(),
+        )
+        .await?;
 
         Ok(CheckResult::Ok)
     }

--- a/aziotctl/src/internal/check/checks/host_connect_iothub.rs
+++ b/aziotctl/src/internal/check/checks/host_connect_iothub.rs
@@ -116,9 +116,12 @@ impl HostConnectIotHub {
             .parse::<hyper::Uri>()
             .context("Invalid URL specified in provisioning.iothub_hostname")?;
 
-        // TODO: add proxy support once is supported in identityd
-        crate::internal::common::resolve_and_tls_handshake(iothub_hostname_url, &iothub_hostname)
-            .await?;
+        crate::internal::common::resolve_and_tls_handshake(
+            iothub_hostname_url,
+            &iothub_hostname,
+            shared.cfg.proxy_uri.clone(),
+        )
+        .await?;
 
         Ok(CheckResult::Ok)
     }

--- a/aziotctl/src/internal/check/mod.rs
+++ b/aziotctl/src/internal/check/mod.rs
@@ -30,6 +30,10 @@ pub struct CheckerCfg {
     /// If using manual provisioning, this does not need to be specified.
     #[structopt(long, value_name = "IOTHUB_HOSTNAME")]
     pub iothub_hostname: Option<String>,
+
+    /// Sets the proxy URI that this device would use to connect to Azure DPS and IoTHub endpoints.
+    #[structopt(long, value_name = "PROXY_URI")]
+    pub proxy_uri: Option<hyper::Uri>,
 }
 
 pub struct CheckerShared {

--- a/aziotctl/src/internal/common.rs
+++ b/aziotctl/src/internal/common.rs
@@ -72,12 +72,16 @@ impl CertificateValidity {
     }
 }
 
-pub async fn resolve_and_tls_handshake(endpoint: hyper::Uri, hostname_display: &str) -> Result<()> {
+pub async fn resolve_and_tls_handshake(
+    endpoint: hyper::Uri,
+    hostname_display: &str,
+    proxy_uri: Option<hyper::Uri>,
+) -> Result<()> {
     use hyper::service::Service;
 
     // we don't actually care about the stream that gets returned. All we care about
     // is whether or not the TLS handshake was successful
-    let _ = hyper_openssl::HttpsConnector::new()
+    let _ = http_common::MaybeProxyConnector::new(proxy_uri, None, &[])
         .with_context(|| {
             anyhow!(
                 "Could not connect to {} : could not create TLS connector",


### PR DESCRIPTION
The proxy parameter will be passed in via command line argument, since the configuration doesn't contain this information.
This will also be useful to wire up proxy URI passed in from the iotedge check tool (which is read from the Edge runtime configuration).