### PR TITLE
Add all IS APIs to client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,8 @@ dependencies = [
 name = "aziot-identity-client-async"
 version = "0.1.0"
 dependencies = [
+ "aziot-cert-common-http",
+ "aziot-identity-common",
  "aziot-identity-common-http",
  "http",
  "http-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "http",
  "http-common",
  "hyper",
+ "percent-encoding",
 ]
 
 [[package]]

--- a/identity/aziot-identity-client-async/Cargo.toml
+++ b/identity/aziot-identity-client-async/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 http = "0.2"
 hyper = "0.14"
+percent-encoding = "2"
 
 aziot-cert-common-http = { path = "../../cert/aziot-cert-common-http" }
 aziot-identity-common = { path = "../aziot-identity-common" }

--- a/identity/aziot-identity-client-async/Cargo.toml
+++ b/identity/aziot-identity-client-async/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2018"
 http = "0.2"
 hyper = "0.14"
 
+aziot-cert-common-http = { path = "../../cert/aziot-cert-common-http" }
+aziot-identity-common = { path = "../aziot-identity-common" }
 aziot-identity-common-http = { path = "../aziot-identity-common-http" }
 http-common = { path = "../../http-common", features = ["tokio1"] }

--- a/identity/aziot-identity-client-async/src/lib.rs
+++ b/identity/aziot-identity-client-async/src/lib.rs
@@ -161,11 +161,7 @@ impl Client {
         let res: get_module_identities::Response = http_common::request::<(), _>(
             &self.inner,
             http::Method::GET,
-            make_uri!(
-                "/identities/modules",
-                self.api_version,
-                ID_TYPE_AZIOT
-            ),
+            make_uri!("/identities/modules", self.api_version, ID_TYPE_AZIOT),
             None,
         )
         .await?;

--- a/identity/aziot-identity-client-async/src/lib.rs
+++ b/identity/aziot-identity-client-async/src/lib.rs
@@ -26,7 +26,13 @@ macro_rules! make_uri {
     ($path:literal, $api_version:expr, $type:expr, $name:ident) => {
         &format!(
             "http://identityd.sock{}/{}?api-version={}&type={}",
-            $path, $name, $api_version, $type
+            $path,
+            percent_encoding::percent_encode(
+                $name.as_bytes(),
+                http_common::PATH_SEGMENT_ENCODE_SET
+            ),
+            $api_version,
+            $type
         )
     };
 }

--- a/identity/aziot-identity-client-async/src/lib.rs
+++ b/identity/aziot-identity-client-async/src/lib.rs
@@ -147,7 +147,7 @@ impl Client {
             make_uri!(
                 "/identities/modules",
                 self.api_version,
-                ID_TYPE_AZIOT.to_string(),
+                ID_TYPE_AZIOT,
                 module_name
             ),
             None,
@@ -164,7 +164,7 @@ impl Client {
             make_uri!(
                 "/identities/modules",
                 self.api_version,
-                ID_TYPE_AZIOT.to_string()
+                ID_TYPE_AZIOT
             ),
             None,
         )
@@ -180,7 +180,7 @@ impl Client {
             make_uri!(
                 "/identities/modules",
                 self.api_version,
-                ID_TYPE_AZIOT.to_string(),
+                ID_TYPE_AZIOT,
                 module_name
             ),
             None,
@@ -197,7 +197,7 @@ impl Client {
             make_uri!(
                 "/identities/modules",
                 self.api_version,
-                ID_TYPE_AZIOT.to_string(),
+                ID_TYPE_AZIOT,
                 module_name
             ),
             None,

--- a/identity/aziot-identity-client-async/src/lib.rs
+++ b/identity/aziot-identity-client-async/src/lib.rs
@@ -4,37 +4,212 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::must_use_candidate, clippy::missing_errors_doc)]
 
+use aziot_identity_common::{Identity, ID_TYPE_AZIOT, ID_TYPE_LOCAL};
+
+// All exports of aziot_identity_common_http are used in this file.
+#[allow(clippy::wildcard_imports)]
+use aziot_identity_common_http::*;
+
+macro_rules! make_uri {
+    ($path:literal, $api_version:expr) => {
+        &format!(
+            "http://identityd.sock{}?api-version={}",
+            $path, $api_version
+        )
+    };
+    ($path:literal, $api_version:expr, $type:expr) => {
+        &format!(
+            "http://identityd.sock{}?api-version={}&type={}",
+            $path, $api_version, $type
+        )
+    };
+    ($path:literal, $api_version:expr, $type:expr, $name:ident) => {
+        &format!(
+            "http://identityd.sock{}/{}?api-version={}&type={}",
+            $path, $name, $api_version, $type
+        )
+    };
+}
+
 #[derive(Debug)]
 pub struct Client {
-    api_version: aziot_identity_common_http::ApiVersion,
+    api_version: ApiVersion,
     inner: hyper::Client<http_common::Connector, hyper::Body>,
 }
 
 impl Client {
-    pub fn new(
-        api_version: aziot_identity_common_http::ApiVersion,
-        connector: http_common::Connector,
-    ) -> Self {
+    pub fn new(api_version: ApiVersion, connector: http_common::Connector) -> Self {
         let inner = hyper::Client::builder().build(connector);
         Client { api_version, inner }
     }
 
+    pub async fn get_caller_identity(&self) -> Result<Identity, std::io::Error> {
+        let res: get_caller_identity::Response = http_common::request::<(), _>(
+            &self.inner,
+            http::Method::GET,
+            make_uri!("/identities/identity", self.api_version),
+            None,
+        )
+        .await?;
+
+        Ok(res.identity)
+    }
+
+    pub async fn get_device_identity(&self) -> Result<Identity, std::io::Error> {
+        let body = get_device_identity::Request {
+            id_type: ID_TYPE_AZIOT.to_string(),
+        };
+
+        let res: get_device_identity::Response = http_common::request(
+            &self.inner,
+            http::Method::POST,
+            make_uri!("/identities/device", self.api_version),
+            Some(&body),
+        )
+        .await?;
+
+        Ok(res.identity)
+    }
+
     pub async fn reprovision(&self) -> Result<(), std::io::Error> {
-        let body = aziot_identity_common_http::reprovision_device::Request {
-            id_type: "aziot".to_owned(),
+        let body = reprovision_device::Request {
+            id_type: ID_TYPE_AZIOT.to_string(),
         };
 
         http_common::request_no_content(
             &self.inner,
             http::Method::POST,
-            &format!(
-                "http://identityd.sock/identities/device/reprovision?api-version={}",
-                self.api_version
-            ),
+            make_uri!("/device/reprovision", self.api_version),
             Some(&body),
         )
         .await?;
 
         Ok(())
+    }
+
+    pub async fn create_module_identity(
+        &self,
+        module_name: &str,
+    ) -> Result<Identity, std::io::Error> {
+        let body = create_module_identity::Request {
+            id_type: ID_TYPE_AZIOT.to_string(),
+            module_id: module_name.to_string(),
+            opts: None,
+        };
+
+        let res: create_module_identity::Response = http_common::request(
+            &self.inner,
+            http::Method::POST,
+            make_uri!("/identities/modules", self.api_version),
+            Some(&body),
+        )
+        .await?;
+
+        Ok(res.identity)
+    }
+
+    pub async fn create_local_identity(
+        &self,
+        module_name: &str,
+        opts: Option<aziot_identity_common::LocalIdOpts>,
+    ) -> Result<Identity, std::io::Error> {
+        #[allow(clippy::redundant_closure)] // closure needed for map()
+        let body = create_module_identity::Request {
+            id_type: ID_TYPE_LOCAL.to_string(),
+            module_id: module_name.to_string(),
+            opts: opts.map(|opts| create_module_identity::CreateModuleOpts::LocalIdOpts(opts)),
+        };
+
+        let res: create_module_identity::Response = http_common::request(
+            &self.inner,
+            http::Method::POST,
+            make_uri!("/identities/modules", self.api_version),
+            Some(&body),
+        )
+        .await?;
+
+        Ok(res.identity)
+    }
+
+    pub async fn update_module_identity(
+        &self,
+        module_name: &str,
+    ) -> Result<Identity, std::io::Error> {
+        let res: update_module_identity::Response = http_common::request::<(), _>(
+            &self.inner,
+            http::Method::PUT,
+            make_uri!(
+                "/identities/modules",
+                self.api_version,
+                ID_TYPE_AZIOT.to_string(),
+                module_name
+            ),
+            None,
+        )
+        .await?;
+
+        Ok(res.identity)
+    }
+
+    pub async fn get_identities(&self) -> Result<Vec<Identity>, std::io::Error> {
+        let res: get_module_identities::Response = http_common::request::<(), _>(
+            &self.inner,
+            http::Method::GET,
+            make_uri!(
+                "/identities/modules",
+                self.api_version,
+                ID_TYPE_AZIOT.to_string()
+            ),
+            None,
+        )
+        .await?;
+
+        Ok(res.identities)
+    }
+
+    pub async fn get_identity(&self, module_name: &str) -> Result<Identity, std::io::Error> {
+        let res: get_module_identity::Response = http_common::request::<(), _>(
+            &self.inner,
+            http::Method::GET,
+            make_uri!(
+                "/identities/modules",
+                self.api_version,
+                ID_TYPE_AZIOT.to_string(),
+                module_name
+            ),
+            None,
+        )
+        .await?;
+
+        Ok(res.identity)
+    }
+
+    pub async fn delete_identity(&self, module_name: &str) -> Result<(), std::io::Error> {
+        http_common::request_no_content::<()>(
+            &self.inner,
+            http::Method::DELETE,
+            make_uri!(
+                "/identities/modules",
+                self.api_version,
+                ID_TYPE_AZIOT.to_string(),
+                module_name
+            ),
+            None,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_trust_bundle(&self) -> Result<aziot_cert_common_http::Pem, std::io::Error> {
+        let res: get_trust_bundle::Response = http_common::request::<(), _>(
+            &self.inner,
+            http::Method::GET,
+            make_uri!("/trust-bundle", self.api_version),
+            None,
+        )
+        .await?;
+
+        Ok(res.certificate)
     }
 }

--- a/identity/aziot-identity-common/src/lib.rs
+++ b/identity/aziot-identity-common/src/lib.rs
@@ -3,6 +3,12 @@
 #![deny(rust_2018_idioms)]
 #![warn(clippy::all, clippy::pedantic)]
 
+/// URI query parameter that identifies module identity type.
+pub const ID_TYPE_AZIOT: &str = "aziot";
+
+/// URI query parameter that identifies local identity type.
+pub const ID_TYPE_LOCAL: &str = "local";
+
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct DeviceId(pub String);
 #[derive(Clone, Debug, Eq, Ord, PartialOrd, PartialEq, serde::Deserialize, serde::Serialize)]

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use aziot_identity_common::{ID_TYPE_AZIOT, ID_TYPE_LOCAL};
 use aziot_identityd_config as config;
 
 pub mod auth;
@@ -30,12 +31,6 @@ pub mod identity;
 
 use config_common::watcher::UpdateConfig;
 pub use error::{Error, InternalError};
-
-/// URI query parameter that identifies module identity type.
-const ID_TYPE_AZIOT: &str = "aziot";
-
-/// URI query parameter that identifies local identity type.
-const ID_TYPE_LOCAL: &str = "local";
 
 macro_rules! match_id_type {
     ($id_type:ident { $( $type:ident => $action:block ,)+ }) => {


### PR DESCRIPTION
Previously, aziot-identity-client-async only had the reprovision API because that was the only one used.

This PR adds the rest of the IS APIs to the client since they'll all be needed in edgelet.