### PR TITLE
Add check up_to_date_configs

### DIFF
--- a/aziotctl/aziotctl-common/src/check_last_modified.rs
+++ b/aziotctl/aziotctl-common/src/check_last_modified.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use std::fs;
+use std::path::Path;
+
+pub enum CheckResult {
+    Ok,
+    Ignored,
+    Warning(String),
+    Failed(std::io::Error),
+}
+
+pub fn check_last_modified(services: &[&str]) -> CheckResult {
+    let config = Path::new("/etc/aziot/config.toml");
+
+    if !config.exists() {
+        return CheckResult::Ignored;
+    }
+
+    let config_metadata = match fs::metadata(config) {
+        Ok(m) => m,
+        Err(err) => return CheckResult::Failed(err),
+    };
+
+    let config_last_modified = config_metadata
+        .modified()
+        .expect("file metadata should contain valid last_modified");
+
+    for service in services {
+        let service_config = format!("/etc/aziot/{}/config.d/00-super.toml", service);
+        let service_config = Path::new(&service_config);
+
+        if !service_config.exists() {
+            return CheckResult::Warning(format!(
+                "{} does not exist.\n\
+                Did you run 'iotedge config apply'?",
+                service_config.display()
+            ));
+        }
+
+        let service_config_metadata = match fs::metadata(service_config) {
+            Ok(m) => m,
+            Err(err) => return CheckResult::Failed(err),
+        };
+
+        let service_config_last_modified = service_config_metadata
+            .modified()
+            .expect("file metadata should contain valid last_modified");
+
+        if config_last_modified > service_config_last_modified {
+            return CheckResult::Warning(format!(
+                "{} was modified after {}'s config\n\
+                You must run 'iotedge config apply' to update {}'s config with the latest config.toml",
+                config.display(),
+                service,
+                service
+            ));
+        }
+    }
+
+    CheckResult::Ok
+}

--- a/aziotctl/aziotctl-common/src/check_last_modified.rs
+++ b/aziotctl/aziotctl-common/src/check_last_modified.rs
@@ -33,8 +33,9 @@ pub fn check_last_modified(services: &[&str]) -> CheckResult {
         if !service_config.exists() {
             return CheckResult::Warning(format!(
                 "{} does not exist.\n\
-                Did you run 'iotedge config apply'?",
-                service_config.display()
+                Did you run '{} config apply'?",
+                service_config.display(),
+                super::program_name()
             ));
         }
 
@@ -50,9 +51,10 @@ pub fn check_last_modified(services: &[&str]) -> CheckResult {
         if config_last_modified > service_config_last_modified {
             return CheckResult::Warning(format!(
                 "{} was modified after {}'s config\n\
-                You must run 'iotedge config apply' to update {}'s config with the latest config.toml",
+                You must run '{} config apply' to update {}'s config with the latest config.toml",
                 config.display(),
                 service,
+                super::program_name(),
                 service
             ));
         }

--- a/aziotctl/aziotctl-common/src/lib.rs
+++ b/aziotctl/aziotctl-common/src/lib.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
+pub mod check_last_modified;
 pub mod config;
 mod restart;
 mod set_log_level;

--- a/aziotctl/src/internal/check/checks/mod.rs
+++ b/aziotctl/src/internal/check/checks/mod.rs
@@ -22,6 +22,7 @@ mod host_connect_dps_endpoint;
 mod host_connect_iothub;
 mod host_local_time;
 mod hostname;
+mod up_to_date_configs;
 mod well_formed_configs;
 
 pub fn all_checks() -> Vec<(&'static str, Vec<Box<dyn Checker>>)> {
@@ -30,6 +31,7 @@ pub fn all_checks() -> Vec<(&'static str, Vec<Box<dyn Checker>>)> {
         ("Configuration checks", {
             let mut v: Vec<Box<dyn Checker>> = Vec::new();
             v.extend(well_formed_configs::well_formed_configs());
+            v.push(Box::new(up_to_date_configs::UpToDateConfigs::default()));
             v.push(Box::new(hostname::Hostname::default()));
             // TODO: add aziotd version info to https://github.com/Azure/azure-iotedge
             // v.push(Box::new(aziotd_version::AziotdVersion::default()));

--- a/aziotctl/src/internal/check/checks/up_to_date_configs.rs
+++ b/aziotctl/src/internal/check/checks/up_to_date_configs.rs
@@ -25,7 +25,7 @@ impl Checker for UpToDateConfigs {
             InternalCheckResult::Ok => CheckResult::Ok,
             InternalCheckResult::Ignored => CheckResult::Ignored,
             InternalCheckResult::Warning(message) => CheckResult::Warning(anyhow!(message)),
-            InternalCheckResult::Failed(error) => CheckResult::Failed(error.into())
+            InternalCheckResult::Failed(error) => CheckResult::Failed(error.into()),
         }
     }
 }

--- a/aziotctl/src/internal/check/checks/up_to_date_configs.rs
+++ b/aziotctl/src/internal/check/checks/up_to_date_configs.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use anyhow::anyhow;
+use serde::Serialize;
+
+use aziotctl_common::check_last_modified::check_last_modified;
+use aziotctl_common::check_last_modified::CheckResult as InternalCheckResult;
+
+use crate::internal::check::{CheckResult, Checker, CheckerCache, CheckerMeta, CheckerShared};
+
+#[derive(Serialize, Default)]
+pub struct UpToDateConfigs {}
+
+#[async_trait::async_trait]
+impl Checker for UpToDateConfigs {
+    fn meta(&self) -> CheckerMeta {
+        CheckerMeta {
+            id: "configs-up-to-date",
+            description: "daemon configurations up-to-date with config.toml",
+        }
+    }
+
+    async fn execute(&mut self, _shared: &CheckerShared, _cache: &mut CheckerCache) -> CheckResult {
+        match check_last_modified(&["keyd", "certd", "identityd", "tpmd"]) {
+            InternalCheckResult::Ok => CheckResult::Ok,
+            InternalCheckResult::Ignored => CheckResult::Ignored,
+            InternalCheckResult::Warning(message) => CheckResult::Warning(anyhow!(message)),
+            InternalCheckResult::Failed(error) => CheckResult::Failed(error.into())
+        }
+    }
+}


### PR DESCRIPTION
This check verifies that the super config files (`/etc/aziot/*/config.d/00-super.toml`) have a `last_modified` after `/etc/aziot/config.toml`. Prints a warning if `config.toml` was modified after `00-super.toml`, since that means the user probably forgot to run `aziotctl config apply` after updating `config.toml`.

Example message:
```
‼ daemon configurations up-to-date with config.toml - Warning
    /etc/aziot/config.toml was modified after keyd's config
    You must run 'aziotctl config apply' to update keyd's config with the latest config.toml
```