### PR TITLE
Apply proxy to port 443 only

### DIFF
--- a/aziotctl/src/internal/check/checks/host_connect_iothub.rs
+++ b/aziotctl/src/internal/check/checks/host_connect_iothub.rs
@@ -116,10 +116,16 @@ impl HostConnectIotHub {
             .parse::<hyper::Uri>()
             .context("Invalid URL specified in provisioning.iothub_hostname")?;
 
+        let proxy = if self.port_number == 443 {
+            shared.cfg.proxy_uri.clone()
+        } else {
+            None
+        };
+
         crate::internal::common::resolve_and_tls_handshake(
             iothub_hostname_url,
             &iothub_hostname,
-            shared.cfg.proxy_uri.clone(),
+            proxy,
         )
         .await?;
 


### PR DESCRIPTION
Apply proxy to port 443 only

Test:
Tested in ISA95 environment.
- tested on top level with proxy
- tested on mid level without a proxy
- tested on bottom level with a proxy
Iotedge check is now green.