### PR TITLE
Bump missed version number for e2e tests

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -45,7 +45,7 @@ jobs:
           '/src/ci/package.sh'
       env:
         ARCH: "${{ matrix.arch }}"
-        PACKAGE_VERSION: '1.2.0'
+        PACKAGE_VERSION: '1.2.1'
         PACKAGE_RELEASE: '1'
     - name: 'Generate artifact properties'
       id: 'generate-artifact-properties'


### PR DESCRIPTION
The e2e tests are looking for the current version 1.2.1, but the github actions is still tagging the newest builds as 1.2.0. This causes the tests to break