### PR TITLE
Reject DPS results with status failed

### DIFF
--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -719,6 +719,14 @@ impl IdentityManager {
         assert!(!status.eq_ignore_ascii_case("assigning"));
 
         let mut state = operation.registration_state.ok_or(Error::DeviceNotFound)?;
+
+        if state.status == Some("failed".to_string()) {
+            return Err(Error::DpsClient(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                state.error_message.unwrap_or_default(),
+            )));
+        }
+
         let iothub_hostname = state.assigned_hub.get_or_insert("".into());
         let device_id = state.device_id.get_or_insert("".into());
         let device = aziot_identity_common::IoTHubDevice {

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -715,12 +715,9 @@ impl IdentityManager {
             .await
             .map_err(Error::DpsClient)?;
 
-        let status = operation.status;
-        assert!(!status.eq_ignore_ascii_case("assigning"));
-
         let mut state = operation.registration_state.ok_or(Error::DeviceNotFound)?;
 
-        if state.status == Some("failed".to_string()) {
+        if state.status.as_deref() == Some("failed") {
             return Err(Error::DpsClient(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 state.error_message.unwrap_or_default(),

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -720,15 +720,15 @@ impl IdentityManager {
 
         let state = operation.registration_state.ok_or(Error::DeviceNotFound)?;
 
-        if state.assigned_hub.is_none() || state.device_id.is_none() {
-            return Err(Error::DpsClient(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                state.error_message.unwrap_or_default(),
-            )));
-        }
-
-        let iothub_hostname = state.assigned_hub.expect("assigned_hub should not be none");
-        let device_id = state.device_id.expect("device_id should not be none");
+        let (iothub_hostname, device_id) = match (state.assigned_hub, state.device_id) {
+            (Some(iothub_hostname), Some(device_id)) => (iothub_hostname, device_id),
+            _ => {
+                return Err(Error::DpsClient(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    state.error_message.unwrap_or_default(),
+                )))
+            }
+        };
 
         Ok(aziot_identity_common::IoTHubDevice {
             local_gateway_hostname: local_gateway_hostname


### PR DESCRIPTION
Fail DPS provisioning if the response has status `failed`.