### PR TITLE
Purge module identities on device reprovision

### DIFF
--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -88,7 +88,7 @@ impl IdentityManager {
             if let Err(err) = std::fs::remove_dir_all(module_backup_path) {
                 if err.kind() != std::io::ErrorKind::NotFound {
                     log::warn!(
-                        "Failed to module identities before reprovisioning: {}",
+                        "Failed to clear module identities before reprovisioning: {}",
                         err
                     );
                 }


### PR DESCRIPTION
This is a port of https://github.com/Azure/iotedge/pull/4833.

Like in 1.1, we need to delete existing module identities on a reprovision because those module identities may no longer be valid.