### PR TITLE
Add an openapi spec for the Identity Service

### DIFF
--- a/identity/aziot-identityd/openapi/2020-09-01-preview.yaml
+++ b/identity/aziot-identityd/openapi/2020-09-01-preview.yaml
@@ -1,4 +1,4 @@
-# Ref: https://spec.openapis.org/oas/v4.0.3
+# Ref: https://spec.openapis.org/oas/v3.0.3
 
 openapi: 3.0.1
 
@@ -202,12 +202,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateIdentityRequest'
+              $ref: '#/components/schemas/CreateModuleRequest'
             examples:
               'Module identity':
                 value:
                   type: 'aziot'
                   moduleId: 'module01'
+              'Local identity':
+                value:
+                  type: 'local'
+                  moduleId: 'module01'
+                  localIdOpts:
+                    type: 'x509'
+                    attributes: 'server'
         required: true
       x-codegen-request-body-name: CreateModuleIdentityRequest
       responses:
@@ -216,7 +223,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AziotModuleIdentityResponse'
+                $ref: '#/components/schemas/ModuleIdentityResponse'
               examples:
                 'SAS case':
                   value:
@@ -243,6 +250,15 @@ paths:
                         type: 'x509'
                         keyHandle: 'string'
                         certId: 'string'
+                'Local identity':
+                  value:
+                    type: 'local'
+                    spec:
+                      moduleId: 'module01'
+                      auth:
+                        privateKey: 'private key bytes'
+                        certificate: 'certificate bytes'
+                        expiration: 'yyyy-mm-ddThh:mm:ss+00:00'
         default:
           description: Unexpected error
           content:
@@ -253,7 +269,7 @@ paths:
   /identities/modules/{id}?api-version=2020-09-01:
     parameters:
       - $ref: '#/components/parameters/IdentityName'
-      - $ref: '#/components/parameters/AziotIdentityTypeParameter'
+      - $ref: '#/components/parameters/AnyModuleIdentityTypeParameter'
     get:
       tags:
       - Identity operations
@@ -265,7 +281,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AziotModuleIdentityResponse'
+                $ref: '#/components/schemas/ModuleIdentityResponse'
               examples:
                 'SAS case':
                   value:
@@ -292,6 +308,15 @@ paths:
                         type: 'x509'
                         keyHandle: 'string'
                         certId: 'string'
+                'Local identity':
+                  value:
+                    type: 'local'
+                    spec:
+                      moduleId: 'module01'
+                      auth:
+                        privateKey: 'private key bytes'
+                        certificate: 'certificate bytes'
+                        expiration: 'yyyy-mm-ddThh:mm:ss+00:00'
         default:
           description: Unexpected error
           content:
@@ -346,6 +371,19 @@ paths:
 
 components:
   schemas:
+    AnyIdentityType:
+      type: string
+      enum:
+      - aziot
+      - local
+      example:
+        local:
+          value: local
+          summary: 'Local identity.'
+        aziot:
+          value: aziot
+          summary: 'Module identity.'
+
     AuthenticationCredentials:
       required:
       - type
@@ -464,11 +502,69 @@ components:
       type: object
       properties:
         'type':
-          $ref: '#/components/schemas/AziotIdentityType'
+          type: string
+          description: The identity type.
+          example: aziot
+          enum:
+          - aziot
+          - local
         'moduleId':
           type: string
           description: Name of the module to add to the identity registry.
           example: module01
+
+    CreateLocalIdentityRequest:
+      allOf:
+      - $ref: '#/components/schemas/CreateIdentityRequest'
+      - type: 'object'
+        properties:
+          'localIdOpts':
+            type: object
+            default: '{"type": "x509", "attributes": "client"}'
+            properties:
+              'type':
+                type: string
+                description: Type of local identity. Currently, only x509 is supported.
+                enum:
+                - x509
+              'attributes':
+                type: string
+                description: Attributes of the X.509 local identity certificate. May be either client or server.
+                enum:
+                - client
+                - server
+            description: Optional field to specify configuration of the issued local identity.
+
+    CreateModuleRequest:
+      oneOf:
+      - $ref: '#/components/schemas/CreateIdentityRequest'
+      - $ref: '#/components/schemas/CreateLocalIdentityRequest'
+      discriminator:
+        propertyName: type
+        mapping:
+          aziot: '#/components/schemas/CreateIdentityRequest'
+          local: '#/components/schemas/CreateLocalIdentityRequest'
+#      required:
+#      - moduleId
+#      - type
+#      type: object
+#      properties:
+#        'type':
+#          type: string
+#          description: The identity type.
+#          example: aziot
+#          enum:
+#          - aziot
+#          - local
+#        'moduleId':
+#          type: string
+#          description: Name of the module to add to the identity registry.
+#          example: module01
+#      discriminator:
+#        propertyName: 'type'
+#        mapping:
+#          'aziot': '#/components/schemas/CreateIdentityRequest'
+#          'local': '#/components/schemas/CreateLocalIdentityRequest'
 
     ErrorResponse:
       required:
@@ -477,6 +573,57 @@ components:
       properties:
         'message':
           type: string
+
+    LocalIdentityResponse:
+      required:
+      - spec
+      - type
+      type: object
+      properties:
+        'type':
+          $ref: '#/components/schemas/LocalIdentityType'
+        'spec':
+          $ref: '#/components/schemas/LocalIdentitySpec'
+
+    LocalIdentitySpec:
+      required:
+      - moduleId
+      - auth
+      type: object
+      properties:
+        'moduleId':
+          type: string
+          description: The identity name for the workload in the local registry.
+          example: module01
+        'auth':
+          type: object
+          properties:
+            'privateKey':
+              type: string
+              format: byte
+            'certificate':
+              type: string
+              format: byte
+            'expiration':
+              type: string
+              format: date-time
+      description: The local identity specification.
+
+    LocalIdentityType:
+      type: string
+      example: local
+      enum:
+      - local
+
+    ModuleIdentityResponse:
+      oneOf:
+      - $ref: '#/components/schemas/AziotModuleIdentityResponse'
+      - $ref: '#/components/schemas/LocalIdentityResponse'
+      discriminator:
+        propertyName: 'type'
+        mapping:
+          'aziot': '#/components/schemas/AziotModuleIdentityResponse'
+          'local': '#/components/schemas/LocalIdentityResponse'
 
     ProvisioningResultRequest:
       required:
@@ -509,6 +656,27 @@ components:
       allOf:
       - $ref: '#/components/schemas/UpdateModuleRequest'
 
+    UpdateLocalIdentityRequest:
+      allOf:
+      - $ref: '#/components/schemas/UpdateModuleRequest'
+      - type: 'object'
+        properties:
+          'localIdOpts':
+            type: object
+            properties:
+              'type':
+                type: string
+                description: Type of local identity. Currently, only x509 is supported.
+                enum:
+                - x509
+              'attributes':
+                type: string
+                description: Attributes of the X.509 local identity certificate. May be either client or server.
+                enum:
+                - client
+                - server
+            description: Optional field to specify configuration of the issued local identity.
+
     UpdateModuleRequest:
       required:
       - moduleId
@@ -521,10 +689,16 @@ components:
           example: aziot
           enum:
           - aziot
+          - local
         'moduleId':
           type: string
           description: Name of the module to add to the identity registry.
           example: module01
+      discriminator:
+        propertyName: 'type'
+        mapping:
+          'aziot': '#/components/schemas/UpdateAziotIdentityRequest'
+          'local': '#/components/schemas/UpdateLocalIdentityRequest'
 
     X509AuthenticationCredentials:
       allOf:
@@ -551,6 +725,14 @@ components:
       required: true
       schema:
         type: string
+
+    AnyModuleIdentityTypeParameter:
+      name: type
+      in: query
+      description: Supported identity types
+      required: true
+      schema:
+        $ref: '#/components/schemas/AnyIdentityType'
 
     AziotIdentityTypeParameter:
       name: type

--- a/identity/aziot-identityd/openapi/2020-09-01-preview.yaml
+++ b/identity/aziot-identityd/openapi/2020-09-01-preview.yaml
@@ -116,7 +116,7 @@ paths:
                   'type':
                     $ref: '#/components/schemas/AziotIdentityType'
                   'spec':
-                    $ref: '#/components/schemas/AziotDeviceIdentitySpec'
+                    $ref: '#/components/schemas/AziotIdentitySpec'
               examples:
                 'SAS case':
                   value:
@@ -146,14 +146,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /identities/modules?api-version=2020-09-01:
+  /identities/modules?api-version=2020-09-01&type={type}:
+    parameters:
+    - $ref: '#/components/parameters/AziotIdentityTypeParameter'
     get:
       tags:
       - Identity operations
       summary: List IoT module identities
       operationId: getModuleIdentities
-      parameters:
-      - $ref: '#/components/parameters/AziotIdentityTypeParameter'
       responses:
         200:
           description: Ok
@@ -193,6 +193,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /identities/modules?api-version=2020-09-01:
     post:
       tags:
       - Identity operations
@@ -267,10 +269,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /identities/modules/{id}?api-version=2020-09-01:
+  /identities/modules/{id}?api-version=2020-09-01&type={type}:
     parameters:
       - $ref: '#/components/parameters/IdentityName'
-      - $ref: '#/components/parameters/ModuleIdentityTypes'
+      - $ref: '#/components/parameters/ModuleIdentityKind'
     get:
       tags:
       - Identity operations
@@ -389,33 +391,6 @@ components:
           sas: '#/components/schemas/SASAuthenticationCredentials'
           x509: '#/components/schemas/X509AuthenticationCredentials'
 
-    AziotDeviceIdentitySpec:
-      required:
-      - auth
-      - deviceId
-      - gatewayHost
-      - hubName
-      type: object
-      properties:
-        'hubName':
-          type: string
-          description: The name of the IoT hub where the device is provisioned.
-          example: myhub.net
-        'gatewayHost':
-          type: string
-          description: The hostname of the parent Edge gateway that intermediates
-            all requests for the current device when in a nested configuration. In
-            a single-node deployment (i.e. non-nested) it will match the 'hubName'.
-          example: parentdevice
-        'deviceId':
-          type: string
-          description: The identity name of the provisioned device in the assigned
-            IoT Hub.
-          example: device01
-        'auth':
-          $ref: '#/components/schemas/AuthenticationCredentials'
-      description: The device identity specification.
-
     AziotIdentityResponse:
       required:
       - spec
@@ -437,9 +412,39 @@ components:
             $ref: '#/components/schemas/AziotModuleIdentityResponse'
 
     AziotIdentitySpec:
-      oneOf:
-      - $ref: '#/components/schemas/AziotDeviceIdentitySpec'
-      - $ref: '#/components/schemas/AziotModuleIdentitySpec'
+      required:
+      - deviceId
+      - gatewayHost
+      - hubName
+      type: object
+      properties:
+        'hubName':
+          type: string
+          description: The name of the IoT hub where the device is provisioned.
+          example: myhub.net
+        'gatewayHost':
+          type: string
+          description: The hostname of the parent Edge gateway that intermediates
+            all requests for the current device when in a nested configuration. In
+            a single-node deployment (i.e. non-nested) it will match the 'hubName'.
+          example: parentdevice
+        'deviceId':
+          type: string
+          description: The identity name of the provisioned device in the assigned
+            IoT Hub.
+          example: device01
+        'moduleId':
+          type: string
+          description: The identity name of the device workload in the provisioned
+            device in the assigned IoT Hub.
+          example: module01
+        'genId':
+          type: string
+          description: The generation ID of the device workload assigned by IoT Hub.
+          example: "12345"
+        'auth':
+          $ref: '#/components/schemas/AuthenticationCredentials'
+      description: The device identity specification.
 
     AziotIdentityType:
       type: string
@@ -463,12 +468,8 @@ components:
 
     AziotModuleIdentitySpec:
       allOf:
-      - $ref: '#/components/schemas/AziotDeviceIdentitySpec'
+      - $ref: '#/components/schemas/AziotIdentitySpec'
       required:
-      - auth
-      - deviceId
-      - gatewayHost
-      - hubName
       - moduleId
       - genId
       type: object
@@ -491,7 +492,7 @@ components:
       type: object
       properties:
         'type':
-          $ref: '#/components/schemas/IdentityTypes'
+          $ref: '#/components/schemas/IdentityKind'
         'moduleId':
           type: string
           description: Name of the module to add to the identity registry.
@@ -523,7 +524,7 @@ components:
         'message':
           type: string
 
-    IdentityTypes:
+    IdentityKind:
       type: string
       description: The identity type.
       enum:
@@ -625,7 +626,9 @@ components:
       type: object
       properties:
         'type':
-          $ref: '#/components/schemas/AziotIdentityType'
+          type: string
+          enum:
+          - aziot
 
     SASAuthenticationCredentials:
       allOf:
@@ -655,6 +658,14 @@ components:
 
 
   parameters:
+    AziotIdentityTypeParameter:
+      name: type
+      in: path
+      description: Aziot identity type
+      required: true
+      schema:
+        $ref: '#/components/schemas/AziotIdentityType'
+
     IdentityName:
       name: id
       in: path
@@ -664,19 +675,12 @@ components:
       schema:
         type: string
 
-    ModuleIdentityTypes:
+    ModuleIdentityKind:
       name: type
-      in: query
+      in: path
       description: Supported identity types
       required: true
       schema:
-        $ref: '#/components/schemas/IdentityTypes'
+        $ref: '#/components/schemas/IdentityKind'
 
-    AziotIdentityTypeParameter:
-      name: type
-      in: query
-      description: Aziot identity type
-      required: true
-      schema:
-        $ref: '#/components/schemas/AziotIdentityType'
 

--- a/identity/aziot-identityd/openapi/2020-09-01-preview.yaml
+++ b/identity/aziot-identityd/openapi/2020-09-01-preview.yaml
@@ -95,7 +95,8 @@ paths:
       operationId: getDeviceIdentity
       x-codegen-request-body-name: GetDeviceIdentityRequest
       requestBody:
-        description: Type of identity to reprovision
+        description: The type of provisioned identity
+        required: true
         content:
           application/json:
             schema:
@@ -197,8 +198,10 @@ paths:
       - Identity operations
       summary: Create IoT module identity
       operationId: createModuleIdentity
+      x-codegen-request-body-name: CreateModuleIdentityRequest
       requestBody:
-        description: Data for a module identity to register
+        description: The type of module identity to create
+        required: true
         content:
           application/json:
             schema:
@@ -215,8 +218,6 @@ paths:
                   localIdOpts:
                     type: 'x509'
                     attributes: 'server'
-        required: true
-      x-codegen-request-body-name: CreateModuleIdentityRequest
       responses:
         200:
           description: Ok
@@ -269,7 +270,7 @@ paths:
   /identities/modules/{id}?api-version=2020-09-01:
     parameters:
       - $ref: '#/components/parameters/IdentityName'
-      - $ref: '#/components/parameters/AnyModuleIdentityTypeParameter'
+      - $ref: '#/components/parameters/ModuleIdentityTypes'
     get:
       tags:
       - Identity operations
@@ -346,14 +347,14 @@ paths:
       - Identity operations
       summary: Trigger an IoT device reprovisioning flow
       operationId: reprovision
+      x-codegen-request-body-name: ReprovisionRequest
       requestBody:
         description: Type of identity to reprovision
+        required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ReprovisionRequest'
-        required: true
-      x-codegen-request-body-name: ReprovisionRequest
       responses:
         200:
           description: Ok
@@ -371,19 +372,6 @@ paths:
 
 components:
   schemas:
-    AnyIdentityType:
-      type: string
-      enum:
-      - aziot
-      - local
-      example:
-        local:
-          value: local
-          summary: 'Local identity.'
-        aziot:
-          value: aziot
-          summary: 'Module identity.'
-
     AuthenticationCredentials:
       required:
       - type
@@ -395,6 +383,11 @@ components:
           enum:
           - sas
           - x509
+      discriminator:
+        propertyName: type
+        mapping:
+          sas: '#/components/schemas/SASAuthenticationCredentials'
+          x509: '#/components/schemas/X509AuthenticationCredentials'
 
     AziotDeviceIdentitySpec:
       required:
@@ -420,14 +413,7 @@ components:
             IoT Hub.
           example: device01
         'auth':
-          oneOf:
-          - $ref: '#/components/schemas/SASAuthenticationCredentials'
-          - $ref: '#/components/schemas/X509AuthenticationCredentials'
-          discriminator:
-            propertyName: type
-            mapping:
-              sas: '#/components/schemas/SASAuthenticationCredentials'
-              x509: '#/components/schemas/X509AuthenticationCredentials'
+          $ref: '#/components/schemas/AuthenticationCredentials'
       description: The device identity specification.
 
     AziotIdentityResponse:
@@ -457,9 +443,12 @@ components:
 
     AziotIdentityType:
       type: string
-      example: aziot
       enum:
       - aziot
+      example:
+        aziot:
+          value: aziot
+          summary: 'Module identity.'
 
     AziotModuleIdentityResponse:
       required:
@@ -502,12 +491,7 @@ components:
       type: object
       properties:
         'type':
-          type: string
-          description: The identity type.
-          example: aziot
-          enum:
-          - aziot
-          - local
+          $ref: '#/components/schemas/IdentityTypes'
         'moduleId':
           type: string
           description: Name of the module to add to the identity registry.
@@ -516,24 +500,10 @@ components:
     CreateLocalIdentityRequest:
       allOf:
       - $ref: '#/components/schemas/CreateIdentityRequest'
-      - type: 'object'
-        properties:
-          'localIdOpts':
-            type: object
-            default: '{"type": "x509", "attributes": "client"}'
-            properties:
-              'type':
-                type: string
-                description: Type of local identity. Currently, only x509 is supported.
-                enum:
-                - x509
-              'attributes':
-                type: string
-                description: Attributes of the X.509 local identity certificate. May be either client or server.
-                enum:
-                - client
-                - server
-            description: Optional field to specify configuration of the issued local identity.
+      type: object
+      properties:
+        'localIdOpts':
+          $ref: '#/components/schemas/LocalIdOptsType'
 
     CreateModuleRequest:
       oneOf:
@@ -544,27 +514,6 @@ components:
         mapping:
           aziot: '#/components/schemas/CreateIdentityRequest'
           local: '#/components/schemas/CreateLocalIdentityRequest'
-#      required:
-#      - moduleId
-#      - type
-#      type: object
-#      properties:
-#        'type':
-#          type: string
-#          description: The identity type.
-#          example: aziot
-#          enum:
-#          - aziot
-#          - local
-#        'moduleId':
-#          type: string
-#          description: Name of the module to add to the identity registry.
-#          example: module01
-#      discriminator:
-#        propertyName: 'type'
-#        mapping:
-#          'aziot': '#/components/schemas/CreateIdentityRequest'
-#          'local': '#/components/schemas/CreateLocalIdentityRequest'
 
     ErrorResponse:
       required:
@@ -573,6 +522,20 @@ components:
       properties:
         'message':
           type: string
+
+    IdentityTypes:
+      type: string
+      description: The identity type.
+      enum:
+      - aziot
+      - local
+      example:
+        aziot:
+          value: aziot
+          summary: 'Azure IoT Hub identity.'
+        local:
+          value: local
+          summary: 'Local identity.'
 
     LocalIdentityResponse:
       required:
@@ -585,6 +548,23 @@ components:
         'spec':
           $ref: '#/components/schemas/LocalIdentitySpec'
 
+    LocalAuthType:
+      required:
+      - privateKey
+      - certificate
+      - expiration
+      type: object
+      properties:
+        'privateKey':
+          type: string
+          format: byte
+        'certificate':
+          type: string
+          format: byte
+        'expiration':
+          type: string
+          format: date-time
+
     LocalIdentitySpec:
       required:
       - moduleId
@@ -596,17 +576,7 @@ components:
           description: The identity name for the workload in the local registry.
           example: module01
         'auth':
-          type: object
-          properties:
-            'privateKey':
-              type: string
-              format: byte
-            'certificate':
-              type: string
-              format: byte
-            'expiration':
-              type: string
-              format: date-time
+          $ref: '#/components/schemas/LocalAuthType'
       description: The local identity specification.
 
     LocalIdentityType:
@@ -614,6 +584,22 @@ components:
       example: local
       enum:
       - local
+
+    LocalIdOptsType:
+      type: object
+      properties:
+        'type':
+          type: string
+          description: Type of local identity. Currently, only x509 is supported.
+          enum:
+          - x509
+        'attributes':
+          type: string
+          description: Attributes of the X.509 local identity certificate. May be either client or server.
+          enum:
+          - client
+          - server
+      description: Optional field to specify configuration of the issued local identity.
 
     ModuleIdentityResponse:
       oneOf:
@@ -652,54 +638,6 @@ components:
           type: string
           description: Key handle used for Key Service requests.
 
-    UpdateAziotIdentityRequest:
-      allOf:
-      - $ref: '#/components/schemas/UpdateModuleRequest'
-
-    UpdateLocalIdentityRequest:
-      allOf:
-      - $ref: '#/components/schemas/UpdateModuleRequest'
-      - type: 'object'
-        properties:
-          'localIdOpts':
-            type: object
-            properties:
-              'type':
-                type: string
-                description: Type of local identity. Currently, only x509 is supported.
-                enum:
-                - x509
-              'attributes':
-                type: string
-                description: Attributes of the X.509 local identity certificate. May be either client or server.
-                enum:
-                - client
-                - server
-            description: Optional field to specify configuration of the issued local identity.
-
-    UpdateModuleRequest:
-      required:
-      - moduleId
-      - type
-      type: object
-      properties:
-        'type':
-          type: string
-          description: The identity type.
-          example: aziot
-          enum:
-          - aziot
-          - local
-        'moduleId':
-          type: string
-          description: Name of the module to add to the identity registry.
-          example: module01
-      discriminator:
-        propertyName: 'type'
-        mapping:
-          'aziot': '#/components/schemas/UpdateAziotIdentityRequest'
-          'local': '#/components/schemas/UpdateLocalIdentityRequest'
-
     X509AuthenticationCredentials:
       allOf:
       - $ref: '#/components/schemas/AuthenticationCredentials'
@@ -726,13 +664,13 @@ components:
       schema:
         type: string
 
-    AnyModuleIdentityTypeParameter:
+    ModuleIdentityTypes:
       name: type
       in: query
       description: Supported identity types
       required: true
       schema:
-        $ref: '#/components/schemas/AnyIdentityType'
+        $ref: '#/components/schemas/IdentityTypes'
 
     AziotIdentityTypeParameter:
       name: type

--- a/identity/aziot-identityd/openapi/2020-09-01.yaml
+++ b/identity/aziot-identityd/openapi/2020-09-01.yaml
@@ -1,0 +1,397 @@
+# Ref: https://spec.openapis.org/oas/v3.0.3
+
+openapi: 3.0.1
+
+info:
+  title: Identity Service API
+  
+  version: '2020-09-01'
+  
+  description: |
+    This is the specification of the HTTP API of the aziot-identityd service.
+    
+  license:
+    name: 'MIT'
+
+servers:
+- url: 'http://identityd.sock/'
+  description: |
+    The server listens on a unix socket `/run/aziot/identityd.sock`
+
+    
+paths:
+  /identities/identity:
+    get:
+      tags:
+      - Identity operations
+      summary: Get primary cloud identity for authenticated workload (caller)
+      operationId: getIdentity
+      parameters:
+        - $ref: '#/components/parameters/ApiVersionParameter'
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityResponse'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+                
+  /identities/device:
+    post:
+      tags:
+      - Identity operations
+      summary: Get the IoT device provisioning result
+      operationId: getDeviceIdentity
+      parameters:
+        - $ref: '#/components/parameters/ApiVersionParameter'
+      requestBody:
+        description: Type of identity to reprovision
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionedIdentityResponse'              
+      x-codegen-request-body-name: GetDeviceIdentityRequest
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityResponse'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+                
+  /identities/modules:
+    get:
+      tags:
+      - Identity operations
+      summary: List module identities
+      operationId: getModuleIdentities
+      parameters:
+      - name: type
+        in: query
+        description: Identity type
+        required: true
+        schema:
+          type: string
+          default: aziot
+          enum:
+          - aziot
+          - local
+      - $ref: '#/components/parameters/ApiVersionParameter'
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModuleIdentitiesResponse'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+      - Identity operations
+      summary: Register IoT module identity
+      operationId: registerModuleIdentity
+      parameters:
+        - $ref: '#/components/parameters/ApiVersionParameter'
+      requestBody:
+        description: Data for a module identity to register
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterModuleRequest'
+        required: true
+      x-codegen-request-body-name: RegisteryModuleIdentityRequest
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityResponse'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      
+  /identities/modules/{moduleId}:
+    get:
+      tags:
+      - Identity operations
+      summary: Get IoT module identity information
+      operationId: getModuleIdentityInfo
+      parameters:
+      - $ref: '#/components/parameters/ApiVersionParameter'
+      - name: moduleId
+        in: path
+        description: Module ID
+        example: module01
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: query
+        description: Identity type
+        required: true
+        schema:
+          type: string
+          default: aziot
+          enum:
+          - aziot
+          - local
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityResponse'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+      - Identity operations
+      summary: Delete the IoT module identity
+      operationId: deleteModuleIdentity
+      parameters:
+      - $ref: '#/components/parameters/ApiVersionParameter'
+      - name: moduleId
+        in: path
+        description: Module ID
+        example: module01
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: query
+        description: Identity type
+        required: true
+        schema:
+          type: string
+          default: aziot
+          enum:
+          - aziot
+      responses:
+        204:
+          description: No Content
+          content: {}
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+                
+  /identities/device/reprovision:
+    post:
+      tags:
+      - Identity operations
+      summary: Trigger an IoT device reprovisioning flow
+      operationId: reprovision
+      parameters:
+        - $ref: '#/components/parameters/ApiVersionParameter'
+      requestBody:
+        description: Type of identity to reprovision
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionedIdentityResponse'
+        required: true
+      x-codegen-request-body-name: ReprovisionRequest
+      responses:
+        200:
+          description: Ok
+          content: {}
+        204:
+          description: No Content
+          content: {}
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+
+components:
+  schemas:
+    RegisterModuleRequest:
+      required:
+      - moduleId
+      - type
+      type: object
+      properties:
+        'type':
+          type: string
+          description: The identity type.
+          default: aziot
+          enum:
+          - aziot
+          - local
+        'moduleId':
+          type: string
+          description: Name of the module to add to the identity registry.
+          example: module01
+      discriminator:
+        propertyName: 'type'
+        mapping:
+          'aziot': '#/components/schemas/RegisterAziotIdentityRequest'
+          'local': '#/components/schemas/RegisterLocalIdentityRequest'
+
+    RegisterAziotIdentityRequest:
+      allOf:
+      - $ref: '#/components/schemas/RegisterModuleRequest'
+
+    RegisterLocalIdentityRequest:
+      allOf:
+      - $ref: '#/components/schemas/RegisterModuleRequest'
+      - type: 'object'
+        properties:
+          'localIdOpts':
+            type: object
+            properties:
+              'type':
+                type: string
+                description: Type of local identity. Currently, only x509 is supported.
+                enum:
+                - x509
+              'attributes':
+                type: string
+                description: Attributes of the X.509 local identity certificate. May be either client or server.
+                enum:
+                - client
+                - server
+            description: Optional field to specify configuration of the issued local identity.
+     
+            
+    ModuleIdentitiesResponse:
+      type: object
+      properties:
+        'identities':
+          type: array
+          description: A collection of module identities
+          items:
+            $ref: '#/components/schemas/IdentityResponse'
+            
+    IdentityResponse:
+      required:
+      - spec
+      - type
+      type: object
+      properties:
+        'type':
+          type: string
+          description: The identity type.
+          default: aziot
+          enum:
+          - aziot
+          - local
+        'spec':
+          $ref: '#/components/schemas/IdentitySpec'
+          
+    IdentitySpec:
+      required:
+      - deviceId
+      - hubName
+      type: object
+      properties:
+        'hubName':
+          type: string
+          description: The name of the IoT hub where the device is provisioned.
+          example: myhub.net
+        'gatewayHost':
+          type: string
+          description: The hostname of the parent Edge gateway that intermediates
+            all requests for the current device when in a nested configuration. In
+            a single-node deployment (i.e. non-nested) it will match the 'hubName'.
+          example: parentdevice
+        'deviceId':
+          type: string
+          description: The identity name of the provisioned device in the assigned
+            IoT Hub.
+          example: device01
+        'moduleId':
+          type: string
+          description: The identity name of the device workload in the provisioned
+            device in the assigned IoT Hub.
+          example: module01
+        'genId':
+          type: string
+          description: The generation ID of the device workload assigned by IoT Hub.
+          example: "12345"
+        'auth':
+          $ref: '#/components/schemas/AuthenticationProperties'
+      description: The identity specification.
+      
+    AuthenticationProperties:
+      required:
+      - keyHandle
+      - type
+      type: object
+      properties:
+        'type':
+          type: string
+          description: Indicates the type of authentication credential used.
+          enum:
+          - sas
+          - x509
+        'keyHandle':
+          type: string
+          description: Key handle used for Key Service requests.
+        'certId':
+          type: string
+          description: Certificate ID of the identity X.509 certificate.
+          
+    ProvisionedIdentityResponse:
+      required:
+      - type
+      type: object
+      properties:
+        'type':
+          type: string
+          default: aziot
+          enum:
+          - aziot
+
+    ErrorResponse:
+      required:
+      - message
+      type: object
+      properties:
+        'message':
+          type: string
+           
+          
+  parameters:
+    ApiVersionParameter:
+      name: api-version
+      in: query
+      description: The version of the API.
+      required: true
+      schema:
+        type: string
+        default: '2020-09-01'
+        enum:
+        - '2020-09-01'
+

--- a/identity/aziot-identityd/openapi/2020-09-01.yaml
+++ b/identity/aziot-identityd/openapi/2020-09-01.yaml
@@ -116,7 +116,7 @@ paths:
                   'type':
                     $ref: '#/components/schemas/AziotIdentityType'
                   'spec':
-                    $ref: '#/components/schemas/AziotDeviceIdentitySpec'
+                    $ref: '#/components/schemas/AziotIdentitySpec'
               examples:
                 'SAS case':
                   value:
@@ -146,14 +146,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /identities/modules?api-version=2020-09-01:
+  /identities/modules?api-version=2020-09-01&type={type}:
+    parameters:
+    - $ref: '#/components/parameters/AziotIdentityTypeParameter'
     get:
       tags:
       - Identity operations
       summary: List IoT module identities
       operationId: getModuleIdentities
-      parameters:
-      - $ref: '#/components/parameters/AziotIdentityTypeParameter'
       responses:
         200:
           description: Ok
@@ -193,6 +193,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /identities/modules?api-version=2020-09-01:
     post:
       tags:
       - Identity operations
@@ -251,10 +253,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /identities/modules/{id}?api-version=2020-09-01:
+  /identities/modules/{id}?api-version=2020-09-01&type={type}:
     parameters:
       - $ref: '#/components/parameters/IdentityName'
-      - $ref: '#/components/parameters/ModuleIdentityTypes'
+      - $ref: '#/components/parameters/ModuleIdentityKind'
     get:
       tags:
       - Identity operations
@@ -364,33 +366,6 @@ components:
           sas: '#/components/schemas/SASAuthenticationCredentials'
           x509: '#/components/schemas/X509AuthenticationCredentials'
 
-    AziotDeviceIdentitySpec:
-      required:
-      - auth
-      - deviceId
-      - gatewayHost
-      - hubName
-      type: object
-      properties:
-        'hubName':
-          type: string
-          description: The name of the IoT hub where the device is provisioned.
-          example: myhub.net
-        'gatewayHost':
-          type: string
-          description: The hostname of the parent Edge gateway that intermediates
-            all requests for the current device when in a nested configuration. In
-            a single-node deployment (i.e. non-nested) it will match the 'hubName'.
-          example: parentdevice
-        'deviceId':
-          type: string
-          description: The identity name of the provisioned device in the assigned
-            IoT Hub.
-          example: device01
-        'auth':
-          $ref: '#/components/schemas/AuthenticationCredentials'
-      description: The device identity specification.
-
     AziotIdentityResponse:
       required:
       - spec
@@ -412,9 +387,39 @@ components:
             $ref: '#/components/schemas/AziotModuleIdentityResponse'
 
     AziotIdentitySpec:
-      oneOf:
-      - $ref: '#/components/schemas/AziotDeviceIdentitySpec'
-      - $ref: '#/components/schemas/AziotModuleIdentitySpec'
+      required:
+      - deviceId
+      - gatewayHost
+      - hubName
+      type: object
+      properties:
+        'hubName':
+          type: string
+          description: The name of the IoT hub where the device is provisioned.
+          example: myhub.net
+        'gatewayHost':
+          type: string
+          description: The hostname of the parent Edge gateway that intermediates
+            all requests for the current device when in a nested configuration. In
+            a single-node deployment (i.e. non-nested) it will match the 'hubName'.
+          example: parentdevice
+        'deviceId':
+          type: string
+          description: The identity name of the provisioned device in the assigned
+            IoT Hub.
+          example: device01
+        'moduleId':
+          type: string
+          description: The identity name of the device workload in the provisioned
+            device in the assigned IoT Hub.
+          example: module01
+        'genId':
+          type: string
+          description: The generation ID of the device workload assigned by IoT Hub.
+          example: "12345"
+        'auth':
+          $ref: '#/components/schemas/AuthenticationCredentials'
+      description: The device identity specification.
 
     AziotIdentityType:
       type: string
@@ -438,12 +443,8 @@ components:
 
     AziotModuleIdentitySpec:
       allOf:
-      - $ref: '#/components/schemas/AziotDeviceIdentitySpec'
+      - $ref: '#/components/schemas/AziotIdentitySpec'
       required:
-      - auth
-      - deviceId
-      - gatewayHost
-      - hubName
       - moduleId
       - genId
       type: object
@@ -466,7 +467,7 @@ components:
       type: object
       properties:
         'type':
-          $ref: '#/components/schemas/IdentityTypes'
+          $ref: '#/components/schemas/IdentityKind'
         'moduleId':
           type: string
           description: Name of the module to add to the identity registry.
@@ -488,7 +489,7 @@ components:
         'message':
           type: string
 
-    IdentityTypes:
+    IdentityKind:
       type: string
       description: The identity type.
       enum:
@@ -520,7 +521,9 @@ components:
       type: object
       properties:
         'type':
-          $ref: '#/components/schemas/AziotIdentityType'
+          type: string
+          enum:
+          - aziot
 
     SASAuthenticationCredentials:
       allOf:
@@ -550,6 +553,14 @@ components:
 
 
   parameters:
+    AziotIdentityTypeParameter:
+      name: type
+      in: path
+      description: Aziot identity type
+      required: true
+      schema:
+        $ref: '#/components/schemas/AziotIdentityType'
+
     IdentityName:
       name: id
       in: path
@@ -559,19 +570,12 @@ components:
       schema:
         type: string
 
-    ModuleIdentityTypes:
+    ModuleIdentityKind:
       name: type
-      in: query
+      in: path
       description: Supported identity types
       required: true
       schema:
-        $ref: '#/components/schemas/IdentityTypes'
+        $ref: '#/components/schemas/IdentityKind'
 
-    AziotIdentityTypeParameter:
-      name: type
-      in: query
-      description: Aziot identity type
-      required: true
-      schema:
-        $ref: '#/components/schemas/AziotIdentityType'
 

--- a/identity/aziot-identityd/openapi/2020-09-01.yaml
+++ b/identity/aziot-identityd/openapi/2020-09-01.yaml
@@ -136,7 +136,7 @@ paths:
       tags:
       - Identity operations
       summary: Get IoT module identity information
-      operationId: getModuleIdentityInfo
+      operationId: getModuleIdentityById
       parameters:
       - $ref: '#/components/parameters/ApiVersionParameter'
       - name: moduleId

--- a/identity/aziot-identityd/openapi/2020-09-01.yaml
+++ b/identity/aziot-identityd/openapi/2020-09-01.yaml
@@ -1,4 +1,4 @@
-# Ref: https://spec.openapis.org/oas/v4.0.3
+# Ref: https://spec.openapis.org/oas/v3.0.3
 
 openapi: 3.0.1
 
@@ -95,7 +95,8 @@ paths:
       operationId: getDeviceIdentity
       x-codegen-request-body-name: GetDeviceIdentityRequest
       requestBody:
-        description: Type of identity to reprovision
+        description: The type of provisioned identity
+        required: true
         content:
           application/json:
             schema:
@@ -197,26 +198,26 @@ paths:
       - Identity operations
       summary: Create IoT module identity
       operationId: createModuleIdentity
+      x-codegen-request-body-name: CreateModuleIdentityRequest
       requestBody:
-        description: Data for a module identity to register
+        description: The type of module identity to create
+        required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateIdentityRequest'
+              $ref: '#/components/schemas/CreateModuleRequest'
             examples:
               'Module identity':
                 value:
                   type: 'aziot'
                   moduleId: 'module01'
-        required: true
-      x-codegen-request-body-name: CreateModuleIdentityRequest
       responses:
         200:
           description: Ok
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AziotModuleIdentityResponse'
+                $ref: '#/components/schemas/ModuleIdentityResponse'
               examples:
                 'SAS case':
                   value:
@@ -253,7 +254,7 @@ paths:
   /identities/modules/{id}?api-version=2020-09-01:
     parameters:
       - $ref: '#/components/parameters/IdentityName'
-      - $ref: '#/components/parameters/AziotIdentityTypeParameter'
+      - $ref: '#/components/parameters/ModuleIdentityTypes'
     get:
       tags:
       - Identity operations
@@ -265,7 +266,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AziotModuleIdentityResponse'
+                $ref: '#/components/schemas/ModuleIdentityResponse'
               examples:
                 'SAS case':
                   value:
@@ -321,14 +322,14 @@ paths:
       - Identity operations
       summary: Trigger an IoT device reprovisioning flow
       operationId: reprovision
+      x-codegen-request-body-name: ReprovisionRequest
       requestBody:
         description: Type of identity to reprovision
+        required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ReprovisionRequest'
-        required: true
-      x-codegen-request-body-name: ReprovisionRequest
       responses:
         200:
           description: Ok
@@ -357,6 +358,11 @@ components:
           enum:
           - sas
           - x509
+      discriminator:
+        propertyName: type
+        mapping:
+          sas: '#/components/schemas/SASAuthenticationCredentials'
+          x509: '#/components/schemas/X509AuthenticationCredentials'
 
     AziotDeviceIdentitySpec:
       required:
@@ -382,14 +388,7 @@ components:
             IoT Hub.
           example: device01
         'auth':
-          oneOf:
-          - $ref: '#/components/schemas/SASAuthenticationCredentials'
-          - $ref: '#/components/schemas/X509AuthenticationCredentials'
-          discriminator:
-            propertyName: type
-            mapping:
-              sas: '#/components/schemas/SASAuthenticationCredentials'
-              x509: '#/components/schemas/X509AuthenticationCredentials'
+          $ref: '#/components/schemas/AuthenticationCredentials'
       description: The device identity specification.
 
     AziotIdentityResponse:
@@ -419,9 +418,12 @@ components:
 
     AziotIdentityType:
       type: string
-      example: aziot
       enum:
       - aziot
+      example:
+        aziot:
+          value: aziot
+          summary: 'Module identity.'
 
     AziotModuleIdentityResponse:
       required:
@@ -464,11 +466,19 @@ components:
       type: object
       properties:
         'type':
-          $ref: '#/components/schemas/AziotIdentityType'
+          $ref: '#/components/schemas/IdentityTypes'
         'moduleId':
           type: string
           description: Name of the module to add to the identity registry.
           example: module01
+
+    CreateModuleRequest:
+      oneOf:
+      - $ref: '#/components/schemas/CreateIdentityRequest'
+      discriminator:
+        propertyName: type
+        mapping:
+          aziot: '#/components/schemas/CreateIdentityRequest'
 
     ErrorResponse:
       required:
@@ -477,6 +487,24 @@ components:
       properties:
         'message':
           type: string
+
+    IdentityTypes:
+      type: string
+      description: The identity type.
+      enum:
+      - aziot
+      example:
+        aziot:
+          value: aziot
+          summary: 'Azure IoT Hub identity.'
+
+    ModuleIdentityResponse:
+      oneOf:
+      - $ref: '#/components/schemas/AziotModuleIdentityResponse'
+      discriminator:
+        propertyName: 'type'
+        mapping:
+          'aziot': '#/components/schemas/AziotModuleIdentityResponse'
 
     ProvisioningResultRequest:
       required:
@@ -505,27 +533,6 @@ components:
           type: string
           description: Key handle used for Key Service requests.
 
-    UpdateAziotIdentityRequest:
-      allOf:
-      - $ref: '#/components/schemas/UpdateModuleRequest'
-
-    UpdateModuleRequest:
-      required:
-      - moduleId
-      - type
-      type: object
-      properties:
-        'type':
-          type: string
-          description: The identity type.
-          example: aziot
-          enum:
-          - aziot
-        'moduleId':
-          type: string
-          description: Name of the module to add to the identity registry.
-          example: module01
-
     X509AuthenticationCredentials:
       allOf:
       - $ref: '#/components/schemas/AuthenticationCredentials'
@@ -551,6 +558,14 @@ components:
       required: true
       schema:
         type: string
+
+    ModuleIdentityTypes:
+      name: type
+      in: query
+      description: Supported identity types
+      required: true
+      schema:
+        $ref: '#/components/schemas/IdentityTypes'
 
     AziotIdentityTypeParameter:
       name: type


### PR DESCRIPTION
The api only includes the 'aziot' supported APIs.  I consider the support for 'local' identities still in preview and created a separate version of the api that has all the same stuff plus the definitions for local identities.  Neither includes the PUT for [/identities/modules/{module-id}](https://github.com/Azure/iot-identity-service/blob/main/docs/api/identity-service.md#update-iot-module-identity).  I'll submit a separate PR that removes the PUT from the docs.