### PR TITLE
Fix build for new Rust stable 1.52.0

### DIFF
--- a/aziotctl/aziotctl-common/src/config/mod.rs
+++ b/aziotctl/aziotctl-common/src/config/mod.rs
@@ -75,14 +75,11 @@ fn parse_manual_connection_string(
     let mut symmetric_key = None;
 
     for sections in connection_string.split(';') {
-        let mut parts = sections.split('=');
-        match parts
-            .next()
-            .expect("str::split always returns at least one part")
-        {
-            HOSTNAME_KEY => iothub_hostname = parts.next(),
-            DEVICEID_KEY => device_id = parts.next(),
-            SHAREDACCESSKEY_KEY => symmetric_key = parts.next(),
+        let parts = sections.split_once('=');
+        match parts {
+            Some((HOSTNAME_KEY, value)) => iothub_hostname = Some(value),
+            Some((DEVICEID_KEY, value)) => device_id = Some(value),
+            Some((SHAREDACCESSKEY_KEY, value)) => symmetric_key = Some(value),
             _ => (), // Ignore extraneous component in the connection string
         }
     }

--- a/aziotctl/src/internal/check/additional_info.rs
+++ b/aziotctl/src/internal/check/additional_info.rs
@@ -100,13 +100,7 @@ impl OsInfo {
 fn parse_os_release_line(line: &str) -> Option<(&str, &str)> {
     let line = line.trim();
 
-    let mut parts = line.split('=');
-
-    let key = parts
-        .next()
-        .expect("split line will have at least one part");
-
-    let value = parts.next()?;
+    let (key, value) = line.split_once('=')?;
 
     // The value is essentially a shell string, so it can be quoted in single or
     // double quotes, and can have escaped sequences using backslash.

--- a/aziotctl/src/main.rs
+++ b/aziotctl/src/main.rs
@@ -5,6 +5,7 @@
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,
+    clippy::let_underscore_drop,
     clippy::let_unit_value,
     clippy::module_name_repetitions,
     clippy::similar_names,

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -7,7 +7,11 @@
 
 #![deny(rust_2018_idioms)]
 #![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::default_trait_access, clippy::let_unit_value)]
+#![allow(
+    clippy::default_trait_access,
+    clippy::let_underscore_drop,
+    clippy::let_unit_value
+)]
 
 mod error;
 

--- a/cert/aziot-certd/src/http/mod.rs
+++ b/cert/aziot-certd/src/http/mod.rs
@@ -21,7 +21,7 @@ fn to_http_error(err: &crate::Error) -> http_common::server::Error {
     let error_message = http_common::server::error_to_message(err);
 
     // TODO: When we get distributed tracing, associate these logs with the tracing ID.
-    for line in error_message.split('\n') {
+    for line in error_message.lines() {
         log::log!(
             match err {
                 crate::Error::Internal(_) => log::Level::Error,

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,
+    clippy::let_underscore_drop,
     clippy::missing_errors_doc,
     clippy::module_name_repetitions,
     clippy::must_use_candidate,

--- a/identity/aziot-identityd/src/http/mod.rs
+++ b/identity/aziot-identityd/src/http/mod.rs
@@ -29,7 +29,7 @@ fn to_http_error(err: &crate::Error) -> http_common::server::Error {
     let error_message = http_common::server::error_to_message(err);
 
     // TODO: When we get distributed tracing, associate these logs with the tracing ID.
-    for line in error_message.split('\n') {
+    for line in error_message.lines() {
         log::log!(
             match err {
                 crate::Error::Internal(_) => log::Level::Error,

--- a/key/aziot-key-openssl-engine-shared-test/src/main.rs
+++ b/key/aziot-key-openssl-engine-shared-test/src/main.rs
@@ -266,7 +266,7 @@ fn generate_cert(
     let ca_key_handle = match &kind {
         GenerateCertKind::Ca => key_handle,
         GenerateCertKind::Client { ca_key_handle, .. }
-        | GenerateCertKind::Server { ca_key_handle, .. } => ca_key_handle.to_owned(),
+        | GenerateCertKind::Server { ca_key_handle, .. } => ca_key_handle.clone(),
     };
     let ca_key = load_private_key(&mut engine, ca_key_handle)?;
     builder.sign(&ca_key, openssl::hash::MessageDigest::sha256())?;

--- a/key/aziot-keyd/src/http/mod.rs
+++ b/key/aziot-keyd/src/http/mod.rs
@@ -35,7 +35,7 @@ fn to_http_error(err: &crate::Error) -> http_common::server::Error {
     let error_message = http_common::server::error_to_message(err);
 
     // TODO: When we get distributed tracing, associate these logs with the tracing ID.
-    for line in error_message.split('\n') {
+    for line in error_message.lines() {
         log::log!(
             match err {
                 crate::Error::Internal(_) => log::Level::Error,

--- a/pkcs11/pkcs11/src/lib.rs
+++ b/pkcs11/pkcs11/src/lib.rs
@@ -124,9 +124,8 @@ impl std::str::FromStr for Uri {
         where
             F: FnMut(&[u8]) -> Option<T>,
         {
-            let mut parts = s.splitn(2, '=');
+            let (key, value) = s.split_once('=').unwrap_or((s, ""));
 
-            let key = parts.next().expect("str::splitn() yields at least one str");
             let key = percent_encoding::percent_decode(key.as_bytes());
             let key: std::borrow::Cow<'a, _> = key.into();
             let typed_key = match key_discriminant(&*key) {
@@ -134,7 +133,6 @@ impl std::str::FromStr for Uri {
                 None => return Ok(None),
             };
 
-            let value = parts.next().unwrap_or_default();
             let value = percent_encoding::percent_decode(value.as_bytes());
             match value.decode_utf8() {
                 Ok(value) => Ok(Some((typed_key, value))),
@@ -154,11 +152,8 @@ impl std::str::FromStr for Uri {
             .strip_prefix("pkcs11:")
             .ok_or(ParsePkcs11UriError::InvalidScheme)?;
 
-        let mut url_parts = s.split('?');
+        let (path, query) = s.split_once('?').unwrap_or((s, ""));
 
-        let path = url_parts
-            .next()
-            .expect("str::split() yields at least one str");
         let path_components = path.split(';');
         for path_component in path_components {
             let key_value_pair = parse_key_value_pair(path_component, |key| match key {
@@ -185,7 +180,6 @@ impl std::str::FromStr for Uri {
             }
         }
 
-        let query = url_parts.next().unwrap_or_default();
         let query_components = query.split('&');
         for query_component in query_components {
             let key_value_pair = parse_key_value_pair(query_component, |key| match key {

--- a/tpm/aziot-tpmd/src/http/mod.rs
+++ b/tpm/aziot-tpmd/src/http/mod.rs
@@ -23,7 +23,7 @@ fn to_http_error(err: &crate::Error) -> http_common::server::Error {
     let error_message = http_common::server::error_to_message(err);
 
     // TODO: When we get distributed tracing, associate these logs with the tracing ID.
-    for line in error_message.split('\n') {
+    for line in error_message.lines() {
         log::log!(
             match err {
                 crate::Error::Internal(_) => log::Level::Error,


### PR DESCRIPTION
- Replace `.to_owned()` with `.clone()` where possible.

- Replace `str::split` with new `str::split_once` when splitting into one or two parts.

- Replace `str::split('\n')` with `str::lines`.