### PR TITLE
Teach libaziot-keys to decrypt IoT Edge v1.1 secrets.

### DIFF
--- a/key/aziot-keys/src/key.rs
+++ b/key/aziot-keys/src/key.rs
@@ -456,9 +456,7 @@ pub(crate) unsafe fn decrypt(
                     (ciphertext, tag)
                 }
 
-                0x02 => {
-                    ciphertext.split_at(ciphertext.len() - 16)
-                }
+                0x02 => ciphertext.split_at(ciphertext.len() - 16),
 
                 version => {
                     return Err(crate::implementation::err_invalid_parameter(


### PR DESCRIPTION
IoT Edge v1.1's secrets used the version v1 and stored the tag in front of
the ciphertext.

This commit changes libaziot-keys to use version v2 for encrypting new secrets,
and support decrypting both v1 and v2 secrets.