### PR TITLE
Fix Identity Service auth for local IDs

### DIFF
--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -659,6 +659,7 @@ impl auth::authorization::Authorizer for SettingsAuthorizer {
                     p.name.0 == m
                         && p.id_type.map_or(false, |i| {
                             i.contains(&aziot_identity_common::IdType::Module)
+                                || i.contains(&aziot_identity_common::IdType::Local)
                         })
                 }
                 auth::OperationType::GetDevice => p


### PR DESCRIPTION
A refactor of the auth code forgot to add local IDs. Fixed so that local IDs are authorized the same as module IDs.