### PR TITLE
Allow shutting down http_common server

### DIFF
--- a/aziotd/Cargo.toml
+++ b/aziotd/Cargo.toml
@@ -10,7 +10,7 @@ backtrace = "0.3"
 hyper = "0.14"
 log = "0.4"
 serde = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 
 aziot-certd = { path = "../cert/aziot-certd" }
 aziot-identityd = { path = "../identity/aziot-identityd" }

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -203,8 +203,12 @@ where
         .incoming()
         .await
         .map_err(|err| ErrorKind::Service(Box::new(err)))?;
+
+    // Channel to gracefully shut down the server. It's currently not used.
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
     let () = incoming
-        .serve(server)
+        .serve(server, shutdown_rx)
         .await
         .map_err(|err| ErrorKind::Service(Box::new(err)))?;
 

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -30,3 +30,4 @@ serde_json = "1"
 
 [features]
 tokio1 = ["headers", "hyper", "hyper-openssl", "hyper-proxy", "openssl", "openssl-sys", "tokio"]
+serve_with_shutdown = ["tokio/time"]

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -21,7 +21,7 @@ openssl-sys = { version = "0.9", optional = true }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["net", "rt-multi-thread", "sync"], optional = true }
+tokio = { version = "1", features = ["net", "rt-multi-thread", "sync", "time"], optional = true }
 tracing = { version = "0.1", features = ["log"] }
 url = { version = "2", features = ["serde"] }
 
@@ -30,4 +30,3 @@ serde_json = "1"
 
 [features]
 tokio1 = ["headers", "hyper", "hyper-openssl", "hyper-proxy", "openssl", "openssl-sys", "tokio"]
-serve_with_shutdown = ["tokio/time"]

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -126,13 +126,7 @@ impl Incoming {
                                 .fetch_update(
                                     atomic::Ordering::AcqRel,
                                     atomic::Ordering::Acquire,
-                                    |current| {
-                                        if current == 0 {
-                                            None
-                                        } else {
-                                            Some(current - 1)
-                                        }
-                                    },
+                                    |current| current.checked_sub(1),
                                 )
                                 .is_ok();
 


### PR DESCRIPTION
Passes in a shutdown oneshot to `http_common::Incoming:serve`

Posting a message to the corresponding `oneshot::Sender` will cause the server to gracefully shut down by awaiting all unfinished server tasks.

This is currently not used by any of the aziotd services, but edged will use it for when it has to shut down and restart its servers for reprovisioning.