### PR TITLE
Update ex_data.rs for Rust > 1.51

### DIFF
--- a/key/aziot-key-openssl-engine/src/ex_data.rs
+++ b/key/aziot-key-openssl-engine/src/ex_data.rs
@@ -116,18 +116,7 @@ where
 
     let ptr = from_d.cast::<*const U>();
     if !ptr.is_null() {
-        // TODO:
-        // Replace this block's contents with `std::sync::Arc::increment_ref_count(ptr)`
-        // when iotedge starts using Rust 1.51+
-
-        let ex_data = std::sync::Arc::from_raw(*ptr);
-
-        // Bump the refcount ...
-        let ex_data_clone = ex_data.clone();
-
-        // ... and `forget` the two `Arc`s, so that they don't get dropped and decrease the refcount again.
-        std::mem::forget(ex_data);
-        std::mem::forget(ex_data_clone);
+        std::sync::Arc::increment_strong_count(ptr);
     }
 }
 
@@ -140,12 +129,7 @@ where
 
     let ptr = ptr.cast::<U>();
     if !ptr.is_null() {
-        // TODO:
-        // Replace this block's contents with `std::sync::Arc::decrement_ref_count(ptr)`
-        // when iotedge starts using Rust 1.51+
-
-        let ex_data = std::sync::Arc::from_raw(ptr);
-        drop(ex_data);
+        std::sync::Arc::decrement_strong_count(ptr);
     }
 }
 


### PR DESCRIPTION
Removes workaround for edgelet that was using 1.47.

This reverts d539159c8d23719eeb303392f1062622971b8708