### PR TITLE
Reprovision when identity reconciliation fails

### DIFF
--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -516,7 +516,11 @@ impl IdentityManager {
                             self.get_backup_provisioning_info(credential.clone())?;
 
                         if skip_if_backup_is_valid && backup_device.is_some() {
-                            backup_device.expect("backup device cannot be none")
+                            let backup_device =
+                                backup_device.expect("backup device cannot be none");
+                            log::info!("Provisioned with backup for {}.", backup_device.device_id);
+
+                            backup_device
                         } else {
                             let operation = dps_client
                                 .register(&registration_id, &dps_auth_kind)
@@ -551,7 +555,11 @@ impl IdentityManager {
                             self.get_backup_provisioning_info(credential.clone())?;
 
                         if skip_if_backup_is_valid && backup_device.is_some() {
-                            backup_device.expect("backup device cannot be none")
+                            let backup_device =
+                                backup_device.expect("backup device cannot be none");
+                            log::info!("Provisioned with backup for {}.", backup_device.device_id);
+
+                            backup_device
                         } else {
                             let operation = dps_client
                                 .register(&registration_id, &dps_auth_kind)
@@ -569,7 +577,11 @@ impl IdentityManager {
                             self.get_backup_provisioning_info(credential.clone())?;
 
                         if skip_if_backup_is_valid && backup_device.is_some() {
-                            backup_device.expect("backup device cannot be none")
+                            let backup_device =
+                                backup_device.expect("backup device cannot be none");
+                            log::info!("Provisioned with backup for {}.", backup_device.device_id);
+
+                            backup_device
                         } else {
                             let operation = dps_client
                                 .register(&registration_id, &dps_auth_kind)

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -471,25 +471,6 @@ impl IdentityManager {
                 scope_id,
                 attestation,
             } => {
-                async fn operation_to_iot_hub_device(
-                    credentials: aziot_identity_common::Credentials,
-                    operation: aziot_dps_client_async::model::RegistrationOperationStatus,
-                ) -> Result<aziot_identity_common::IoTHubDevice, Error> {
-                    let status = operation.status;
-                    assert!(!status.eq_ignore_ascii_case("assigning"));
-
-                    let mut state = operation.registration_state.ok_or(Error::DeviceNotFound)?;
-                    let iothub_hostname = state.assigned_hub.get_or_insert("".into());
-                    let device_id = state.device_id.get_or_insert("".into());
-                    let device = aziot_identity_common::IoTHubDevice {
-                        iothub_hostname: iothub_hostname.clone(),
-                        device_id: device_id.clone(),
-                        credentials,
-                    };
-
-                    Ok(device)
-                }
-
                 let dps_client = aziot_dps_client_async::Client::new(
                     &global_endpoint,
                     &scope_id,
@@ -500,7 +481,7 @@ impl IdentityManager {
                     self.proxy_uri.clone(),
                 );
 
-                let device = match attestation {
+                let (dps_auth_kind, registration_id, credentials) = match attestation {
                     config::DpsAttestationMethod::SymmetricKey {
                         registration_id,
                         symmetric_key,
@@ -508,27 +489,10 @@ impl IdentityManager {
                         let dps_auth_kind = aziot_dps_client_async::DpsAuthKind::SymmetricKey {
                             sas_key: symmetric_key.clone(),
                         };
-                        let credential = aziot_identity_common::Credentials::SharedPrivateKey(
-                            symmetric_key.clone(),
-                        );
+                        let credentials =
+                            aziot_identity_common::Credentials::SharedPrivateKey(symmetric_key);
 
-                        let backup_device =
-                            self.get_backup_provisioning_info(credential.clone())?;
-
-                        if skip_if_backup_is_valid && backup_device.is_some() {
-                            let backup_device =
-                                backup_device.expect("backup device cannot be none");
-                            log::info!("Provisioned with backup for {}.", backup_device.device_id);
-
-                            backup_device
-                        } else {
-                            let operation = dps_client
-                                .register(&registration_id, &dps_auth_kind)
-                                .await
-                                .map_err(Error::DPSClient)?;
-
-                            operation_to_iot_hub_device(credential, operation).await?
-                        }
+                        (dps_auth_kind, registration_id, credentials)
                     }
                     config::DpsAttestationMethod::X509 {
                         registration_id,
@@ -546,52 +510,31 @@ impl IdentityManager {
                             identity_cert: identity_cert.clone(),
                             identity_pk: identity_pk.clone(),
                         };
-                        let credential = aziot_identity_common::Credentials::X509 {
+                        let credentials = aziot_identity_common::Credentials::X509 {
                             identity_cert: identity_cert.clone(),
                             identity_pk: identity_pk.clone(),
                         };
 
-                        let backup_device =
-                            self.get_backup_provisioning_info(credential.clone())?;
-
-                        if skip_if_backup_is_valid && backup_device.is_some() {
-                            let backup_device =
-                                backup_device.expect("backup device cannot be none");
-                            log::info!("Provisioned with backup for {}.", backup_device.device_id);
-
-                            backup_device
-                        } else {
-                            let operation = dps_client
-                                .register(&registration_id, &dps_auth_kind)
-                                .await
-                                .map_err(Error::DPSClient)?;
-
-                            operation_to_iot_hub_device(credential, operation).await?
-                        }
+                        (dps_auth_kind, registration_id, credentials)
                     }
                     config::DpsAttestationMethod::Tpm { registration_id } => {
                         let dps_auth_kind = aziot_dps_client_async::DpsAuthKind::Tpm;
-                        let credential = aziot_identity_common::Credentials::Tpm;
+                        let credentials = aziot_identity_common::Credentials::Tpm;
 
-                        let backup_device =
-                            self.get_backup_provisioning_info(credential.clone())?;
-
-                        if skip_if_backup_is_valid && backup_device.is_some() {
-                            let backup_device =
-                                backup_device.expect("backup device cannot be none");
-                            log::info!("Provisioned with backup for {}.", backup_device.device_id);
-
-                            backup_device
-                        } else {
-                            let operation = dps_client
-                                .register(&registration_id, &dps_auth_kind)
-                                .await
-                                .map_err(Error::DPSClient)?;
-
-                            operation_to_iot_hub_device(credential, operation).await?
-                        }
+                        (dps_auth_kind, registration_id, credentials)
                     }
                 };
+
+                let device = self
+                    .dps_provision(
+                        skip_if_backup_is_valid,
+                        dps_client,
+                        dps_auth_kind,
+                        registration_id,
+                        credentials,
+                    )
+                    .await?;
+
                 self.set_device(&device);
                 aziot_identity_common::ProvisioningStatus::Provisioned(device)
             }
@@ -601,6 +544,43 @@ impl IdentityManager {
                 aziot_identity_common::ProvisioningStatus::Unprovisioned
             }
         };
+        Ok(device)
+    }
+
+    async fn dps_provision(
+        &self,
+        skip_if_backup_is_valid: bool,
+        dps_client: aziot_dps_client_async::Client,
+        dps_auth_kind: aziot_dps_client_async::DpsAuthKind,
+        registration_id: String,
+        credentials: aziot_identity_common::Credentials,
+    ) -> Result<aziot_identity_common::IoTHubDevice, Error> {
+        let backup_device = self.get_backup_provisioning_info(credentials.clone())?;
+
+        if skip_if_backup_is_valid && backup_device.is_some() {
+            let backup_device = backup_device.expect("backup device cannot be none");
+            log::info!("Provisioned with backup for {}.", backup_device.device_id);
+
+            return Ok(backup_device);
+        }
+
+        let operation = dps_client
+            .register(&registration_id, &dps_auth_kind)
+            .await
+            .map_err(Error::DPSClient)?;
+
+        let status = operation.status;
+        assert!(!status.eq_ignore_ascii_case("assigning"));
+
+        let mut state = operation.registration_state.ok_or(Error::DeviceNotFound)?;
+        let iothub_hostname = state.assigned_hub.get_or_insert("".into());
+        let device_id = state.device_id.get_or_insert("".into());
+        let device = aziot_identity_common::IoTHubDevice {
+            iothub_hostname: iothub_hostname.clone(),
+            device_id: device_id.clone(),
+            credentials,
+        };
+
         Ok(device)
     }
 

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -423,10 +423,14 @@ impl Api {
                     ReprovisionTrigger::Startup | ReprovisionTrigger::ConfigurationFileUpdate => {
                         log::info!("Could not reconcile Identities with current device data. Reprovisioning.");
 
-                        self.id_manager.provision_device(self.settings.provisioning.clone(), false).await?;
+                        self.id_manager
+                            .provision_device(self.settings.provisioning.clone(), false)
+                            .await?;
                         log::info!("Successfully reprovisioned.");
 
-                        self.id_manager.reconcile_hub_identities(self.settings.clone()).await?;
+                        self.id_manager
+                            .reconcile_hub_identities(self.settings.clone())
+                            .await?;
                     }
 
                     // Don't attempt to reprovision if this function was called by the reprovision API.


### PR DESCRIPTION
If Identity Service fails to contact Hub during identity reconciliation, it will try once to reprovision the device.