### PR TITLE
Lift key import out of `get_sas_connector`

### DIFF
--- a/identity/aziot-dps-client-async/src/lib.rs
+++ b/identity/aziot-dps-client-async/src/lib.rs
@@ -307,6 +307,9 @@ impl Client {
         let body = hyper::body::to_bytes(body)
             .await
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+        // Unlike IoT Hub, DPS responses don't contain any potentially sensitive
+        // credential info, so it's safe to log these bodies.
         log::debug!("DPS response body {:?}", body);
 
         let res: TResponse = match status {

--- a/identity/aziot-dps-client-async/src/lib.rs
+++ b/identity/aziot-dps-client-async/src/lib.rs
@@ -40,10 +40,7 @@ pub enum DpsAuthKind {
     Tpm,
     /// Used as part of a recursive call within `request`
     #[doc(hidden)]
-    TpmWithAuth {
-        // base64 encoded
-        auth_key: String,
-    },
+    TpmPostChallenge,
 }
 
 pub struct Client {
@@ -161,7 +158,7 @@ impl Client {
             .await;
         };
 
-        if matches!(auth_kind, DpsAuthKind::TpmWithAuth { .. }) {
+        if matches!(auth_kind, DpsAuthKind::TpmPostChallenge { .. }) {
             // import the returned authentication key into the TPM
             let auth_key = res
                 .registration_state
@@ -191,7 +188,7 @@ impl Client {
     // TPM provisioning has special 2-step challenge/response flow which is
     // basically identical to the symmetric key flow, except that the TPM client
     // is used instead of the key client. To keep things DRY, a recursive call
-    // is used, passing `DpsAuthKind::TpmWithAuth` as the auth kind.
+    // is used, passing `DpsAuthKind::TpmPostChallenge` as the auth kind.
     #[async_recursion::async_recursion]
     async fn request<TRequest, TResponse>(
         &self,
@@ -228,29 +225,33 @@ impl Client {
             DpsAuthKind::Tpm => {
                 http_common::MaybeProxyConnector::new(self.proxy_uri.clone(), None, &[])?
             }
-            DpsAuthKind::SymmetricKey { sas_key: key }
-            | DpsAuthKind::TpmWithAuth { auth_key: key } => {
+            DpsAuthKind::SymmetricKey { sas_key: key } => {
                 let audience = format!("{}/registrations/{}", self.scope_id, registration_id);
-                let (connector, token) = if matches!(auth_kind, DpsAuthKind::SymmetricKey { .. }) {
-                    get_sas_connector(
-                        &audience,
-                        &key,
-                        &*self.key_client,
-                        self.proxy_uri.clone(),
-                        false,
-                    )
-                    .await?
-                } else {
-                    get_sas_connector(
-                        &audience,
-                        &base64::decode(key)
-                            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
-                        &*self.tpm_client,
-                        self.proxy_uri.clone(),
-                        true,
-                    )
-                    .await?
-                };
+                let key_handle = self.key_client.load_key(key).await?;
+                let (connector, token) = get_sas_connector(
+                    &audience,
+                    key_handle,
+                    &*self.key_client,
+                    self.proxy_uri.clone(),
+                    false,
+                )
+                .await?;
+                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                req.headers_mut()
+                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
+                connector
+            }
+            DpsAuthKind::TpmPostChallenge => {
+                let audience = format!("{}/registrations/{}", self.scope_id, registration_id);
+                let (connector, token) = get_sas_connector(
+                    &audience,
+                    (),
+                    &*self.tpm_client,
+                    self.proxy_uri.clone(),
+                    true,
+                )
+                .await?;
 
                 let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
@@ -331,11 +332,15 @@ impl Client {
                 let reg_result: model::TpmRegistrationResult = serde_json::from_slice(&body)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
 
-                // update auth method
-                *auth_kind = DpsAuthKind::TpmWithAuth {
-                    auth_key: reg_result.authentication_key,
-                };
+                self.tpm_client
+                    .import_auth_key(
+                        base64::decode(reg_result.authentication_key)
+                            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
+                    )
+                    .await?;
 
+                // update auth method, and recurse
+                *auth_kind = DpsAuthKind::TpmPostChallenge;
                 return self
                     .request(registration_id, method, resource_uri, auth_kind, orig_body)
                     .await;

--- a/identity/aziot-dps-client-async/src/lib.rs
+++ b/identity/aziot-dps-client-async/src/lib.rs
@@ -308,10 +308,6 @@ impl Client {
             .await
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
 
-        // Unlike IoT Hub, DPS responses don't contain any potentially sensitive
-        // credential info, so it's safe to log these bodies.
-        log::debug!("DPS response body {:?}", body);
-
         let res: TResponse = match status {
             hyper::StatusCode::OK | hyper::StatusCode::ACCEPTED => {
                 if !is_json {

--- a/identity/aziot-hub-client-async/src/lib.rs
+++ b/identity/aziot-hub-client-async/src/lib.rs
@@ -191,9 +191,10 @@ impl Client {
                     "{}/devices/{}",
                     hub_device.iothub_hostname, hub_device.device_id
                 );
+                let key_handle = self.key_client.load_key(&key).await?;
                 let (connector, token) = get_sas_connector(
                     &audience,
-                    &key,
+                    key_handle,
                     &*self.key_client,
                     self.proxy_uri.clone(),
                     false,
@@ -213,7 +214,7 @@ impl Client {
                 );
                 let (connector, token) = get_sas_connector(
                     &audience,
-                    "",
+                    (),
                     &*self.tpm_client,
                     self.proxy_uri.clone(),
                     false,
@@ -275,6 +276,7 @@ impl Client {
         let body = hyper::body::to_bytes(body)
             .await
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+        log::debug!("IoTHub response body {:?}", body);
 
         let res: TResponse = match res_status_code {
             hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
@@ -346,9 +348,10 @@ impl Client {
                     "{}/devices/{}",
                     hub_device.iothub_hostname, hub_device.device_id
                 );
+                let key_handle = self.key_client.load_key(&key).await?;
                 let (connector, token) = get_sas_connector(
                     &audience,
-                    &key,
+                    key_handle,
                     &*self.key_client,
                     self.proxy_uri.clone(),
                     false,
@@ -368,7 +371,7 @@ impl Client {
                 );
                 let (connector, token) = get_sas_connector(
                     &audience,
-                    "",
+                    (),
                     &*self.tpm_client,
                     self.proxy_uri.clone(),
                     false,

--- a/identity/aziot-hub-client-async/src/lib.rs
+++ b/identity/aziot-hub-client-async/src/lib.rs
@@ -276,7 +276,6 @@ impl Client {
         let body = hyper::body::to_bytes(body)
             .await
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-        log::debug!("IoTHub response body {:?}", body);
 
         let res: TResponse = match res_status_code {
             hyper::StatusCode::OK | hyper::StatusCode::CREATED => {


### PR DESCRIPTION
This should fix the issue where module identities were not working with DPS-TPM provisioning.
I've also included some light refactoring, which should make the code a bit easier to grok in the future.