### PR TITLE
Add aziotctl system reprovision command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,8 +90,6 @@ dependencies = [
  "http-common",
  "hyper",
  "percent-encoding",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -236,6 +234,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aziot-identity-client-async"
+version = "0.1.0"
+dependencies = [
+ "aziot-identity-common-http",
+ "http",
+ "http-common",
+ "hyper",
+]
+
+[[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
 dependencies = [
@@ -330,8 +338,6 @@ dependencies = [
  "http-common",
  "hyper",
  "percent-encoding",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -485,9 +491,6 @@ dependencies = [
  "http",
  "http-common",
  "hyper",
- "percent-encoding",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -581,6 +584,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
+ "aziot-identity-client-async",
+ "aziot-identity-common-http",
  "aziot-identityd-config",
  "aziot-keyd-config",
  "aziot-keys-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
 	"identity/aziot-cloud-client-async-common",
 	"identity/aziot-dps-client-async",
 	"identity/aziot-hub-client-async",
+	"identity/aziot-identity-client-async",
 	"identity/aziot-identity-common",
 	"identity/aziot-identity-common-http",
 	"identity/aziot-identityd",

--- a/aziotctl/aziotctl-common/Cargo.toml
+++ b/aziotctl/aziotctl-common/Cargo.toml
@@ -16,6 +16,8 @@ url = { version = "2", features = ["serde"] }
 
 aziot-certd-config = { path = "../../cert/aziot-certd-config" }
 aziot-identityd-config = { path = "../../identity/aziot-identityd-config" }
+aziot-identity-client-async = { path = "../../identity/aziot-identity-client-async" }
+aziot-identity-common-http = { path = "../../identity/aziot-identity-common-http" }
 aziot-keyd-config = { path = "../../key/aziot-keyd-config" }
 aziot-keys-common = { path = "../../key/aziot-keys-common", features = ["serde"] }
 aziot-tpmd-config = { path = "../../tpm/aziot-tpmd-config" }

--- a/aziotctl/aziotctl-common/src/lib.rs
+++ b/aziotctl/aziotctl-common/src/lib.rs
@@ -20,11 +20,13 @@ use serde::{Deserialize, Serialize};
 
 pub mod check_last_modified;
 pub mod config;
+mod reprovision;
 mod restart;
 mod set_log_level;
 mod status;
 mod system_logs;
 
+pub use reprovision::reprovision;
 pub use restart::restart;
 pub use set_log_level::set_log_level;
 pub use status::get_status;

--- a/aziotctl/aziotctl-common/src/reprovision.rs
+++ b/aziotctl/aziotctl-common/src/reprovision.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use anyhow::{anyhow, Result};
+
+pub async fn reprovision(uri: &url::Url) -> Result<()> {
+    let connector =
+        http_common::Connector::new(&uri).map_err(|err| anyhow!("Invalid uri {}: {}", uri, err))?;
+    let client = aziot_identity_client_async::Client::new(
+        aziot_identity_common_http::ApiVersion::V2020_09_01,
+        connector,
+    );
+
+    match client.reprovision().await {
+        Ok(_) => {
+            println!("Successfully reprovisioned with IoT Hub.");
+            Ok(())
+        }
+
+        Err(err) => {
+            return Err(anyhow!("Failed to reprovision: {}", err));
+        }
+    }
+}

--- a/aziotctl/aziotctl-common/src/reprovision.rs
+++ b/aziotctl/aziotctl-common/src/reprovision.rs
@@ -16,8 +16,6 @@ pub async fn reprovision(uri: &url::Url) -> Result<()> {
             Ok(())
         }
 
-        Err(err) => {
-            return Err(anyhow!("Failed to reprovision: {}", err));
-        }
+        Err(err) => Err(anyhow!("Failed to reprovision: {}", err)),
     }
 }

--- a/aziotctl/aziotctl-common/src/reprovision.rs
+++ b/aziotctl/aziotctl-common/src/reprovision.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 
 pub async fn reprovision(uri: &url::Url) -> Result<()> {
     let connector =
-        http_common::Connector::new(&uri).map_err(|err| anyhow!("Invalid uri {}: {}", uri, err))?;
+        http_common::Connector::new(uri).map_err(|err| anyhow!("Invalid URI {}: {}", uri, err))?;
     let client = aziot_identity_client_async::Client::new(
         aziot_identity_common_http::ApiVersion::V2020_09_01,
         connector,

--- a/aziotctl/src/main.rs
+++ b/aziotctl/src/main.rs
@@ -28,7 +28,7 @@ async fn try_main() -> Result<()> {
         Options::Check(cfg) => check::check(cfg).await?,
         Options::CheckList(cfg) => check_list::check_list(cfg)?,
         Options::Config(cfg) => config::run(cfg)?,
-        Options::System(cfg) => system::system(cfg)?,
+        Options::System(cfg) => system::system(cfg).await?,
     }
 
     Ok(())

--- a/aziotctl/src/system.rs
+++ b/aziotctl/src/system.rs
@@ -46,7 +46,7 @@ pub struct LogLevelOptions {
 pub struct ReprovisionOptions {
     #[structopt(
         value_name = "Identity Service URI",
-        long = "--uri",
+        long,
         default_value = "unix:///var/run/aziot/identityd.sock"
     )]
     uri: url::Url,

--- a/cert/aziot-cert-client-async/Cargo.toml
+++ b/cert/aziot-cert-client-async/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2018"
 http = "0.2"
 hyper = "0.14"
 percent-encoding = "2"
-serde = "1"
-serde_json = "1"
 
 aziot-cert-common-http = { path = "../aziot-cert-common-http" }
 aziot-key-common = { path = "../../key/aziot-key-common" }

--- a/cert/aziot-cert-client-async/src/lib.rs
+++ b/cert/aziot-cert-client-async/src/lib.rs
@@ -3,12 +3,9 @@
 #![deny(rust_2018_idioms)]
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(
-    clippy::default_trait_access,
-    clippy::let_and_return,
     clippy::let_unit_value,
     clippy::missing_errors_doc,
-    clippy::must_use_candidate,
-    clippy::similar_names
+    clippy::must_use_candidate
 )]
 
 #[derive(Debug)]
@@ -43,7 +40,7 @@ impl Client {
             }),
         };
 
-        let res: aziot_cert_common_http::get_cert::Response = request(
+        let res: aziot_cert_common_http::get_cert::Response = http_common::request(
             &self.inner,
             http::Method::POST,
             &format!("http://foo/certificates?api-version={}", self.api_version),
@@ -58,7 +55,7 @@ impl Client {
             pem: aziot_cert_common_http::Pem(pem.to_owned()),
         };
 
-        let res: aziot_cert_common_http::import_cert::Response = request(
+        let res: aziot_cert_common_http::import_cert::Response = http_common::request(
             &self.inner,
             http::Method::PUT,
             &format!(
@@ -76,7 +73,7 @@ impl Client {
     }
 
     pub async fn get_cert(&self, id: &str) -> Result<Vec<u8>, std::io::Error> {
-        let res: aziot_cert_common_http::get_cert::Response = request::<(), _>(
+        let res: aziot_cert_common_http::get_cert::Response = http_common::request::<(), _>(
             &self.inner,
             http::Method::GET,
             &format!(
@@ -94,7 +91,7 @@ impl Client {
     }
 
     pub async fn delete_cert(&self, id: &str) -> Result<(), std::io::Error> {
-        let () = request_no_content::<()>(
+        let () = http_common::request_no_content::<()>(
             &self.inner,
             http::Method::DELETE,
             &format!(
@@ -109,173 +106,5 @@ impl Client {
         )
         .await?;
         Ok(())
-    }
-}
-
-async fn request<TRequest, TResponse>(
-    client: &hyper::Client<http_common::Connector, hyper::Body>,
-    method: http::Method,
-    uri: &str,
-    body: Option<&TRequest>,
-) -> std::io::Result<TResponse>
-where
-    TRequest: serde::Serialize,
-    TResponse: serde::de::DeserializeOwned,
-{
-    let req = hyper::Request::builder().method(method).uri(uri);
-    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let req = if let Some(body) = body {
-        let body = serde_json::to_vec(body)
-            .expect("serializing request body to JSON cannot fail")
-            .into();
-        req.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        req.body(Default::default())
-    };
-    let req = req.expect("cannot fail to create hyper request");
-
-    let res = client
-        .request(req)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let (
-        http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
-        },
-        body,
-    ) = res.into_parts();
-
-    let mut is_json = false;
-    for (header_name, header_value) in headers {
-        if header_name == Some(hyper::header::CONTENT_TYPE) {
-            let value = header_value
-                .to_str()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            if value == "application/json" {
-                is_json = true;
-            }
-        }
-    }
-
-    if !is_json {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "malformed HTTP response",
-        ));
-    }
-
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let res: TResponse = match res_status_code {
-        hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
-            let res = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            res
-        }
-
-        res_status_code
-            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-        {
-            let res: http_common::ErrorBody<'static> = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
-        }
-
-        _ => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "malformed HTTP response",
-            ))
-        }
-    };
-    Ok(res)
-}
-
-async fn request_no_content<TRequest>(
-    client: &hyper::Client<http_common::Connector, hyper::Body>,
-    method: http::Method,
-    uri: &str,
-    body: Option<&TRequest>,
-) -> std::io::Result<()>
-where
-    TRequest: serde::Serialize,
-{
-    let req = hyper::Request::builder().method(method).uri(uri);
-    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let req = if let Some(body) = body {
-        let body = serde_json::to_vec(body)
-            .expect("serializing request body to JSON cannot fail")
-            .into();
-        req.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        req.body(Default::default())
-    };
-    let req = req.expect("cannot fail to create hyper request");
-
-    let res = client
-        .request(req)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let (
-        http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
-        },
-        body,
-    ) = res.into_parts();
-
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    match res_status_code {
-        hyper::StatusCode::NO_CONTENT => Ok(()),
-
-        res_status_code
-            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-        {
-            let mut is_json = false;
-            for (header_name, header_value) in headers {
-                if header_name == Some(hyper::header::CONTENT_TYPE) {
-                    let value = header_value
-                        .to_str()
-                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                    if value == "application/json" {
-                        is_json = true;
-                    }
-                }
-            }
-
-            if !is_json {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "malformed HTTP response",
-                ));
-            }
-
-            let res: http_common::ErrorBody<'static> = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
-        }
-
-        _ => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "malformed HTTP response",
-        )),
     }
 }

--- a/docs/identity-service.md
+++ b/docs/identity-service.md
@@ -414,7 +414,7 @@ The `type` query parameter specifies the identity type to return. Accepted value
 #### Response
 
 ```
-200 Ok
+204 No Content
 ```
 
 ---

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -26,6 +26,9 @@ mod proxy;
 #[cfg(feature = "tokio1")]
 pub use proxy::{get_proxy_uri, MaybeProxyConnector};
 
+mod request;
+pub use request::{request, request_no_content};
+
 pub mod server;
 
 #[cfg(feature = "tokio1")]

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -26,7 +26,9 @@ mod proxy;
 #[cfg(feature = "tokio1")]
 pub use proxy::{get_proxy_uri, MaybeProxyConnector};
 
+#[cfg(feature = "tokio1")]
 mod request;
+#[cfg(feature = "tokio1")]
 pub use request::{request, request_no_content};
 
 pub mod server;

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+pub async fn request<TRequest, TResponse>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: &str,
+    body: Option<&TRequest>,
+) -> std::io::Result<TResponse>
+where
+    TRequest: serde::Serialize,
+    TResponse: serde::de::DeserializeOwned,
+{
+    let req = hyper::Request::builder().method(method).uri(uri);
+    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
+    //
+    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
+    #[allow(clippy::option_if_let_else)]
+    let req = if let Some(body) = body {
+        let body = serde_json::to_vec(body)
+            .expect("serializing request body to JSON cannot fail")
+            .into();
+        req.header(hyper::header::CONTENT_TYPE, "application/json")
+            .body(body)
+    } else {
+        req.body(Default::default())
+    };
+    let req = req.expect("cannot fail to create hyper request");
+
+    let res = client
+        .request(req)
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+    let (
+        http::response::Parts {
+            status: res_status_code,
+            headers,
+            ..
+        },
+        body,
+    ) = res.into_parts();
+
+    let mut is_json = false;
+    for (header_name, header_value) in headers {
+        if header_name == Some(hyper::header::CONTENT_TYPE) {
+            let value = header_value
+                .to_str()
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            if value == "application/json" {
+                is_json = true;
+            }
+        }
+    }
+
+    if !is_json {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "malformed HTTP response",
+        ));
+    }
+
+    let body = hyper::body::to_bytes(body)
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+    let res: TResponse = match res_status_code {
+        hyper::StatusCode::OK => {
+            let res = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            res
+        }
+
+        res_status_code
+            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
+        {
+            let res: super::ErrorBody<'static> = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
+        }
+
+        _ => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "malformed HTTP response",
+            ))
+        }
+    };
+    Ok(res)
+}
+
+pub async fn request_no_content<TRequest>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: &str,
+    body: Option<&TRequest>,
+) -> std::io::Result<()>
+where
+    TRequest: serde::Serialize,
+{
+    let req = hyper::Request::builder().method(method).uri(uri);
+    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
+    //
+    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
+    #[allow(clippy::option_if_let_else)]
+    let req = if let Some(body) = body {
+        let body = serde_json::to_vec(body)
+            .expect("serializing request body to JSON cannot fail")
+            .into();
+        req.header(hyper::header::CONTENT_TYPE, "application/json")
+            .body(body)
+    } else {
+        req.body(Default::default())
+    };
+    let req = req.expect("cannot fail to create hyper request");
+
+    let res = client
+        .request(req)
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+    let (
+        http::response::Parts {
+            status: res_status_code,
+            headers,
+            ..
+        },
+        body,
+    ) = res.into_parts();
+
+    let body = hyper::body::to_bytes(body)
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+    match res_status_code {
+        hyper::StatusCode::NO_CONTENT => Ok(()),
+
+        res_status_code
+            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
+        {
+            let mut is_json = false;
+            for (header_name, header_value) in headers {
+                if header_name == Some(hyper::header::CONTENT_TYPE) {
+                    let value = header_value
+                        .to_str()
+                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                    if value == "application/json" {
+                        is_json = true;
+                    }
+                }
+            }
+
+            if !is_json {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "malformed HTTP response",
+                ));
+            }
+
+            let res: super::ErrorBody<'static> = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
+        }
+
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "malformed HTTP response",
+        )),
+    }
+}

--- a/identity/aziot-identity-client-async/Cargo.toml
+++ b/identity/aziot-identity-client-async/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aziot-identity-client-async"
+version = "0.1.0"
+authors = ["Azure IoT Edge Devs"]
+edition = "2018"
+
+[dependencies]
+http = "0.2"
+hyper = "0.14"
+
+aziot-identity-common-http = { path = "../aziot-identity-common-http" }
+http-common = { path = "../../http-common", features = ["tokio1"] }

--- a/identity/aziot-identity-client-async/src/lib.rs
+++ b/identity/aziot-identity-client-async/src/lib.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::must_use_candidate, clippy::missing_errors_doc)]
+
+#[derive(Debug)]
+pub struct Client {
+    api_version: aziot_identity_common_http::ApiVersion,
+    inner: hyper::Client<http_common::Connector, hyper::Body>,
+}
+
+impl Client {
+    pub fn new(
+        api_version: aziot_identity_common_http::ApiVersion,
+        connector: http_common::Connector,
+    ) -> Self {
+        let inner = hyper::Client::builder().build(connector);
+        Client { api_version, inner }
+    }
+
+    pub async fn reprovision(&self) -> Result<(), std::io::Error> {
+        let body = aziot_identity_common_http::reprovision_device::Request {
+            id_type: "aziot".to_owned(),
+        };
+
+        http_common::request_no_content(
+            &self.inner,
+            http::Method::POST,
+            &format!(
+                "http://foo/identities/device/reprovision?api-version={}",
+                self.api_version
+            ),
+            Some(&body),
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -383,6 +383,15 @@ impl Api {
                     .await?
             }
             ReprovisionTrigger::Api => {
+                // Clear the backed up device state before reprovisioning.
+                // If this fails, log a warning but continue with reprovisioning.
+                let mut backup_file = self.settings.homedir.clone();
+                backup_file.push("device_info");
+
+                if let Err(err) = std::fs::remove_file(backup_file) {
+                    log::warn!("Failed to clear device state before reprovisioning: {}", err);
+                }
+
                 self.id_manager
                     .provision_device(self.settings.provisioning.clone(), false)
                     .await?

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -389,7 +389,10 @@ impl Api {
                 backup_file.push("device_info");
 
                 if let Err(err) = std::fs::remove_file(backup_file) {
-                    log::warn!("Failed to clear device state before reprovisioning: {}", err);
+                    log::warn!(
+                        "Failed to clear device state before reprovisioning: {}",
+                        err
+                    );
                 }
 
                 self.id_manager

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -389,10 +389,12 @@ impl Api {
                 backup_file.push("device_info");
 
                 if let Err(err) = std::fs::remove_file(backup_file) {
-                    log::warn!(
-                        "Failed to clear device state before reprovisioning: {}",
-                        err
-                    );
+                    if err.kind() != std::io::ErrorKind::NotFound {
+                        log::warn!(
+                            "Failed to clear device state before reprovisioning: {}",
+                            err
+                        );
+                    }
                 }
 
                 self.id_manager

--- a/key/aziot-key-client-async/Cargo.toml
+++ b/key/aziot-key-client-async/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2018"
 http = "0.2"
 hyper = "0.14"
 percent-encoding = "2"
-serde = "1"
-serde_json = "1"
 
 http-common = { path = "../../http-common", features = ["tokio1"] }
 aziot-key-common = { path = "../aziot-key-common" }

--- a/tpm/aziot-tpm-client-async/Cargo.toml
+++ b/tpm/aziot-tpm-client-async/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2018"
 [dependencies]
 http = "0.2"
 hyper = "0.14"
-percent-encoding = "2"
-serde = "1"
-serde_json = "1"
 
 aziot-tpm-common = { path = "../aziot-tpm-common" }
 aziot-tpm-common-http = { path = "../aziot-tpm-common-http" }

--- a/tpm/aziot-tpm-client-async/src/lib.rs
+++ b/tpm/aziot-tpm-client-async/src/lib.rs
@@ -2,13 +2,7 @@
 
 #![deny(rust_2018_idioms)]
 #![warn(clippy::all, clippy::pedantic)]
-#![allow(
-    clippy::default_trait_access,
-    clippy::let_and_return,
-    clippy::missing_errors_doc,
-    clippy::must_use_candidate,
-    clippy::similar_names
-)]
+#![allow(clippy::missing_errors_doc, clippy::must_use_candidate)]
 
 #[derive(Debug)]
 pub struct Client {
@@ -28,7 +22,7 @@ impl Client {
     pub async fn get_tpm_keys(&self) -> std::io::Result<aziot_tpm_common::TpmKeys> {
         let body = aziot_tpm_common_http::get_tpm_keys::Request {};
 
-        let res: aziot_tpm_common_http::get_tpm_keys::Response = request(
+        let res: aziot_tpm_common_http::get_tpm_keys::Response = http_common::request(
             &self.inner,
             http::Method::GET,
             &format!("http://foo/get_tpm_keys?api-version={}", self.api_version),
@@ -46,7 +40,7 @@ impl Client {
             key: http_common::ByteString(key.as_ref().to_vec()),
         };
 
-        let _res: aziot_tpm_common_http::import_auth_key::Response = request(
+        let _res: aziot_tpm_common_http::import_auth_key::Response = http_common::request(
             &self.inner,
             http::Method::POST,
             &format!(
@@ -65,7 +59,7 @@ impl Client {
             data: http_common::ByteString(data.as_ref().to_vec()),
         };
 
-        let res: aziot_tpm_common_http::sign_with_auth_key::Response = request(
+        let res: aziot_tpm_common_http::sign_with_auth_key::Response = http_common::request(
             &self.inner,
             http::Method::POST,
             &format!(
@@ -77,92 +71,4 @@ impl Client {
         .await?;
         Ok(res.digest.0)
     }
-}
-
-async fn request<TRequest, TResponse>(
-    client: &hyper::Client<http_common::Connector, hyper::Body>,
-    method: http::Method,
-    uri: &str,
-    body: Option<&TRequest>,
-) -> std::io::Result<TResponse>
-where
-    TRequest: serde::Serialize,
-    TResponse: serde::de::DeserializeOwned,
-{
-    let req = hyper::Request::builder().method(method).uri(uri);
-    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let req = if let Some(body) = body {
-        let body = serde_json::to_vec(body)
-            .expect("serializing request body to JSON cannot fail")
-            .into();
-        req.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        req.body(Default::default())
-    };
-    let req = req.expect("cannot fail to create hyper request");
-
-    let res = client
-        .request(req)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let (
-        http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
-        },
-        body,
-    ) = res.into_parts();
-
-    let mut is_json = false;
-    for (header_name, header_value) in headers {
-        if header_name == Some(hyper::header::CONTENT_TYPE) {
-            let value = header_value
-                .to_str()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            if value == "application/json" {
-                is_json = true;
-            }
-        }
-    }
-
-    if !is_json {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "malformed HTTP response",
-        ));
-    }
-
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let res: TResponse = match res_status_code {
-        hyper::StatusCode::OK => {
-            let res = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            res
-        }
-
-        res_status_code
-            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-        {
-            let res: http_common::ErrorBody<'static> = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
-        }
-
-        _ => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "malformed HTTP response",
-            ))
-        }
-    };
-    Ok(res)
 }


### PR DESCRIPTION
Adds the `aziot system reprovision` command, which triggers the `/reprovision` API of Identity Service.

Also adds an async client for Identity Service. Currently only supports the `reprovision` API, as that's the only one used.