### PR TITLE
Add fd URIs to Connector

### DIFF
--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -703,6 +703,7 @@ fn socket_name_to_fd(name: &str) -> Result<std::os::unix::io::RawFd, String> {
     Ok(index + SD_LISTEN_FDS_START)
 }
 
+#[cfg(feature = "tokio1")]
 fn fd_to_listener(fd: std::os::unix::io::RawFd) -> std::io::Result<Incoming> {
     if is_unix_fd(fd)? {
         let listener: std::os::unix::net::UnixListener =

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+#[cfg(feature = "tokio1")]
 use std::sync::atomic;
 
+#[cfg(feature = "tokio1")]
 use futures_util::future;
 
 const SD_LISTEN_FDS_START: std::os::unix::io::RawFd = 3;


### PR DESCRIPTION
Adds support for `fd` URIs (such as `fd://0` or `fd://aziot-edged.workload.socket`) to Connector.