### PR TITLE
Add check for preventing DPS provisioning in nested mode

### DIFF
--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -529,7 +529,7 @@ mod tests {
     #[should_panic(expected = "DPS provisioning is not supported in nested mode")]
     fn dps_not_supported_in_nested() {
         let super_config = r#"
-parent_hostname = "device.hostname"
+local_gateway_hostname = "device.hostname"
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -144,6 +144,10 @@ pub fn run(
                 id_scope,
                 attestation,
             } => {
+                if local_gateway_hostname.is_some() {
+                    return Err(anyhow!("DPS provisioning is not supported in nested mode"));
+                }
+
                 let attestation = match attestation {
                     super_config::DpsAttestationMethod::SymmetricKey {
                         registration_id,

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -524,4 +524,29 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    #[should_panic(expected = "DPS provisioning is not supported in nested mode")]
+    fn dps_not_supported_in_nested() {
+        let super_config = r#"
+parent_hostname = "device.hostname"
+
+[provisioning]
+source = "dps"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
+id_scope = "0ab1234C5D6"
+
+[provisioning.attestation]
+method = "symmetric_key"
+registration_id = "my-device"
+symmetric_key = { value = "YXppb3QtaWRlbnRpdHktc2VydmljZXxhemlvdC1pZGVudGl0eS1zZXJ2aWNlfGF6aW90LWlkZW50aXR5LXNlcg==" }
+        
+"#;
+        let super_config: super_config::Config = toml::from_str(super_config).unwrap();
+
+        let aziotcs_uid = nix::unistd::Uid::from_raw(5555);
+        let aziotid_uid = nix::unistd::Uid::from_raw(5556);
+
+        super::run(super_config, aziotcs_uid, aziotid_uid).unwrap();
+    }
 }

--- a/identity/aziot-identityd/src/error.rs
+++ b/identity/aziot-identityd/src/error.rs
@@ -6,6 +6,7 @@ pub enum Error {
     Authorization,
     DeviceNotFound,
     DPSClient(std::io::Error),
+    DPSNotSupportedInNestedMode,
     HubClient(std::io::Error),
     KeyClient(std::io::Error),
     ModuleNotFound,
@@ -29,6 +30,9 @@ impl std::fmt::Display for Error {
             Error::Authorization => f.write_str("authorization error"),
             Error::DeviceNotFound => f.write_str("device identity not found"),
             Error::DPSClient(_) => f.write_str("DPS client error"),
+            Error::DPSNotSupportedInNestedMode => {
+                f.write_str("DPS provisioning is not supported in nested mode")
+            }
             Error::HubClient(_) => f.write_str("Hub client error"),
             Error::KeyClient(_) => f.write_str("Key client error"),
             Error::ModuleNotFound => f.write_str("module identity not found"),
@@ -46,6 +50,7 @@ impl std::error::Error for Error {
             Error::Authentication
             | Error::Authorization
             | Error::DeviceNotFound
+            | Error::DPSNotSupportedInNestedMode
             | Error::ModuleNotFound => None,
             Error::DPSClient(err) | Error::HubClient(err) | Error::KeyClient(err) => Some(err),
             Error::Internal(err) => Some(err),

--- a/identity/aziot-identityd/src/http/mod.rs
+++ b/identity/aziot-identityd/src/http/mod.rs
@@ -56,6 +56,7 @@ fn to_http_error(err: &crate::Error) -> http_common::server::Error {
         },
 
         crate::error::Error::DPSClient(_)
+        | crate::error::Error::DPSNotSupportedInNestedMode
         | crate::error::Error::HubClient(_)
         | crate::error::Error::KeyClient(_) => http_common::server::Error {
             status_code: hyper::StatusCode::NOT_FOUND,

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -480,6 +480,10 @@ impl IdentityManager {
                 scope_id,
                 attestation,
             } => {
+                if provisioning.local_gateway_hostname.is_some() {
+                    return Err(Error::DPSNotSupportedInNestedMode);
+                }
+
                 let dps_client = aziot_dps_client_async::Client::new(
                     &global_endpoint,
                     &scope_id,


### PR DESCRIPTION
Nested Edge deployments only support IoT Hub provisioning for release/1.2. This PR introduces informative errors on invoking `aziotctl config apply` and daemon logs, if Identity Service is configured with `parent_hostname` AND DPS provisioning parameters.