### PR TITLE
CN fallback for X.509 registration

### DIFF
--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -231,7 +231,7 @@ pub fn run(
                         }
 
                         aziot_identityd_config::DpsAttestationMethod::X509 {
-                            registration_id: Some(registration_id),
+                            registration_id,
                             identity_cert: super::DEVICE_ID_ID.to_owned(),
                             identity_pk: super::DEVICE_ID_ID.to_owned(),
                         }

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -231,7 +231,7 @@ pub fn run(
                         }
 
                         aziot_identityd_config::DpsAttestationMethod::X509 {
-                            registration_id,
+                            registration_id: Some(registration_id),
                             identity_cert: super::DEVICE_ID_ID.to_owned(),
                             identity_pk: super::DEVICE_ID_ID.to_owned(),
                         }

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -174,7 +174,7 @@ pub enum DpsAttestationMethod {
     },
 
     X509 {
-        registration_id: String,
+        registration_id: Option<String>,
 
         #[serde(flatten)]
         identity: X509Identity,

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -76,7 +76,7 @@ pub enum DpsAttestationMethod {
         symmetric_key: String,
     },
     X509 {
-        registration_id: String,
+        registration_id: Option<String>,
         identity_cert: String,
         identity_pk: String,
     },

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -628,8 +628,8 @@ impl IdentityManager {
                         let registration_id = match registration_id {
                             Some(registration_id) => registration_id,
                             None => match cert_subject_name {
-                                std::option::Option::Some(cert_subject_name) => cert_subject_name?,
-                                std::option::Option::None => {
+                                Some(cert_subject_name) => cert_subject_name?,
+                                None => {
                                     return Err(Error::Internal(InternalError::CreateCertificate(
                                                 "device identity certificate subject is required to register with DPS, but it is not configured".to_string().into())));
                                 }
@@ -814,8 +814,8 @@ impl IdentityManager {
             let new_cert_subject = match subject {
                 Some(subject) => subject.to_string(),
                 None => match old_cert_subject_name {
-                    std::option::Option::Some(sn) => sn?,
-                    std::option::Option::None => {
+                    Some(sn) => sn?,
+                    None => {
                         return Err(Error::Internal(InternalError::CreateCertificate(
                                     "device identity certificate subject is required to register with DPS, but it is not configured".to_string().into())));
                     }


### PR DESCRIPTION
In 1.1, iotedge had a fallback mechanism for DPS X.509 attestation. In 1.2, however, new options for obtaining device identity certificate became available. In the new world, CS could be configured to issue identity certificate in one of these configurations:

1. receive a CSR with any subject name. This subject would be IS's config.toml registration_id value. 
2. receive a CSR and common name is configured within CS config.toml. This will override any common name specified in the CSR.

With this fix, the behavior is changed to bring back parity with 1.1 behavior (i.e. if registration_id is missing, fallback to identity cert's subject name as registration_id). The CSR issued by IS to renew the identity cert will contain subject name set as one of the following values (in order of precedence): 
- First, the IS config.toml X.509 attestation registration_id is used in the CSR to renew the identity cert
- If registration_id is missing, the current identity certificate's subject name is used in the CSR to renew the identity cert
- When the identity certificate is returned, the latest valid/renewed cert's subject is used, if the registration_id is missing.

Note that if registration_id is set to a value different from the identity certificate subject name returned by CS, DPS will reject the registration request (as of DPS API version 2019-04-15). So, it is upto the user to avoid this scenario currently. 

TODO:

- [x] Validate E2E manually
- [x] Send a PR for iotedge import tool changes