### PR TITLE
Rate-limit + timeout fix for incomplete socket reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tokio",
  "url",
  "wildmatch",
 ]
@@ -299,6 +300,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tokio",
  "toml",
  "url",
 ]
@@ -430,6 +432,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tokio",
  "url",
  "wildmatch",
 ]
@@ -530,6 +533,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-io-timeout",
  "tracing",
  "url",
 ]
@@ -2273,6 +2274,16 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/cert/aziot-certd/Cargo.toml
+++ b/cert/aziot-certd/Cargo.toml
@@ -24,6 +24,7 @@ percent-encoding = "2"
 regex = "1"
 serde = "1"
 serde_json = "1"
+tokio = { version = "1", features = ["time"] }
 url = "2"
 wildmatch = "1"
 

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -21,6 +21,7 @@ percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["net", "rt-multi-thread"], optional = true }
+tokio-io-timeout = { version = "1" }
 tracing = { version = "0.1", features = ["log"] }
 url = { version = "2", features = ["serde"] }
 

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -20,7 +20,7 @@ openssl = { version = "0.10", optional = true }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["net", "rt-multi-thread"], optional = true }
+tokio = { version = "1", features = ["net", "rt-multi-thread", "sync"], optional = true }
 tokio-io-timeout = { version = "1" }
 tracing = { version = "0.1", features = ["log"] }
 url = { version = "2", features = ["serde"] }

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -27,8 +27,15 @@ pub enum AsyncStream {
 #[cfg(feature = "tokio1")]
 #[derive(Debug)]
 pub enum Incoming {
-    Tcp(tokio::net::TcpListener),
-    Unix(tokio::net::UnixListener),
+    Tcp {
+        listener: tokio::net::TcpListener,
+    },
+    Unix {
+        listener: tokio::net::UnixListener,
+        user_state: futures_util::lock::Mutex<
+            std::collections::BTreeMap<libc::uid_t, std::sync::Arc<tokio::sync::Semaphore>>,
+        >,
+    },
 }
 
 #[cfg(feature = "tokio1")]
@@ -45,8 +52,10 @@ impl Incoming {
         <H as hyper::service::Service<hyper::Request<hyper::Body>>>::Future: Send,
     {
         const READ_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+        const MAX_REQUESTS_PER_USER: usize = 10;
+
         match self {
-            Incoming::Tcp(listener) => loop {
+            Incoming::Tcp { listener } => loop {
                 let (tcp_stream, _) = listener.accept().await?;
                 let mut timeout_stream = tokio_io_timeout::TimeoutStream::new(tcp_stream);
                 timeout_stream.set_read_timeout(Some(READ_WRITE_TIMEOUT));
@@ -64,20 +73,41 @@ impl Incoming {
                 });
             },
 
-            Incoming::Unix(listener) => loop {
+            Incoming::Unix {
+                listener,
+                user_state,
+            } => loop {
                 let (unix_stream, _) = listener.accept().await?;
                 let ucred = unix_stream.peer_cred()?;
+                let user_state = user_state
+                    .lock()
+                    .await
+                    .entry(ucred.uid())
+                    .or_insert_with(|| {
+                        std::sync::Arc::new(tokio::sync::Semaphore::new(MAX_REQUESTS_PER_USER))
+                    })
+                    .clone();
                 let mut timeout_stream = tokio_io_timeout::TimeoutStream::new(unix_stream);
                 timeout_stream.set_read_timeout(Some(READ_WRITE_TIMEOUT));
                 timeout_stream.set_write_timeout(Some(READ_WRITE_TIMEOUT));
 
                 let server = crate::uid::UidService::new(ucred.uid(), server.clone());
                 tokio::spawn(async move {
-                    if let Err(http_err) = hyper::server::conn::Http::new()
-                        .serve_connection(Box::pin(timeout_stream), server)
-                        .await
-                    {
-                        log::info!("Error while serving HTTP connection: {}", http_err);
+                    match user_state.try_acquire_owned() {
+                        Ok(_permit) => {
+                            if let Err(http_err) = hyper::server::conn::Http::new()
+                                .serve_connection(Box::pin(timeout_stream), server)
+                                .await
+                            {
+                                log::info!("Error while serving HTTP connection: {}", http_err);
+                            }
+                        }
+                        Err(limit_err) => {
+                            log::info!(
+                                "Error while acquiring permit for HTTP connection: {}",
+                                limit_err
+                            );
+                        }
                     }
                 });
             },
@@ -146,7 +176,7 @@ impl Connector {
                         unsafe { std::os::unix::io::FromRawFd::from_raw_fd(fd) };
                     listener.set_nonblocking(true)?;
                     let listener = tokio::net::TcpListener::from_std(listener)?;
-                    Ok(Incoming::Tcp(listener))
+                    Ok(Incoming::Tcp { listener })
                 }
 
                 nix::sys::socket::SockAddr::Unix(_) => {
@@ -154,7 +184,12 @@ impl Connector {
                         unsafe { std::os::unix::io::FromRawFd::from_raw_fd(fd) };
                     listener.set_nonblocking(true)?;
                     let listener = tokio::net::UnixListener::from_std(listener)?;
-                    Ok(Incoming::Unix(listener))
+                    Ok(Incoming::Unix {
+                        listener,
+                        user_state: futures_util::lock::Mutex::new(
+                            std::collections::BTreeMap::new(),
+                        ),
+                    })
                 }
 
                 sock_addr => Err(std::io::Error::new(
@@ -172,7 +207,7 @@ impl Connector {
                 {
                     if cfg!(debug_assertions) {
                         let listener = tokio::net::TcpListener::bind((&*host, port)).await?;
-                        Ok(Incoming::Tcp(listener))
+                        Ok(Incoming::Tcp { listener })
                     } else {
                         Err(std::io::Error::new(
                             std::io::ErrorKind::Other,
@@ -189,7 +224,12 @@ impl Connector {
                     }
 
                     let listener = tokio::net::UnixListener::bind(socket_path)?;
-                    Ok(Incoming::Unix(listener))
+                    Ok(Incoming::Unix {
+                        listener,
+                        user_state: futures_util::lock::Mutex::new(
+                            std::collections::BTreeMap::new(),
+                        ),
+                    })
                 }
             }
         }

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -32,9 +32,7 @@ pub enum Incoming {
     },
     Unix {
         listener: tokio::net::UnixListener,
-        user_state: std::sync::Mutex<
-            std::collections::BTreeMap<libc::uid_t, std::sync::Arc<tokio::sync::Semaphore>>,
-        >,
+        user_state: std::collections::BTreeMap<libc::uid_t, std::sync::Arc<tokio::sync::Semaphore>>,
     },
 }
 
@@ -80,8 +78,6 @@ impl Incoming {
                 let (unix_stream, _) = listener.accept().await?;
                 let ucred = unix_stream.peer_cred()?;
                 let user_state = user_state
-                    .get_mut()
-                    .expect("mutex shouldn't fail")
                     .entry(ucred.uid())
                     .or_insert_with(|| {
                         std::sync::Arc::new(tokio::sync::Semaphore::new(MAX_REQUESTS_PER_USER))
@@ -186,7 +182,7 @@ impl Connector {
                     let listener = tokio::net::UnixListener::from_std(listener)?;
                     Ok(Incoming::Unix {
                         listener,
-                        user_state: std::sync::Mutex::new(std::collections::BTreeMap::new()),
+                        user_state: Default::default(),
                     })
                 }
 
@@ -224,7 +220,7 @@ impl Connector {
                     let listener = tokio::net::UnixListener::bind(socket_path)?;
                     Ok(Incoming::Unix {
                         listener,
-                        user_state: std::sync::Mutex::new(std::collections::BTreeMap::new()),
+                        user_state: Default::default(),
                     })
                 }
             }

--- a/identity/aziot-identityd/Cargo.toml
+++ b/identity/aziot-identityd/Cargo.toml
@@ -24,6 +24,7 @@ percent-encoding = "2"
 regex = "1"
 serde = "1"
 serde_json = "1.0"
+tokio = { version = "1", features = ["time"] }
 toml = "0.5"
 url = "2"
 

--- a/key/aziot-keyd/Cargo.toml
+++ b/key/aziot-keyd/Cargo.toml
@@ -20,6 +20,7 @@ percent-encoding = "2"
 regex = "1"
 serde = "1"
 serde_json = "1"
+tokio = { version = "1", features = ["time"] }
 url = "2"
 wildmatch = "1"
 

--- a/tpm/aziot-tpmd/Cargo.toml
+++ b/tpm/aziot-tpmd/Cargo.toml
@@ -12,6 +12,7 @@ hyper = "0.14"
 log = "0.4"
 serde = "1"
 serde_json = "1"
+tokio = { version = "1", features = ["time"] }
 url = "2"
 
 aziot-tpm = { path = "../aziot-tpm-rs" }


### PR DESCRIPTION
There are two parts to the fix:
1. ensure request content read is timed out within 5 seconds to avoid content-length being set to greater value than actual content 
2. rate-limit all clients to 10 concurrent requests per uid per service (this applies uniformly to all uids)


