### PR TITLE
Remove override of tpm2-pkcs11 store file.

### DIFF
--- a/docs-dev/running/aziot-keyd.md
+++ b/docs-dev/running/aziot-keyd.md
@@ -165,12 +165,6 @@ Assuming you're using Microsoft's implementation of `libaziot_keys.so`, start wi
 
     For `x509_thumbprint` and `x509_ca`, if the keys are backed by hardware, use a `pkcs11:` URI instead of a `file://` URI.
 
-1. If you're using PKCS#11 and specifically the `tpm2-pkcs11` library, remember to also export the `TPM2_PKCS11_STORE` env var.
-
-    ```sh
-    export TPM2_PKCS11_STORE=/opt/tpm2-pkcs11
-    ```
-
 1. Create the `/run/aziot` directory if it doesn't already exist, and make sure it's readable and writable by the user you will run the service as.
 
 1. Run the service, setting the `AZIOT_KEYD_CONFIG` and `AZIOT_KEYD_CONFIG_DIR` env vars if necessary.

--- a/docs/pkcs11/tpm2-pkcs11.md
+++ b/docs/pkcs11/tpm2-pkcs11.md
@@ -163,19 +163,11 @@ wait $(jobs -pr)
 
     cd ~/src/tpm2-pkcs11
 
-    # The `tpm2-pkcs11` library uses a filesystem directory
-    # to store wrapped keys.
-    sudo mkdir -p /opt/tpm2-pkcs11
-    # aziotks was created by the aziot-identity-service package.
-    sudo chown aziotks:aziotks /opt/tpm2-pkcs11
-    sudo chmod 0700 /opt/tpm2-pkcs11
-
     # --enable-debug=!yes is needed to disable assert() in
     # CKR_FUNCTION_NOT_SUPPORTED-returning unimplemented functions.
     ./configure \
         --enable-debug=info \
-        --enable-esapi-session-manage-flags \
-        --with-storedir=/opt/tpm2-pkcs11
+        --enable-esapi-session-manage-flags
     make "-j$(nproc)"
     sudo make install
 )
@@ -199,9 +191,6 @@ SO_PIN="so$PIN"
 
 sudo tpm2_clear
 
-# This is the directory tpm2-pkcs11 was configured to use.
-export TPM2_PKCS11_STORE='/opt/tpm2-pkcs11'
-
 # tpm2_ptool requires Python 3 >= 3.7 and expects `python3`
 # to be that version by default.
 #
@@ -211,7 +200,7 @@ export TPM2_PKCS11_STORE='/opt/tpm2-pkcs11'
 #
 # export PYTHON_INTERPRETER=python3.7
 
-sudo rm -f "$TPM2_PKCS11_STORE/tpm2_pkcs11.sqlite3"
+sudo rm -rf /var/lib/aziot/keyd/.tpm2_pkcs11
 (
     cd ~/src/tpm2-pkcs11/tools &&
     sudo -u aziotks ./tpm2_ptool init --primary-auth '1234' &&


### PR DESCRIPTION
The existing instructions for creating the base slot were wrong because
`sudo -u aziotks ./tpm2_ptool` would not see the `TPM2_PKCS11_STORE` env var.
But we don't really care to override the default store location anyway;
the default will put it in `$HOME/.tpm2_pkcs11` where `$HOME` is
aziotks's homedir, which is just as good a place for it as anywhere else.

If the user does want to override the store location for some reason,
they can do it on their own.