### PR TITLE
Revert build to use Rust 1.47

### DIFF
--- a/aziotctl/aziotctl-common/src/config/mod.rs
+++ b/aziotctl/aziotctl-common/src/config/mod.rs
@@ -75,11 +75,14 @@ fn parse_manual_connection_string(
     let mut symmetric_key = None;
 
     for sections in connection_string.split(';') {
-        let parts = sections.split_once('=');
-        match parts {
-            Some((HOSTNAME_KEY, value)) => iothub_hostname = Some(value),
-            Some((DEVICEID_KEY, value)) => device_id = Some(value),
-            Some((SHAREDACCESSKEY_KEY, value)) => symmetric_key = Some(value),
+        let mut parts = sections.splitn(2, '=');
+        match parts
+            .next()
+            .expect("str::splitn always returns at least one part")
+        {
+            HOSTNAME_KEY => iothub_hostname = parts.next(),
+            DEVICEID_KEY => device_id = parts.next(),
+            SHAREDACCESSKEY_KEY => symmetric_key = parts.next(),
             _ => (), // Ignore extraneous component in the connection string
         }
     }

--- a/aziotctl/src/internal/check/additional_info.rs
+++ b/aziotctl/src/internal/check/additional_info.rs
@@ -100,7 +100,13 @@ impl OsInfo {
 fn parse_os_release_line(line: &str) -> Option<(&str, &str)> {
     let line = line.trim();
 
-    let (key, value) = line.split_once('=')?;
+    let mut parts = line.splitn(2, '=');
+
+    let key = parts
+        .next()
+        .expect("split line will have at least one part");
+
+    let value = parts.next()?;
 
     // The value is essentially a shell string, so it can be quoted in single or
     // double quotes, and can have escaped sequences using backslash.

--- a/aziotctl/src/main.rs
+++ b/aziotctl/src/main.rs
@@ -5,7 +5,6 @@
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,
-    clippy::let_underscore_drop,
     clippy::let_unit_value,
     clippy::module_name_repetitions,
     clippy::similar_names,

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -7,11 +7,7 @@
 
 #![deny(rust_2018_idioms)]
 #![warn(clippy::all, clippy::pedantic)]
-#![allow(
-    clippy::default_trait_access,
-    clippy::let_underscore_drop,
-    clippy::let_unit_value
-)]
+#![allow(clippy::default_trait_access, clippy::let_unit_value)]
 
 mod error;
 

--- a/cert/aziot-certd/src/error.rs
+++ b/cert/aziot-certd/src/error.rs
@@ -23,13 +23,11 @@ impl std::fmt::Display for Error {
             Error::InvalidParameter(name, _) => {
                 write!(f, "parameter {:?} has an invalid value", name)
             }
-            Error::Unauthorized(user, id) => {
-                write!(
-                    f,
-                    "user {} is not authorized to modify the cert {}",
-                    user, id
-                )
-            }
+            Error::Unauthorized(user, id) => write!(
+                f,
+                "user {} is not authorized to modify the cert {}",
+                user, id
+            ),
         }
     }
 }

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -858,7 +858,12 @@ fn get_cert_inner(
                     result.extend_from_slice(&bytes);
                 }
             }
-            Ok((!result.is_empty()).then(|| result))
+
+            if result.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(result))
+            }
         }
     }
 }

--- a/config-common/src/lib.rs
+++ b/config-common/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(
     clippy::default_trait_access,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
     clippy::module_name_repetitions
 )]
 

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,
-    clippy::let_underscore_drop,
     clippy::missing_errors_doc,
     clippy::module_name_repetitions,
     clippy::must_use_candidate,

--- a/identity/aziot-identity-client-async/src/lib.rs
+++ b/identity/aziot-identity-client-async/src/lib.rs
@@ -2,12 +2,14 @@
 
 #![deny(rust_2018_idioms)]
 #![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::must_use_candidate, clippy::missing_errors_doc)]
+#![allow(
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::wildcard_imports
+)]
 
 use aziot_identity_common::{Identity, ID_TYPE_AZIOT, ID_TYPE_LOCAL};
 
-// All exports of aziot_identity_common_http are used in this file.
-#[allow(clippy::wildcard_imports)]
 use aziot_identity_common_http::*;
 
 macro_rules! make_uri {

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,
-    clippy::let_underscore_drop,
     clippy::let_unit_value,
     clippy::missing_errors_doc,
     clippy::module_name_repetitions,
@@ -198,7 +197,7 @@ impl Api {
             }
         }
 
-        return Err(Error::Authorization);
+        Err(Error::Authorization)
     }
 
     pub async fn get_identity(

--- a/iotedged/src/main.rs
+++ b/iotedged/src/main.rs
@@ -5,7 +5,6 @@
 #![allow(
     clippy::default_trait_access,
     clippy::let_and_return,
-    clippy::let_underscore_drop,
     clippy::type_complexity
 )]
 

--- a/key/aziot-key-openssl-engine/src/ex_data.rs
+++ b/key/aziot-key-openssl-engine/src/ex_data.rs
@@ -116,7 +116,18 @@ where
 
     let ptr = from_d.cast::<*const U>();
     if !ptr.is_null() {
-        std::sync::Arc::increment_strong_count(ptr);
+        // TODO:
+        // Replace this block's contents with `std::sync::Arc::increment_ref_count(ptr)`
+        // when iotedge starts using Rust 1.51+
+
+        let ex_data = std::sync::Arc::from_raw(*ptr);
+
+        // Bump the refcount ...
+        let ex_data_clone = ex_data.clone();
+
+        // ... and `forget` the two `Arc`s, so that they don't get dropped and decrease the refcount again.
+        std::mem::forget(ex_data);
+        std::mem::forget(ex_data_clone);
     }
 }
 
@@ -129,7 +140,12 @@ where
 
     let ptr = ptr.cast::<U>();
     if !ptr.is_null() {
-        std::sync::Arc::decrement_strong_count(ptr);
+        // TODO:
+        // Replace this block's contents with `std::sync::Arc::decrement_ref_count(ptr)`
+        // when iotedge starts using Rust 1.51+
+
+        let ex_data = std::sync::Arc::from_raw(ptr);
+        drop(ex_data);
     }
 }
 

--- a/key/aziot-keyd/src/error.rs
+++ b/key/aziot-keyd/src/error.rs
@@ -24,13 +24,11 @@ impl std::fmt::Display for Error {
                 write!(f, "parameter {:?} has an invalid value", name)
             }
             Error::InvalidParameter(None) => f.write_str("a parameter has an invalid value"),
-            Error::Unauthorized(user, id) => {
-                write!(
-                    f,
-                    "user {} is not authorized to access the key {}",
-                    user, id
-                )
-            }
+            Error::Unauthorized(user, id) => write!(
+                f,
+                "user {} is not authorized to access the key {}",
+                user, id
+            ),
         }
     }
 }

--- a/key/aziot-keyd/src/keys.rs
+++ b/key/aziot-keyd/src/keys.rs
@@ -1172,7 +1172,7 @@ pub(crate) mod sys {
         unused,
         clippy::too_many_lines,
         clippy::unreadable_literal,
-        clippy::unseparated_literal_suffix,
+        clippy::unseparated_literal_suffix
     )]
 
     use openssl_sys::EVP_PKEY;

--- a/key/aziot-keyd/src/keys.rs
+++ b/key/aziot-keyd/src/keys.rs
@@ -1173,7 +1173,6 @@ pub(crate) mod sys {
         clippy::too_many_lines,
         clippy::unreadable_literal,
         clippy::unseparated_literal_suffix,
-        clippy::upper_case_acronyms
     )]
 
     use openssl_sys::EVP_PKEY;

--- a/key/aziot-keys/src/lib.rs
+++ b/key/aziot-keys/src/lib.rs
@@ -14,7 +14,6 @@
     clippy::similar_names,
     clippy::too_many_lines,
     clippy::type_complexity,
-    clippy::upper_case_acronyms
 )]
 
 //! This library is used to create and load keys for the Azure IoT Keys Service.

--- a/mini-sntp/src/lib.rs
+++ b/mini-sntp/src/lib.rs
@@ -8,8 +8,7 @@
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
     clippy::too_many_lines,
-    clippy::use_self,
-    clippy::unusual_byte_groupings
+    clippy::use_self
 )]
 
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};

--- a/openssl-build/src/lib.rs
+++ b/openssl-build/src/lib.rs
@@ -10,7 +10,7 @@ pub fn define_version_number_cfg() {
         .expect("DEP_OPENSSL_VERSION_NUMBER must have been set by openssl-sys");
     let openssl_version = u64::from_str_radix(&openssl_version, 16)
         .expect("DEP_OPENSSL_VERSION_NUMBER must have been set to a valid integer");
-    #[allow(clippy::unusual_byte_groupings)]
+    #[allow(clippy::inconsistent_digit_grouping)]
     {
         if openssl_version >= 0x01_01_00_00_0 {
             println!("cargo:rustc-cfg=ossl110");

--- a/openssl-sys2/src/lib.rs
+++ b/openssl-sys2/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(rust_2018_idioms)]
 #![warn(clippy::all, clippy::pedantic)]
-#![allow(non_camel_case_types, clippy::upper_case_acronyms)]
+#![allow(non_camel_case_types)]
 
 mod asn1;
 pub use asn1::*;

--- a/pkcs11/pkcs11-sys/src/lib.rs
+++ b/pkcs11/pkcs11-sys/src/lib.rs
@@ -6,7 +6,6 @@
     non_camel_case_types,
     non_snake_case,
     clippy::must_use_candidate,
-    clippy::upper_case_acronyms,
     clippy::use_self
 )]
 

--- a/pkcs11/pkcs11/src/lib.rs
+++ b/pkcs11/pkcs11/src/lib.rs
@@ -5,9 +5,7 @@
 #![allow(
     non_snake_case,
     clippy::default_trait_access,
-    clippy::let_underscore_drop,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
     clippy::must_use_candidate,
     clippy::too_many_lines,
     clippy::type_complexity,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-1.47.0
+[toolchain]
+channel = "1.47"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,1 @@
-[toolchain]
-channel = "stable"
-components = ["clippy", "rustfmt"]
+1.47.0

--- a/tpm/aziot-tpm-rs/src/lib.rs
+++ b/tpm/aziot-tpm-rs/src/lib.rs
@@ -4,11 +4,7 @@
 
 #![deny(rust_2018_idioms)]
 #![warn(clippy::all, clippy::pedantic)]
-#![allow(
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
-    clippy::module_name_repetitions
-)]
+#![allow(clippy::missing_errors_doc, clippy::module_name_repetitions)]
 #![deny(missing_docs)]
 
 mod error;

--- a/tpm/aziot-tpm-sys/src/lib.rs
+++ b/tpm/aziot-tpm-sys/src/lib.rs
@@ -9,7 +9,7 @@
     non_snake_case,
     non_upper_case_globals,
     clippy::must_use_candidate,
-    clippy::too_many_lines,
+    clippy::too_many_lines
 )]
 
 use std::os::raw::{c_int, c_uchar, c_void};

--- a/tpm/aziot-tpm-sys/src/lib.rs
+++ b/tpm/aziot-tpm-sys/src/lib.rs
@@ -10,7 +10,6 @@
     non_upper_case_globals,
     clippy::must_use_candidate,
     clippy::too_many_lines,
-    clippy::upper_case_acronyms
 )]
 
 use std::os::raw::{c_int, c_uchar, c_void};


### PR DESCRIPTION
This is a temporary reversion so that the code in this repo is compatible with iotedge.

This reverts:
- f733226 Update ex_data.rs for Rust > 1.51 (#224)
- d9895b5 Fix build for new Rust stable 1.52.0 (#214)