### PR TITLE
Remove always_reprovision_on_startup from Identity Service

### DIFF
--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -57,7 +57,6 @@ pub fn run(
 
     let provisioning = {
         let super_config::Provisioning {
-            always_reprovision_on_startup,
             provisioning,
         } = provisioning;
 
@@ -211,7 +210,6 @@ pub fn run(
         };
 
         aziot_identityd_config::Provisioning {
-            always_reprovision_on_startup,
             provisioning,
         }
     };

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -56,9 +56,7 @@ pub fn run(
     };
 
     let provisioning = {
-        let super_config::Provisioning {
-            provisioning,
-        } = provisioning;
+        let super_config::Provisioning { provisioning } = provisioning;
 
         let provisioning = match provisioning {
             super_config::ProvisioningType::Manual {
@@ -209,9 +207,7 @@ pub fn run(
             super_config::ProvisioningType::None => aziot_identityd_config::ProvisioningType::None,
         };
 
-        aziot_identityd_config::Provisioning {
-            provisioning,
-        }
+        aziot_identityd_config::Provisioning { provisioning }
     };
 
     let identityd_config = aziot_identityd_config::Settings {

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -49,9 +49,6 @@ pub struct Config {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Provisioning {
-    #[serde(default)]
-    pub always_reprovision_on_startup: bool,
-
     #[serde(flatten)]
     pub provisioning: ProvisioningType,
 }

--- a/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-tpm/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-tpm/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "0ab1234C5D6"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-connection-string/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-connection-string/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-symmetric-key/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-symmetric-key/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-pkcs11/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-pkcs11/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509/identityd.toml
@@ -2,7 +2,6 @@ hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "manual"
 iothub_hostname = "example.azure-devices.net"
 device_id = "my-device"

--- a/aziotctl/src/config/mp.rs
+++ b/aziotctl/src/config/mp.rs
@@ -56,7 +56,6 @@ To reconfigure IoT Identity Service, run:
         hostname: None,
 
         provisioning: common_config::super_config::Provisioning {
-            always_reprovision_on_startup: false,
             provisioning: common_config::super_config::ProvisioningType::Manual {
                 inner: common_config::super_config::ManualProvisioning::ConnectionString {
                     connection_string,

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -407,7 +407,6 @@ hostname = "$common_resource_name"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = true
 source = "manual"
 iothub_hostname = "$common_resource_name.azure-devices.net"
 device_id = "$iot_device_id"
@@ -481,7 +480,6 @@ hostname = "$common_resource_name"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = true
 source = "manual"
 iothub_hostname = "$common_resource_name.azure-devices.net"
 device_id = "$iot_device_id"
@@ -534,7 +532,6 @@ hostname = "$common_resource_name"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "$dps_scope_id"
@@ -656,7 +653,6 @@ hostname = "$common_resource_name"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = true
 source = "dps"
 global_endpoint = "https://global.azure-devices-provisioning.net/"
 scope_id = "$dps_scope_id"

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -88,18 +88,6 @@ pub enum DpsAttestationMethod {
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub struct Provisioning {
-    // This type used to have the `provisioning` field before the `always_reprovision_on_startup` field. It doesn't matter much except that the fields are
-    // serialized in the order of definition when generating a new config via `aziotctl config apply`, and it would've been nice to serialize
-    // the `provisioning` value before the `always_reprovision_on_startup` value.
-    //
-    // Unfortunately the TOML serializer needs "values" (like `always_reprovision_on_startup`) to come before "tables" (like `provisioning`),
-    // otherwise it fails to serialize the value. It ought to not matter for this type because the `provisioning` value is flattened,
-    // but the TOML serializer doesn't know this.
-    //
-    // So we have to move the `always_reprovision_on_startup` field before the `provisioning` field.
-    #[serde(default)]
-    pub always_reprovision_on_startup: bool,
-
     #[serde(flatten)]
     pub provisioning: ProvisioningType,
 }
@@ -165,8 +153,6 @@ mod tests {
     #[test]
     fn manual_sas_provisioning_settings_succeeds() {
         let s = load_settings("test/good_sas_config.toml").unwrap();
-
-        assert_eq!(s.provisioning.always_reprovision_on_startup, false);
 
         if !matches!(
             s.provisioning.provisioning,

--- a/identity/aziot-identityd-config/test/good_sas_config.toml
+++ b/identity/aziot-identityd-config/test/good_sas_config.toml
@@ -5,7 +5,6 @@ hostname = "iotedge"
 homedir = "/var/lib/aziot/identityd"
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "manual"
 iothub_hostname = "hubname"
 device_id = "deviceid"

--- a/identity/aziot-identityd/config/unix/default.toml
+++ b/identity/aziot-identityd/config/unix/default.toml
@@ -22,7 +22,6 @@ homedir = "/var/lib/aziot/identityd"
 
 
 # [provisioning]
-# always_reprovision_on_startup = false
 # source = "manual"
 # iothub_hostname = "hubname"
 # device_id = "deviceid"

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -405,7 +405,7 @@ impl Api {
                 self.id_manager
                     .provision_device(
                         self.settings.provisioning.clone(),
-                        !self.settings.provisioning.always_reprovision_on_startup,
+                        true,
                     )
                     .await?
             }

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -403,10 +403,7 @@ impl Api {
             }
             ReprovisionTrigger::Startup => {
                 self.id_manager
-                    .provision_device(
-                        self.settings.provisioning.clone(),
-                        true,
-                    )
+                    .provision_device(self.settings.provisioning.clone(), true)
                     .await?
             }
         };

--- a/identity/aziot-identityd/test/good_auth_settings.toml
+++ b/identity/aziot-identityd/test/good_auth_settings.toml
@@ -25,7 +25,6 @@ idtype = ["module", "local"]
 uid = 1003
 
 [provisioning]
-always_reprovision_on_startup = false
 source = "manual"
 iothub_hostname = "hubname"
 device_id = "deviceid"


### PR DESCRIPTION
Removes the `always_reprovision_on_startup` option from Identity Service. This will be replaced with aziot-edged's `AutoReprovisioningMode` setting.