### PR TITLE
Ignore duplicate cert error when adding certs to trusted store in openssl 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "log",
  "nix",
  "openssl",
+ "openssl-sys",
  "percent-encoding",
  "serde",
  "serde_json",

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -17,6 +17,7 @@ libc = "0.2"
 log = "0.4"
 nix = "0.18"
 openssl = { version = "0.10", optional = true }
+openssl-sys = { version = "0.9", optional = true }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -29,4 +30,4 @@ url = { version = "2", features = ["serde"] }
 serde_json = "1"
 
 [features]
-tokio1 = ["headers", "hyper", "hyper-openssl", "hyper-proxy", "openssl", "tokio"]
+tokio1 = ["headers", "hyper", "hyper-openssl", "hyper-proxy", "openssl", "openssl-sys", "tokio"]


### PR DESCRIPTION
This was originally found with IoT Edge 1.1 because it used an old version of
native-tls that also forwarded this error. IoT Edge fixed the issue by updating
its use of native-tls to a version that ignores this error
(and all other errors).