### PR TITLE
Add pid to UnixService

### DIFF
--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -56,7 +56,7 @@ impl Incoming {
                 let (tcp_stream, _) = listener.accept().await?;
 
                 // TCP is available in test builds only (not production). Assume current user is root.
-                let server = crate::uid::UidService::new(0, server.clone());
+                let server = crate::uid::UidService::new(None, 0, server.clone());
                 tokio::spawn(async move {
                     if let Err(http_err) = hyper::server::conn::Http::new()
                         .serve_connection(tcp_stream, server)
@@ -80,7 +80,7 @@ impl Incoming {
                     })
                     .clone();
 
-                let server = crate::uid::UidService::new(ucred.uid(), server.clone());
+                let server = crate::uid::UidService::new(ucred.pid(), ucred.uid(), server.clone());
                 tokio::spawn(async move {
                     match user_state.try_acquire_owned() {
                         Ok(_permit) => {

--- a/http-common/src/uid.rs
+++ b/http-common/src/uid.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use libc::uid_t;
+use libc::{pid_t, uid_t};
 
 pub struct UidService<T> {
+    pid: Option<pid_t>,
     uid: uid_t,
     inner: T,
 }
 
 impl<T> UidService<T> {
-    pub fn new(uid: uid_t, inner: T) -> Self {
-        UidService { uid, inner }
+    pub fn new(pid: Option<pid_t>, uid: uid_t, inner: T) -> Self {
+        UidService { pid, uid, inner }
     }
 }
 
@@ -34,7 +35,9 @@ where
 
     fn call(&mut self, req: hyper::Request<hyper::Body>) -> Self::Future {
         let mut req = req;
-        req.extensions_mut().insert(self.uid);
+        let extensions = req.extensions_mut();
+        extensions.insert(self.uid);
+        extensions.insert(self.pid);
         Box::pin(self.inner.call(req))
     }
 


### PR DESCRIPTION
PID is used in aziot-edged to authenticate callers.

The tokio-refactored edged server uses this server code, so add pid to the HTTP extensions here.