### PR TITLE
Export connection string parsing + validation function

### DIFF
--- a/aziotctl/aziotctl-common/src/config/mod.rs
+++ b/aziotctl/aziotctl-common/src/config/mod.rs
@@ -63,7 +63,7 @@ pub fn write_file(
     Ok(())
 }
 
-fn parse_manual_connection_string(
+pub fn parse_manual_connection_string(
     connection_string: &str,
 ) -> Result<(String, String, Vec<u8>), String> {
     const HOSTNAME_KEY: &str = "HostName";


### PR DESCRIPTION
Pre-requisite for enabling `iotedge config mp` to perform early validation of the passed-in connection string.