### PR TITLE
Fix Identity Service when starting offline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
+ "tokio",
  "url",
 ]
 
@@ -1263,7 +1264,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-io-timeout",
  "tracing",
  "url",
 ]
@@ -2279,16 +2279,6 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
-dependencies = [
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -24,6 +24,8 @@ pub fn run(
         parent_hostname,
         provisioning,
         localid,
+        cloud_timeout_sec,
+        cloud_retries,
         mut aziot_keys,
         mut preloaded_keys,
         cert_issuance,
@@ -267,9 +269,9 @@ pub fn run(
 
         homedir: super::AZIOT_IDENTITYD_HOMEDIR_PATH.into(),
 
-        cloud_timeout_sec: aziot_identityd_config::Settings::default_cloud_timeout(),
+        cloud_timeout_sec,
 
-        cloud_retries: aziot_identityd_config::Settings::default_cloud_retries(),
+        cloud_retries,
 
         principal: vec![],
 

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -267,6 +267,10 @@ pub fn run(
 
         homedir: super::AZIOT_IDENTITYD_HOMEDIR_PATH.into(),
 
+        cloud_timeout_sec: aziot_identityd_config::Settings::default_cloud_timeout(),
+
+        cloud_retries: aziot_identityd_config::Settings::default_cloud_retries(),
+
         principal: vec![],
 
         provisioning,

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -38,6 +38,19 @@ pub struct Config {
     #[serde(alias = "local_gateway_hostname")]
     pub parent_hostname: Option<String>,
 
+    #[serde(
+        default = "aziot_identityd_config::Settings::default_cloud_timeout",
+        deserialize_with = "aziot_identityd_config::deserialize_cloud_timeout",
+        skip_serializing_if = "aziot_identityd_config::Settings::is_default_timeout"
+    )]
+    pub cloud_timeout_sec: u64,
+
+    #[serde(
+        default = "aziot_identityd_config::Settings::default_cloud_retries",
+        skip_serializing_if = "aziot_identityd_config::Settings::is_default_retries"
+    )]
+    pub cloud_retries: u32,
+
     pub provisioning: Provisioning,
 
     pub localid: Option<aziot_identityd_config::LocalId>,

--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -16,6 +16,25 @@
 # local_gateway_hostname = "my-parent-device"
 
 # ==============================================================================
+# Cloud Timeout and Retry Behavior
+# ==============================================================================
+#
+# These settings control the timeout and retries for cloud operations, such as
+# communication with DPS during provisioning or IoT Hub for module identity creation.
+#
+# cloud_timeout_sec is the deadline (in seconds) for a network request (such as
+# an HTTP request) to the aforementioned cloud services. A response from the cloud
+# must be received before this deadline, or the request will fail as timed out.
+#
+# cloud_retries controls how many times a request may be retried should it fail.
+# The client will always send at least one attempt, so its value will be the number
+# of retries after the first attempt should that fail (i.e. cloud_retries = 2
+# means that the client will make a total of 3 attempts).
+#
+# cloud_timeout_sec = 10
+# cloud_retries = 0
+
+# ==============================================================================
 # Provisioning
 # ==============================================================================
 #
@@ -34,7 +53,7 @@
 # source = "manual"
 # iothub_hostname = "example.azure-devices.net"
 # device_id = "my-device"
-# 
+#
 # [provisioning.authentication]
 # method = "sas"
 #
@@ -48,7 +67,7 @@
 # source = "manual"
 # iothub_hostname = "example.azure-devices.net"
 # device_id = "my-device"
-# 
+#
 # [provisioning.authentication]
 # method = "x509"
 #
@@ -65,7 +84,7 @@
 # source = "dps"
 # global_endpoint = "https://global.azure-devices-provisioning.net/"
 # id_scope = "0ab1234C5D6"
-# 
+#
 # [provisioning.attestation]
 # method = "symmetric_key"
 # registration_id = "my-device"
@@ -80,7 +99,7 @@
 # source = "dps"
 # global_endpoint = "https://global.azure-devices-provisioning.net/"
 # id_scope = "0ab1234C5D6"
-# 
+#
 # [provisioning.attestation]
 # method = "x509"
 # registration_id = "my-device"
@@ -98,7 +117,7 @@
 # source = "dps"
 # global_endpoint = "https://global.azure-devices-provisioning.net/"
 # id_scope = "0ab1234C5D6"
-# 
+#
 # [provisioning.attestation]
 # method = "tpm"
 # registration_id = "my-device"
@@ -119,7 +138,7 @@
 # trusted_certs = [
 #     "file:///var/secrets/est-id-ca.pem",
 # ]
-# 
+#
 # [cert_issuance.est.auth]
 # username = "estuser"
 # password = "estpwd"

--- a/aziotctl/src/config/mp.rs
+++ b/aziotctl/src/config/mp.rs
@@ -69,6 +69,10 @@ To reconfigure IoT Identity Service, run:
 
         localid: None,
 
+        cloud_timeout_sec: aziot_identityd_config::Settings::default_cloud_timeout(),
+
+        cloud_retries: aziot_identityd_config::Settings::default_cloud_retries(),
+
         aziot_keys: Default::default(),
 
         preloaded_keys: Default::default(),

--- a/docs/api/identity-service.md
+++ b/docs/api/identity-service.md
@@ -96,7 +96,14 @@ The returned `auth.keyHandle` value is meant to be used with the [Keys Service](
 
 ### Get IoT device provisioning result
 
-`GET /identities/device?api-version=2020-09-01`
+`POST /identities/device?api-version=2020-09-01`
+
+#### Request
+```json
+{
+  "type": "aziot"
+}
+```
 
 #### Response (SAS case)
 ```json

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -22,7 +22,6 @@ percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "sync"], optional = true }
-tokio-io-timeout = { version = "1" }
 tracing = { version = "0.1", features = ["log"] }
 url = { version = "2", features = ["serde"] }
 

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -49,20 +49,17 @@ impl Incoming {
             + 'static,
         <H as hyper::service::Service<hyper::Request<hyper::Body>>>::Future: Send,
     {
-        const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
         const MAX_REQUESTS_PER_USER: usize = 10;
 
         match self {
             Incoming::Tcp { listener } => loop {
                 let (tcp_stream, _) = listener.accept().await?;
-                let mut timeout_stream = tokio_io_timeout::TimeoutReader::new(tcp_stream);
-                timeout_stream.set_timeout(Some(READ_TIMEOUT));
 
                 // TCP is available in test builds only (not production). Assume current user is root.
                 let server = crate::uid::UidService::new(0, server.clone());
                 tokio::spawn(async move {
                     if let Err(http_err) = hyper::server::conn::Http::new()
-                        .serve_connection(Box::pin(timeout_stream), server)
+                        .serve_connection(Box::pin(tcp_stream), server)
                         .await
                     {
                         log::info!("Error while serving HTTP connection: {}", http_err);
@@ -82,15 +79,13 @@ impl Incoming {
                         std::sync::Arc::new(tokio::sync::Semaphore::new(MAX_REQUESTS_PER_USER))
                     })
                     .clone();
-                let mut timeout_stream = tokio_io_timeout::TimeoutReader::new(unix_stream);
-                timeout_stream.set_timeout(Some(READ_TIMEOUT));
 
                 let server = crate::uid::UidService::new(ucred.uid(), server.clone());
                 tokio::spawn(async move {
                     match user_state.try_acquire_owned() {
                         Ok(_permit) => {
                             if let Err(http_err) = hyper::server::conn::Http::new()
-                                .serve_connection(Box::pin(timeout_stream), server)
+                                .serve_connection(Box::pin(unix_stream), server)
                                 .await
                             {
                                 log::info!("Error while serving HTTP connection: {}", http_err);

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -59,7 +59,7 @@ impl Incoming {
                 let server = crate::uid::UidService::new(0, server.clone());
                 tokio::spawn(async move {
                     if let Err(http_err) = hyper::server::conn::Http::new()
-                        .serve_connection(Box::pin(tcp_stream), server)
+                        .serve_connection(tcp_stream, server)
                         .await
                     {
                         log::info!("Error while serving HTTP connection: {}", http_err);
@@ -85,7 +85,7 @@ impl Incoming {
                     match user_state.try_acquire_owned() {
                         Ok(_permit) => {
                             if let Err(http_err) = hyper::server::conn::Http::new()
-                                .serve_connection(Box::pin(unix_stream), server)
+                                .serve_connection(unix_stream, server)
                                 .await
                             {
                                 log::info!("Error while serving HTTP connection: {}", http_err);

--- a/identity/aziot-dps-client-async/src/lib.rs
+++ b/identity/aziot-dps-client-async/src/lib.rs
@@ -291,7 +291,14 @@ impl Client {
             let err = match tokio::time::timeout(self.req_timeout, client.request(req)).await {
                 Ok(res) => match res {
                     Ok(res) => break res,
-                    Err(err) => std::io::Error::new(std::io::ErrorKind::Other, err),
+                    Err(err) => {
+                        if err.is_connect() {
+                            // Network error.
+                            std::io::Error::new(std::io::ErrorKind::NotConnected, err)
+                        } else {
+                            std::io::Error::new(std::io::ErrorKind::Other, err)
+                        }
+                    }
                 },
                 Err(err) => err.into(),
             };

--- a/identity/aziot-hub-client-async/Cargo.toml
+++ b/identity/aziot-hub-client-async/Cargo.toml
@@ -17,6 +17,7 @@ openssl = "0.10"
 percent-encoding = "2"
 serde = "1"
 serde_json = "1"
+tokio = { version = "1", features = ["time"] }
 url = "2"
 
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }

--- a/identity/aziot-hub-client-async/src/lib.rs
+++ b/identity/aziot-hub-client-async/src/lib.rs
@@ -22,6 +22,8 @@ pub const IOT_HUB_ENCODE_SET: &percent_encoding::AsciiSet =
 
 pub struct Client {
     device: aziot_identity_common::IoTHubDevice,
+    req_timeout: std::time::Duration,
+    req_retries: u32,
     key_client: Arc<aziot_key_client_async::Client>,
     key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
     cert_client: Arc<aziot_cert_client_async::Client>,
@@ -33,6 +35,8 @@ impl Client {
     #[must_use]
     pub fn new(
         device: aziot_identity_common::IoTHubDevice,
+        req_timeout: std::time::Duration,
+        req_retries: u32,
         key_client: Arc<aziot_key_client_async::Client>,
         key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
         cert_client: Arc<aziot_cert_client_async::Client>,
@@ -41,6 +45,8 @@ impl Client {
     ) -> Self {
         Client {
             device,
+            req_timeout,
+            req_retries,
             key_client,
             key_engine,
             cert_client,
@@ -71,9 +77,10 @@ impl Client {
             authentication: authentication_type,
         };
 
-        let res: aziot_identity_common::hub::Module = self
-            .request(&self.device, http::Method::PUT, &uri, Some(&body), false)
+        let res = self
+            .send_request(&uri, http::Method::PUT, Some(&body), false)
             .await?;
+        let res = parse_response_body(res).await?;
 
         Ok(res)
     }
@@ -98,9 +105,11 @@ impl Client {
             authentication: authentication_type,
         };
 
-        let res: aziot_identity_common::hub::Module = self
-            .request(&self.device, http::Method::PUT, &uri, Some(&body), true)
+        let res = self
+            .send_request(&uri, http::Method::PUT, Some(&body), true)
             .await?;
+        let res = parse_response_body(res).await?;
+
         Ok(res)
     }
 
@@ -114,9 +123,11 @@ impl Client {
             percent_encoding::percent_encode(module_id.as_bytes(), IOT_HUB_ENCODE_SET),
         );
 
-        let res: aziot_identity_common::hub::Module = self
-            .request::<(), _>(&self.device, http::Method::GET, &uri, None, false)
+        let res = self
+            .send_request::<()>(&uri, http::Method::GET, None, false)
             .await?;
+        let res = parse_response_body(res).await?;
+
         Ok(res)
     }
 
@@ -128,9 +139,11 @@ impl Client {
             percent_encoding::percent_encode(&self.device.device_id.as_bytes(), IOT_HUB_ENCODE_SET),
         );
 
-        let res: Vec<aziot_identity_common::hub::Module> = self
-            .request::<(), _>(&self.device, http::Method::GET, &uri, None, false)
+        let res = self
+            .send_request::<()>(&uri, http::Method::GET, None, false)
             .await?;
+        let res = parse_response_body(res).await?;
+
         Ok(res)
     }
 
@@ -141,328 +154,263 @@ impl Client {
             percent_encoding::percent_encode(module_id.as_bytes(), IOT_HUB_ENCODE_SET),
         );
 
-        let () = self
-            .request_no_content::<()>(&self.device, http::Method::DELETE, &uri, None)
+        let res = self
+            .send_request::<()>(&uri, http::Method::DELETE, None, true)
             .await?;
+        parse_response_empty(res).await?;
+
         Ok(())
     }
 
-    async fn request<TRequest, TResponse>(
+    async fn send_request<TRequest>(
         &self,
-        hub_device: &aziot_identity_common::IoTHubDevice,
-        method: http::Method,
         uri: &str,
+        method: http::Method,
         body: Option<&TRequest>,
         add_if_match: bool,
-    ) -> std::io::Result<TResponse>
+    ) -> std::io::Result<hyper::Response<hyper::Body>>
     where
         TRequest: serde::Serialize,
-        TResponse: serde::de::DeserializeOwned,
     {
-        let uri = format!("https://{}{}", hub_device.local_gateway_hostname, uri);
+        let uri = format!("https://{}{}", self.device.local_gateway_hostname, uri);
 
-        let req = hyper::Request::builder().method(method).uri(uri);
-        // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-        //
-        // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-        #[allow(clippy::option_if_let_else)]
-        let req = if let Some(body) = body {
-            let body = serde_json::to_vec(body)
-                .expect("serializing request body to JSON cannot fail")
-                .into();
-            req.header(hyper::header::CONTENT_TYPE, "application/json")
-                .body(body)
-        } else {
-            req.body(hyper::Body::default())
-        };
+        let mut current_attempt = 1;
+        let retry_limit = self.req_retries + 1;
 
-        let mut req = req.expect("cannot fail to create hyper request");
+        let res = loop {
+            let req = hyper::Request::builder().method(&method).uri(&uri);
 
-        if add_if_match {
-            req.headers_mut().insert(
-                hyper::header::IF_MATCH,
-                hyper::header::HeaderValue::from_static("*"),
+            // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
+            //
+            // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
+            #[allow(clippy::option_if_let_else)]
+            let req = if let Some(body) = body {
+                let body = serde_json::to_vec(body)
+                    .expect("serializing request body to JSON cannot fail")
+                    .into();
+                req.header(hyper::header::CONTENT_TYPE, "application/json")
+                    .body(body)
+            } else {
+                req.body(hyper::Body::default())
+            };
+            let mut req = req.expect("cannot fail to create hyper request");
+
+            if add_if_match {
+                req.headers_mut().insert(
+                    hyper::header::IF_MATCH,
+                    hyper::header::HeaderValue::from_static("*"),
+                );
+            }
+
+            let connector = match self.device.credentials.clone() {
+                aziot_identity_common::Credentials::SharedPrivateKey(key) => {
+                    let audience = format!(
+                        "{}/devices/{}",
+                        self.device.iothub_hostname, self.device.device_id
+                    );
+                    let key_handle = self.key_client.load_key(&key).await?;
+                    let (connector, token) = get_sas_connector(
+                        &audience,
+                        key_handle,
+                        &*self.key_client,
+                        self.proxy_uri.clone(),
+                        false,
+                    )
+                    .await?;
+
+                    let authorization_header_value =
+                        hyper::header::HeaderValue::from_str(&token)
+                            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                    req.headers_mut()
+                        .append(hyper::header::AUTHORIZATION, authorization_header_value);
+                    connector
+                }
+                aziot_identity_common::Credentials::Tpm => {
+                    let audience = format!(
+                        "{}/devices/{}",
+                        self.device.iothub_hostname, self.device.device_id
+                    );
+                    let (connector, token) = get_sas_connector(
+                        &audience,
+                        (),
+                        &*self.tpm_client,
+                        self.proxy_uri.clone(),
+                        false,
+                    )
+                    .await?;
+
+                    let authorization_header_value =
+                        hyper::header::HeaderValue::from_str(&token)
+                            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                    req.headers_mut()
+                        .append(hyper::header::AUTHORIZATION, authorization_header_value);
+                    connector
+                }
+                aziot_identity_common::Credentials::X509 {
+                    identity_cert,
+                    identity_pk,
+                } => {
+                    get_x509_connector(
+                        &identity_cert,
+                        &identity_pk,
+                        &self.key_client,
+                        &mut *self.key_engine.lock().await,
+                        &self.cert_client,
+                        self.proxy_uri.clone(),
+                    )
+                    .await?
+                }
+            };
+
+            let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);
+
+            let err = match tokio::time::timeout(self.req_timeout, client.request(req)).await {
+                Ok(res) => match res {
+                    Ok(res) => break res,
+                    Err(err) => std::io::Error::new(std::io::ErrorKind::Other, err),
+                },
+                Err(err) => err.into(),
+            };
+
+            log::warn!(
+                "Failed to communicate with IoT Hub (attempt {} of {}): {}",
+                current_attempt,
+                retry_limit,
+                err
             );
-        }
 
-        let connector = match hub_device.credentials.clone() {
-            aziot_identity_common::Credentials::SharedPrivateKey(key) => {
-                let audience = format!(
-                    "{}/devices/{}",
-                    hub_device.iothub_hostname, hub_device.device_id
-                );
-                let key_handle = self.key_client.load_key(&key).await?;
-                let (connector, token) = get_sas_connector(
-                    &audience,
-                    key_handle,
-                    &*self.key_client,
-                    self.proxy_uri.clone(),
-                    false,
-                )
-                .await?;
+            if current_attempt == retry_limit {
+                return Err(err);
+            }
 
-                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                req.headers_mut()
-                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
-                connector
-            }
-            aziot_identity_common::Credentials::Tpm => {
-                let audience = format!(
-                    "{}/devices/{}",
-                    hub_device.iothub_hostname, hub_device.device_id
-                );
-                let (connector, token) = get_sas_connector(
-                    &audience,
-                    (),
-                    &*self.tpm_client,
-                    self.proxy_uri.clone(),
-                    false,
-                )
-                .await?;
-
-                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                req.headers_mut()
-                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
-                connector
-            }
-            aziot_identity_common::Credentials::X509 {
-                identity_cert,
-                identity_pk,
-            } => {
-                get_x509_connector(
-                    &identity_cert,
-                    &identity_pk,
-                    &self.key_client,
-                    &mut *self.key_engine.lock().await,
-                    &self.cert_client,
-                    self.proxy_uri.clone(),
-                )
-                .await?
-            }
+            current_attempt += 1;
         };
 
-        let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);
+        Ok(res)
+    }
+}
 
-        let res = client
-            .request(req)
-            .await
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+async fn parse_response_body<TResponse>(
+    response: hyper::Response<hyper::Body>,
+) -> std::io::Result<TResponse>
+where
+    TResponse: serde::de::DeserializeOwned,
+{
+    let (
+        http::response::Parts {
+            status: res_status_code,
+            headers,
+            ..
+        },
+        body,
+    ) = response.into_parts();
+    log::debug!("IoTHub response status {:?}", res_status_code);
+    log::debug!("IoTHub response headers{:?}", headers);
 
-        let (
-            http::response::Parts {
-                status: res_status_code,
-                headers,
-                ..
-            },
-            body,
-        ) = res.into_parts();
-        log::debug!("IoTHub response status {:?}", res_status_code);
-        log::debug!("IoTHub response headers{:?}", headers);
-
-        let mut is_json = false;
-        for (header_name, header_value) in headers {
-            if header_name == Some(hyper::header::CONTENT_TYPE) {
-                let value = header_value
-                    .to_str()
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                if value.contains("application/json") {
-                    is_json = true;
-                }
+    let mut is_json = false;
+    for (header_name, header_value) in headers {
+        if header_name == Some(hyper::header::CONTENT_TYPE) {
+            let value = header_value
+                .to_str()
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            if value.contains("application/json") {
+                is_json = true;
             }
         }
+    }
 
-        let body = hyper::body::to_bytes(body)
-            .await
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+    let body = hyper::body::to_bytes(body)
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
 
-        let res: TResponse = match res_status_code {
-            hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
-                if !is_json {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "malformed HTTP response",
-                    ));
-                }
-                let res = serde_json::from_slice(&body)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                res
-            }
-
-            hyper::StatusCode::NOT_FOUND => {
-                let res: crate::Error = serde_json::from_slice(&body)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    res.message,
-                ));
-            }
-
-            res_status_code
-                if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-            {
-                let res: crate::Error = serde_json::from_slice(&body)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
-            }
-
-            _ => {
+    let res: TResponse = match res_status_code {
+        hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
+            if !is_json {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "malformed HTTP response",
-                ))
+                ));
             }
-        };
-        Ok(res)
-    }
+            let res = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            res
+        }
 
-    async fn request_no_content<TRequest>(
-        &self,
-        hub_device: &aziot_identity_common::IoTHubDevice,
-        method: http::Method,
-        uri: &str,
-        body: Option<&TRequest>,
-    ) -> std::io::Result<()>
-    where
-        TRequest: serde::Serialize,
-    {
-        let uri = format!("https://{}{}", hub_device.local_gateway_hostname, uri);
+        hyper::StatusCode::NOT_FOUND => {
+            let res: crate::Error = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                res.message,
+            ));
+        }
 
-        let req = hyper::Request::builder().method(method).uri(uri);
-        // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-        //
-        // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-        #[allow(clippy::option_if_let_else)]
-        let req = if let Some(body) = body {
-            let body = serde_json::to_vec(body)
-                .expect("serializing request body to JSON cannot fail")
-                .into();
-            req.header(hyper::header::CONTENT_TYPE, "application/json")
-                .body(body)
-        } else {
-            req.body(Default::default())
-        };
-        let mut req = req.expect("cannot fail to create hyper request");
+        res_status_code
+            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
+        {
+            let res: crate::Error = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
+        }
 
-        req.headers_mut().insert(
-            hyper::header::IF_MATCH,
-            hyper::header::HeaderValue::from_static("*"),
-        );
-
-        let connector = match hub_device.credentials.clone() {
-            aziot_identity_common::Credentials::SharedPrivateKey(key) => {
-                let audience = format!(
-                    "{}/devices/{}",
-                    hub_device.iothub_hostname, hub_device.device_id
-                );
-                let key_handle = self.key_client.load_key(&key).await?;
-                let (connector, token) = get_sas_connector(
-                    &audience,
-                    key_handle,
-                    &*self.key_client,
-                    self.proxy_uri.clone(),
-                    false,
-                )
-                .await?;
-
-                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                req.headers_mut()
-                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
-                connector
-            }
-            aziot_identity_common::Credentials::Tpm => {
-                let audience = format!(
-                    "{}/devices/{}",
-                    hub_device.iothub_hostname, hub_device.device_id
-                );
-                let (connector, token) = get_sas_connector(
-                    &audience,
-                    (),
-                    &*self.tpm_client,
-                    self.proxy_uri.clone(),
-                    false,
-                )
-                .await?;
-
-                let authorization_header_value = hyper::header::HeaderValue::from_str(&token)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                req.headers_mut()
-                    .append(hyper::header::AUTHORIZATION, authorization_header_value);
-                connector
-            }
-            aziot_identity_common::Credentials::X509 {
-                identity_cert,
-                identity_pk,
-            } => {
-                get_x509_connector(
-                    &identity_cert,
-                    &identity_pk,
-                    &self.key_client,
-                    &mut *self.key_engine.lock().await,
-                    &self.cert_client,
-                    self.proxy_uri.clone(),
-                )
-                .await?
-            }
-        };
-
-        let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);
-
-        let res = client
-            .request(req)
-            .await
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-        let (
-            http::response::Parts {
-                status: res_status_code,
-                headers,
-                ..
-            },
-            body,
-        ) = res.into_parts();
-
-        let body = hyper::body::to_bytes(body)
-            .await
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-        match res_status_code {
-            hyper::StatusCode::NO_CONTENT => Ok(()),
-
-            res_status_code
-                if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-            {
-                let mut is_json = false;
-                for (header_name, header_value) in headers {
-                    if header_name == Some(hyper::header::CONTENT_TYPE) {
-                        let value = header_value
-                            .to_str()
-                            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                        if value.contains("application/json") {
-                            is_json = true;
-                        }
-                    }
-                }
-
-                if !is_json {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "malformed HTTP response",
-                    ));
-                }
-
-                let res: crate::Error = serde_json::from_slice(&body)
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
-            }
-
-            _ => Err(std::io::Error::new(
+        _ => {
+            return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "malformed HTTP response",
-            )),
+            ))
         }
+    };
+    Ok(res)
+}
+
+async fn parse_response_empty(response: hyper::Response<hyper::Body>) -> std::io::Result<()> {
+    let (
+        http::response::Parts {
+            status: res_status_code,
+            headers,
+            ..
+        },
+        body,
+    ) = response.into_parts();
+
+    let body = hyper::body::to_bytes(body)
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+    match res_status_code {
+        hyper::StatusCode::NO_CONTENT => Ok(()),
+
+        res_status_code
+            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
+        {
+            let mut is_json = false;
+            for (header_name, header_value) in headers {
+                if header_name == Some(hyper::header::CONTENT_TYPE) {
+                    let value = header_value
+                        .to_str()
+                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                    if value.contains("application/json") {
+                        is_json = true;
+                    }
+                }
+            }
+
+            if !is_json {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "malformed HTTP response",
+                ));
+            }
+
+            let res: crate::Error = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
+        }
+
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "malformed HTTP response",
+        )),
     }
 }
 

--- a/identity/aziot-hub-client-async/src/lib.rs
+++ b/identity/aziot-hub-client-async/src/lib.rs
@@ -267,7 +267,14 @@ impl Client {
             let err = match tokio::time::timeout(self.req_timeout, client.request(req)).await {
                 Ok(res) => match res {
                     Ok(res) => break res,
-                    Err(err) => std::io::Error::new(std::io::ErrorKind::Other, err),
+                    Err(err) => {
+                        if err.is_connect() {
+                            // Network error.
+                            std::io::Error::new(std::io::ErrorKind::NotConnected, err)
+                        } else {
+                            std::io::Error::new(std::io::ErrorKind::Other, err)
+                        }
+                    }
                 },
                 Err(err) => err.into(),
             };

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -49,17 +49,17 @@ impl Settings {
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    fn is_default_timeout(timeout: &u64) -> bool {
+    pub fn is_default_timeout(timeout: &u64) -> bool {
         *timeout == Settings::default_cloud_timeout()
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    fn is_default_retries(retries: &u32) -> bool {
+    pub fn is_default_retries(retries: &u32) -> bool {
         *retries == Settings::default_cloud_retries()
     }
 }
 
-fn deserialize_cloud_timeout<'de, D>(deserializer: D) -> Result<u64, D::Error>
+pub fn deserialize_cloud_timeout<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -14,11 +14,15 @@ pub struct Settings {
 
     #[serde(
         default = "Settings::default_cloud_timeout",
-        deserialize_with = "deserialize_cloud_timeout"
+        deserialize_with = "deserialize_cloud_timeout",
+        skip_serializing_if = "Settings::is_default_timeout"
     )]
     pub cloud_timeout_sec: u64,
 
-    #[serde(default = "Settings::default_cloud_retries")]
+    #[serde(
+        default = "Settings::default_cloud_retries",
+        skip_serializing_if = "Settings::is_default_retries"
+    )]
     pub cloud_retries: u32,
 
     pub provisioning: Provisioning,
@@ -42,6 +46,16 @@ impl Settings {
 
     pub fn default_cloud_retries() -> u32 {
         0
+    }
+
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    fn is_default_timeout(timeout: &u64) -> bool {
+        *timeout == Settings::default_cloud_timeout()
+    }
+
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    fn is_default_retries(retries: &u32) -> bool {
+        *retries == Settings::default_cloud_retries()
     }
 }
 

--- a/identity/aziot-identityd/src/error.rs
+++ b/identity/aziot-identityd/src/error.rs
@@ -24,19 +24,10 @@ impl Error {
 
     pub(crate) fn is_network(&self) -> bool {
         match &self {
-            Error::DpsClient(err) | Error::HubClient(err) => match err.kind() {
-                std::io::ErrorKind::TimedOut => true, // Network timed out
-                std::io::ErrorKind::Other => {
-                    if let Some(err) = err.get_ref() {
-                        // TODO: check if error is hyper::Error
-                        return true;
-                    }
-
-                    false
-                }
-                _ => false,
-            },
-
+            Error::DpsClient(err) | Error::HubClient(err) => matches!(
+                err.kind(),
+                std::io::ErrorKind::TimedOut | std::io::ErrorKind::NotConnected
+            ),
             _ => false,
         }
     }

--- a/identity/aziot-identityd/src/error.rs
+++ b/identity/aziot-identityd/src/error.rs
@@ -21,6 +21,25 @@ impl Error {
     {
         Error::InvalidParameter(name, err.into())
     }
+
+    pub(crate) fn is_network(&self) -> bool {
+        match &self {
+            Error::DpsClient(err) | Error::HubClient(err) => match err.kind() {
+                std::io::ErrorKind::TimedOut => true, // Network timed out
+                std::io::ErrorKind::Other => {
+                    if let Some(err) = err.get_ref() {
+                        // TODO: check if error is hyper::Error
+                        return true;
+                    }
+
+                    false
+                }
+                _ => false,
+            },
+
+            _ => false,
+        }
+    }
 }
 
 impl std::fmt::Display for Error {

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -893,18 +893,6 @@ impl IdentityManager {
                         std::collections::BTreeSet::default()
                     };
 
-                // Write out device state and settings.
-                // This overwrites any existing device state and settings backup.
-                std::fs::write(prev_device_info_path, device_status)
-                    .map_err(|err| Error::Internal(InternalError::SaveDeviceInfo(err)))?;
-
-                std::fs::write(prev_settings_path, &settings_serialized)
-                    .map_err(|err| Error::Internal(InternalError::SaveSettings(err)))?;
-
-                if prev_module_set.is_empty() && current_module_set.is_empty() {
-                    return Ok(());
-                }
-
                 let hub_module_ids = self.get_module_identities().await?;
 
                 for m in hub_module_ids {
@@ -932,6 +920,14 @@ impl IdentityManager {
                     self.create_module_identity(&m.0).await?;
                     log::info!("Hub identity {:?} added", &m.0);
                 }
+
+                // Write out device state and settings.
+                // This overwrites any existing device state and settings backup.
+                std::fs::write(prev_device_info_path, device_status)
+                    .map_err(|err| Error::Internal(InternalError::SaveDeviceInfo(err)))?;
+
+                std::fs::write(prev_settings_path, &settings_serialized)
+                    .map_err(|err| Error::Internal(InternalError::SaveSettings(err)))?;
             }
             None => log::info!("reconcilation skipped since device is not provisioned"),
         }

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -893,8 +893,8 @@ impl IdentityManager {
                         std::collections::BTreeSet::default()
                     };
 
-                // Write out device info and settings.
-                // This overwrites the existing device state and settings backup.
+                // Write out device state and settings.
+                // This overwrites any existing device state and settings backup.
                 std::fs::write(prev_device_info_path, device_status)
                     .map_err(|err| Error::Internal(InternalError::SaveDeviceInfo(err)))?;
 

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -893,6 +893,14 @@ impl IdentityManager {
                         std::collections::BTreeSet::default()
                     };
 
+                // Write out device info and settings.
+                // This overwrites the existing device state and settings backup.
+                std::fs::write(prev_device_info_path, device_status)
+                    .map_err(|err| Error::Internal(InternalError::SaveDeviceInfo(err)))?;
+
+                std::fs::write(prev_settings_path, &settings_serialized)
+                    .map_err(|err| Error::Internal(InternalError::SaveSettings(err)))?;
+
                 if prev_module_set.is_empty() && current_module_set.is_empty() {
                     return Ok(());
                 }
@@ -924,12 +932,6 @@ impl IdentityManager {
                     self.create_module_identity(&m.0).await?;
                     log::info!("Hub identity {:?} added", &m.0);
                 }
-
-                let () = std::fs::write(prev_device_info_path, device_status)
-                    .map_err(|err| Error::Internal(InternalError::SaveDeviceInfo(err)))?;
-
-                let () = std::fs::write(prev_settings_path, &settings_serialized)
-                    .map_err(|err| Error::Internal(InternalError::SaveSettings(err)))?;
             }
             None => log::info!("reconcilation skipped since device is not provisioned"),
         }

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -17,6 +17,8 @@ pub(crate) const DEVICE_BACKUP_LOCATION: &str = "device_info";
 
 pub struct IdentityManager {
     homedir_path: std::path::PathBuf,
+    req_timeout: std::time::Duration,
+    req_retries: u32,
     key_client: Arc<aziot_key_client_async::Client>,
     key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
     cert_client: Arc<aziot_cert_client_async::Client>,
@@ -28,6 +30,8 @@ pub struct IdentityManager {
 impl IdentityManager {
     pub fn new(
         homedir_path: std::path::PathBuf,
+        req_timeout: std::time::Duration,
+        req_retries: u32,
         key_client: Arc<aziot_key_client_async::Client>,
         key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
         cert_client: Arc<aziot_cert_client_async::Client>,
@@ -37,6 +41,8 @@ impl IdentityManager {
     ) -> Self {
         IdentityManager {
             homedir_path,
+            req_timeout,
+            req_retries,
             key_client,
             key_engine,
             cert_client,
@@ -70,6 +76,8 @@ impl IdentityManager {
             Some(device) => {
                 let client = aziot_hub_client_async::Client::new(
                     device.clone(),
+                    self.req_timeout,
+                    self.req_retries,
                     self.key_client.clone(),
                     self.key_engine.clone(),
                     self.cert_client.clone(),
@@ -150,6 +158,8 @@ impl IdentityManager {
             Some(device) => {
                 let client = aziot_hub_client_async::Client::new(
                     device.clone(),
+                    self.req_timeout,
+                    self.req_retries,
                     self.key_client.clone(),
                     self.key_engine.clone(),
                     self.cert_client.clone(),
@@ -246,6 +256,8 @@ impl IdentityManager {
             Some(device) => {
                 let client = aziot_hub_client_async::Client::new(
                     device.clone(),
+                    self.req_timeout,
+                    self.req_retries,
                     self.key_client.clone(),
                     self.key_engine.clone(),
                     self.cert_client.clone(),
@@ -332,6 +344,8 @@ impl IdentityManager {
             Some(device) => {
                 let client = aziot_hub_client_async::Client::new(
                     device.clone(),
+                    self.req_timeout,
+                    self.req_retries,
                     self.key_client.clone(),
                     self.key_engine.clone(),
                     self.cert_client.clone(),
@@ -388,6 +402,8 @@ impl IdentityManager {
             Some(device) => {
                 let client = aziot_hub_client_async::Client::new(
                     device.clone(),
+                    self.req_timeout,
+                    self.req_retries,
                     self.key_client.clone(),
                     self.key_engine.clone(),
                     self.cert_client.clone(),
@@ -591,6 +607,8 @@ impl IdentityManager {
                 let dps_client = aziot_dps_client_async::Client::new(
                     &global_endpoint,
                     &scope_id,
+                    self.req_timeout,
+                    self.req_retries,
                     self.key_client.clone(),
                     self.key_engine.clone(),
                     self.cert_client.clone(),

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -10,6 +10,7 @@
     clippy::missing_errors_doc,
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
+    clippy::too_many_arguments,
     clippy::too_many_lines,
     clippy::type_complexity
 )]
@@ -156,6 +157,8 @@ impl Api {
 
         let id_manager = identity::IdentityManager::new(
             settings.homedir.clone(),
+            std::time::Duration::from_secs(settings.cloud_timeout_sec),
+            settings.cloud_retries,
             key_client.clone(),
             key_engine.clone(),
             cert_client.clone(),
@@ -421,16 +424,32 @@ impl Api {
             match err {
                 Error::HubClient(_) => match trigger {
                     ReprovisionTrigger::Startup | ReprovisionTrigger::ConfigurationFileUpdate => {
+                        // Network errors are not fatal because Identity Service can still run off its backup.
+                        if err.is_network() {
+                            log::warn!("Network not available for Identity reconciliation. Using offline backup from last run.");
+
+                            return Ok(());
+                        }
+
                         log::info!("Could not reconcile Identities with current device data. Reprovisioning.");
 
-                        self.id_manager
+                        if let Err(err) = self
+                            .id_manager
                             .provision_device(self.settings.provisioning.clone(), false)
-                            .await?;
-                        log::info!("Successfully reprovisioned.");
+                            .await
+                        {
+                            if err.is_network() {
+                                log::warn!("Reprovisioning failed to communicate with DPS. Using offline backup from last run.");
+                            } else {
+                                return Err(err);
+                            }
+                        } else {
+                            log::info!("Successfully reprovisioned.");
 
-                        self.id_manager
-                            .reconcile_hub_identities(self.settings.clone())
-                            .await?;
+                            self.id_manager
+                                .reconcile_hub_identities(self.settings.clone())
+                                .await?;
+                        }
                     }
 
                     // Don't attempt to reprovision if this function was called by the reprovision API.

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -51,7 +51,7 @@ macro_rules! match_id_type {
     };
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum ReprovisionTrigger {
     ConfigurationFileUpdate,
     Api,
@@ -540,7 +540,7 @@ impl Api {
         // Attempt to re-provision the device. Failures need to be logged and the device should
         // run offline.
         if let Err(err) = self
-            .reprovision_device(auth::AuthId::LocalRoot, trigger.clone())
+            .reprovision_device(auth::AuthId::LocalRoot, trigger)
             .await
         {
             // Failure to reprovision on startup means that provisioning with IoT Hub failed and


### PR DESCRIPTION
Fixes Identity Service when starting offline:
- Fix a bug where device backups weren't written unless at least one module was specified.
- Abort IS if provisioning fails and no backup can be read. This should be considered a fatal error because none of the APIs will work without device information.
- Fix documentation for /identities/device.
- Adds the `cloud_timeout_sec` and `cloud_retries` options to Identity Service config.