### PR TITLE
Add `aziotctl config mp` to create a super-config with a manual-provisioning connection string.

### DIFF
--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -5,8 +5,6 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-// TODO: Move this to aziotctl-common
-
 /// This is the config stored in `/etc/aziot/config.toml`
 ///
 /// It is an amalgam of the individual services' configs, with some tweaks:

--- a/aziotctl/src/config/apply.rs
+++ b/aziotctl/src/config/apply.rs
@@ -15,7 +15,12 @@ use aziotctl_common::config as common_config;
 #[derive(structopt::StructOpt)]
 pub(crate) struct Options {
     /// The path of the config file.
-    #[structopt(long, value_name = "CONFIG", default_value = "/etc/aziot/config.toml")]
+    #[structopt(
+        short = "-c",
+        long,
+        value_name = "CONFIG",
+        default_value = "/etc/aziot/config.toml"
+    )]
     config: std::path::PathBuf,
 }
 

--- a/aziotctl/src/config/mod.rs
+++ b/aziotctl/src/config/mod.rs
@@ -1,15 +1,20 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 mod apply;
+mod mp;
 
 #[derive(structopt::StructOpt)]
 pub(crate) enum Options {
     /// Apply the configuration to the Azure IoT Identity Service and related services.
     Apply(apply::Options),
+
+    /// Quick-create a new configuration for manual provisioning with a connection string.
+    Mp(mp::Options),
 }
 
 pub(crate) fn run(options: Options) -> anyhow::Result<()> {
     match options {
         Options::Apply(options) => apply::run(options),
+        Options::Mp(options) => mp::run(options),
     }
 }

--- a/aziotctl/src/config/mp.rs
+++ b/aziotctl/src/config/mp.rs
@@ -24,7 +24,7 @@ pub(crate) struct Options {
     out_config_file: std::path::PathBuf,
 
     /// Overwrite the new configuration file if it already exists
-    #[structopt(short = "f", long, value_name = "FILE")]
+    #[structopt(short = "f", long)]
     force: bool,
 }
 

--- a/aziotctl/src/config/mp.rs
+++ b/aziotctl/src/config/mp.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+//! This subcommand takes a connection string and writes out the super-config file
+//! configured to use manual provisioning with that connection string.
+//! All other settings are left as their defaults.
+
+use anyhow::{anyhow, Context};
+
+use aziotctl_common::config as common_config;
+
+#[derive(structopt::StructOpt)]
+pub(crate) struct Options {
+    /// The connection string
+    #[structopt(short = "c", long, value_name = "CONNECTION_STRING")]
+    connection_string: String,
+
+    /// The path of the system configuration file to write to
+    #[structopt(
+        short = "o",
+        long,
+        value_name = "FILE",
+        default_value = "/etc/aziot/config.toml"
+    )]
+    out_config_file: std::path::PathBuf,
+
+    /// Overwrite the new configuration file if it already exists
+    #[structopt(short = "f", long, value_name = "FILE")]
+    force: bool,
+}
+
+pub(crate) fn run(options: Options) -> anyhow::Result<()> {
+    let Options {
+        connection_string,
+        out_config_file,
+        force,
+    } = options;
+
+    if !force && out_config_file.exists() {
+        return Err(anyhow!(
+            "\
+File {} already exists. Azure IoT Identity Service has already been configured.
+
+To have the configuration take effect, run:
+
+    aziotctl config apply
+
+To reconfigure IoT Identity Service, run:
+
+    aziotctl config mp --force
+",
+            out_config_file.display()
+        ));
+    }
+
+    let config = common_config::super_config::Config {
+        hostname: None,
+
+        provisioning: common_config::super_config::Provisioning {
+            always_reprovision_on_startup: false,
+            provisioning: common_config::super_config::ProvisioningType::Manual {
+                inner: common_config::super_config::ManualProvisioning::ConnectionString {
+                    connection_string,
+                },
+            },
+        },
+
+        localid: None,
+
+        aziot_keys: Default::default(),
+
+        preloaded_keys: Default::default(),
+
+        cert_issuance: Default::default(),
+
+        preloaded_certs: Default::default(),
+
+        endpoints: Default::default(),
+    };
+    let config = toml::to_vec(&config).context("could not serialize system config")?;
+
+    let user = nix::unistd::User::from_uid(nix::unistd::Uid::current())
+        .context("could not query current user information")?
+        .ok_or_else(|| anyhow!("could not query current user information"))?;
+
+    common_config::write_file(&out_config_file, &config, &user, 0o0600)?;
+
+    println!("Azure IoT Identity Service has been configured successfully!");
+    println!(
+        "The configuration has been written to {}",
+        out_config_file.display()
+    );
+    println!("To apply the new configuration to services, run:");
+    println!();
+    println!(
+        "    aziotctl config apply -c '{}'",
+        out_config_file.display()
+    );
+
+    Ok(())
+}

--- a/http-common/src/proxy.rs
+++ b/http-common/src/proxy.rs
@@ -159,14 +159,6 @@ fn identity_to_tls_connector(
 
     tls_connector.set_private_key(key)?;
 
-    // TODO: This disables HTTP/2 by explicitly setting the ALPN to "http/1.1"
-    // This is needed for nested Edge where IS talks to Edge Hub, because
-    // Edge Hub supports HTTP/2.
-    //
-    // The proper fix for this would be to enable HTTP/2 in the hyper client,
-    // but that didn't work for some reason and needs investigation.
-    tls_connector.set_alpn_protos(b"\x08http/1.1")?;
-
     Ok(tls_connector)
 }
 


### PR DESCRIPTION
Other changes:

- Remove leftover TODO in super_config.rs

- Remove another piece of code that disabled HTTP/2 that
  38075501330c10516312699ebbf2b657ebb15b58 forgot to revert.