### PR TITLE
Fix DPS TPM reprovisioning (#239)

### DIFF
--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -628,6 +628,8 @@ impl IdentityManager {
                     credentials,
                 };
                 self.set_device(&device);
+
+                log::info!("Updated device info for {}.", device.device_id);
                 aziot_identity_common::ProvisioningStatus::Provisioned(device)
             }
             config::ProvisioningType::Dps {
@@ -707,6 +709,8 @@ impl IdentityManager {
                     .await?;
 
                 self.set_device(&device);
+
+                log::info!("Successfully provisioned with DPS.");
                 aziot_identity_common::ProvisioningStatus::Provisioned(device)
             }
             config::ProvisioningType::None => {

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -69,8 +69,11 @@ pub async fn main(
     let connector = settings.endpoints.aziot_identityd.clone();
 
     if !homedir_path.exists() {
-        let () =
-            std::fs::create_dir_all(&homedir_path).map_err(error::InternalError::CreateHomeDir)?;
+        if let Err(err) = std::fs::create_dir_all(&homedir_path) {
+            log::error!("Failed to create home directory: {}", err);
+
+            return Err(error::InternalError::CreateHomeDir(err).into());
+        }
     }
 
     let api = Api::new(settings.clone())?;
@@ -432,8 +435,6 @@ impl Api {
                                 return Err(err);
                             }
                         } else {
-                            log::info!("Successfully reprovisioned.");
-
                             self.id_manager
                                 .reconcile_hub_identities(self.settings.clone())
                                 .await?;
@@ -554,7 +555,8 @@ impl Api {
             // no valid backup could be loaded. Treat this as a fatal error.
             if let ReprovisionTrigger::Startup = trigger {
                 log::error!(
-                    "Failed to provision with IoT Hub, and no valid device backup was found."
+                    "Failed to provision with IoT Hub, and no valid device backup was found: {}",
+                    err
                 );
 
                 return Err(err);

--- a/tpm/aziot-tpm-sys/azure-iot-hsm-c/src/hsm_client_tpm_device.c
+++ b/tpm/aziot-tpm-sys/azure-iot-hsm-c/src/hsm_client_tpm_device.c
@@ -254,6 +254,13 @@ static int insert_key_in_tpm
                 }
             }
         }
+
+        if (TPM2_FlushContext(&sec_info->tpm_device, ek_sess.SessIn.sessionHandle) != TPM_RC_SUCCESS)
+        {
+            // Failure to flush the session isn't a fatal error now, but might cause future calls
+            // to this function to fail.
+            LOG_ERROR("Failed to flush session");
+        }
     }
     return result;
 }

--- a/tpm/aziot-tpm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
+++ b/tpm/aziot-tpm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
@@ -516,11 +516,15 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
     TEST_FUNCTION(hsm_client_tpm_activate_key_succeed)
     {
         //arrange
+        TPMI_DH_CONTEXT tmp_dh_ctx = { 0 };
+
         const HSM_CLIENT_TPM_INTERFACE* tpm_if = hsm_client_tpm_interface();
         HSM_CLIENT_HANDLE sec_handle = tpm_if->hsm_client_tpm_create();
         umock_c_reset_all_calls();
 
         setup_hsm_client_tpm_activate_key_mock();
+        STRICT_EXPECTED_CALL(TPM2_FlushContext(IGNORED_PTR_ARG, tmp_dh_ctx))
+            .IgnoreArgument_flushHandle();
 
         //act
         int import_res = tpm_if->hsm_client_activate_identity_key(sec_handle, TEST_IMPORT_KEY, TEST_KEY_SIZE);


### PR DESCRIPTION
TPMs allow only a limited number of sessions to be open at once. Previously, tpmd wasn't closing its sessions so reprovisioning would fail if called repeatedly once it reached the limit of open sessions.

This change:
- Flushes TPM sessions to fix reprovisioning when using DPS+TPM
- Tweaks the log messages during reprovisioning to make them clearer