### PR TITLE
Enable scheduled E2E tests GH Actions workflow.

### DIFF
--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         branch:
         - 'main'
-
+        - 'release/1.2'
         os:
         - 'centos:7'
         - 'debian:9'
@@ -34,6 +34,8 @@ jobs:
         - 'manual-x509'
         - 'dps-symmetric-key'
         - 'dps-x509'
+
+      max-parallel: 10
 
     steps:
     - uses: 'actions/checkout@v1'

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -19,7 +19,7 @@ get_package() {
         return
     fi
 
-    # The download-artifact does not have a way to download artifacts from other workflows.
+    # The download-artifact action does not have a way to download artifacts from other workflows.
     # Ref: https://github.com/actions/download-artifact/issues/3
     #
     # So instead we use the GitHub API ourselves.
@@ -41,12 +41,12 @@ get_package() {
     # Get workflow runs for this branch and pick the latest one (the first one).
     # From that, get the artifacts URL.
     #
-    # Ref: https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-workflow-runs
+    # Ref: https://docs.github.com/en/rest/reference/actions#list-workflow-runs
     echo "Getting latest workflow run's artifacts URL..." >&2
     artifacts_url="$(
         github_curl -L \
             -H 'accept: application/vnd.github.v3+json' \
-            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/workflows/packages.yaml/runs?branch=$BRANCH&event=push&status=success" |
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/workflows/packages.yaml/runs?branch=${BRANCH//\//%2f}&event=push&status=success" |
             jq -r '.workflow_runs[0].artifacts_url'
     )"
     if [ "$artifacts_url" = 'null' ]; then


### PR DESCRIPTION
- Limit parallelism to 10 to limit the number of concurrent IoT Hubs.

- Enable the workflow on the release/1.2 branch.