### PR TITLE
Add support for non-JSON response types in http_common

### DIFF
--- a/cert/aziot-certd/src/http/create.rs
+++ b/cert/aziot-certd/src/http/create.rs
@@ -32,16 +32,12 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = aziot_cert_common_http::create_cert::Request;
-    type PostResponse = aziot_cert_common_http::create_cert::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -68,9 +64,9 @@ impl http_common::server::Route for Route {
         let res = aziot_cert_common_http::create_cert::Response {
             pem: aziot_cert_common_http::Pem(pem),
         };
-        Ok((hyper::StatusCode::CREATED, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::CREATED, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/cert/aziot-certd/src/http/create.rs
+++ b/cert/aziot-certd/src/http/create.rs
@@ -34,10 +34,7 @@ impl http_common::server::Route for Route {
     type DeleteBody = serde::de::IgnoredAny;
 
     type PostBody = aziot_cert_common_http::create_cert::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -64,7 +61,7 @@ impl http_common::server::Route for Route {
         let res = aziot_cert_common_http::create_cert::Response {
             pem: aziot_cert_common_http::Pem(pem),
         };
-        let res = http_common::server::json_response(hyper::StatusCode::CREATED, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::CREATED, &res);
         Ok(res)
     }
 

--- a/cert/aziot-certd/src/http/get_or_import_or_delete.rs
+++ b/cert/aziot-certd/src/http/get_or_import_or_delete.rs
@@ -43,10 +43,7 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    async fn delete(
-        self,
-        _body: Option<Self::DeleteBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn delete(self, _body: Option<Self::DeleteBody>) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -54,7 +51,7 @@ impl http_common::server::Route for Route {
             return Err(super::to_http_error(&err));
         }
 
-        Ok(http_common::server::empty_response())
+        Ok(http_common::server::response::empty())
     }
 
     async fn get(self) -> http_common::server::RouteResponse {
@@ -70,17 +67,14 @@ impl http_common::server::Route for Route {
         let res = aziot_cert_common_http::get_cert::Response {
             pem: aziot_cert_common_http::Pem(pem),
         };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 
     type PostBody = serde::de::IgnoredAny;
 
     type PutBody = aziot_cert_common_http::import_cert::Request;
-    async fn put(
-        self,
-        body: Self::PutBody,
-    ) -> http_common::server::RouteResponse {
+    async fn put(self, body: Self::PutBody) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -90,7 +84,7 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_cert_common_http::import_cert::Response { pem: body.pem };
-        let res = http_common::server::json_response(hyper::StatusCode::CREATED, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::CREATED, &res);
         Ok(res)
     }
 }

--- a/cert/aziot-certd/src/http/get_or_import_or_delete.rs
+++ b/cert/aziot-certd/src/http/get_or_import_or_delete.rs
@@ -43,11 +43,10 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
     async fn delete(
         self,
         _body: Option<Self::DeleteBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::DeleteResponse>> {
+    ) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -55,11 +54,10 @@ impl http_common::server::Route for Route {
             return Err(super::to_http_error(&err));
         }
 
-        Ok((hyper::StatusCode::NO_CONTENT, None))
+        Ok(http_common::server::empty_response())
     }
 
-    type GetResponse = aziot_cert_common_http::get_cert::Response;
-    async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+    async fn get(self) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -72,18 +70,17 @@ impl http_common::server::Route for Route {
         let res = aziot_cert_common_http::get_cert::Response {
             pem: aziot_cert_common_http::Pem(pem),
         };
-        Ok((hyper::StatusCode::OK, res))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PostBody = serde::de::IgnoredAny;
-    type PostResponse = ();
 
     type PutBody = aziot_cert_common_http::import_cert::Request;
-    type PutResponse = aziot_cert_common_http::import_cert::Response;
     async fn put(
         self,
         body: Self::PutBody,
-    ) -> http_common::server::RouteResponse<Self::PutResponse> {
+    ) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -93,6 +90,7 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_cert_common_http::import_cert::Response { pem: body.pem };
-        Ok((hyper::StatusCode::CREATED, res))
+        let res = http_common::server::json_response(hyper::StatusCode::CREATED, &res);
+        Ok(res)
     }
 }

--- a/cert/aziot-certd/src/http/get_or_import_or_delete.rs
+++ b/cert/aziot-certd/src/http/get_or_import_or_delete.rs
@@ -51,7 +51,7 @@ impl http_common::server::Route for Route {
             return Err(super::to_http_error(&err));
         }
 
-        Ok(http_common::server::response::empty())
+        Ok(http_common::server::response::no_content())
     }
 
     async fn get(self) -> http_common::server::RouteResponse {

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -128,19 +128,17 @@ macro_rules! make_service {
                                                 }
                                             };
 
-                                            let (status_code, response) = match <$route as http_common::server::Route>::delete(route, body).await {
+                                            match <$route as http_common::server::Route>::delete(route, body).await {
                                                 Ok(result) => result,
                                                 Err(err) => return Ok(err.to_http_response()),
-                                            };
-                                            http_common::server::json_response(status_code, response.as_ref())
+                                            }
                                         },
 
                                         http::Method::GET => {
-                                            let (status_code, response) = match <$route as http_common::server::Route>::get(route).await {
+                                            match <$route as http_common::server::Route>::get(route).await {
                                                 Ok(result) => result,
                                                 Err(err) => return Ok(err.to_http_response()),
-                                            };
-                                            http_common::server::json_response(status_code, Some(&response))
+                                            }
                                         },
 
                                         http::Method::POST => {
@@ -176,11 +174,10 @@ macro_rules! make_service {
                                                 }
                                             };
 
-                                            let (status_code, response) = match <$route as http_common::server::Route>::post(route, body).await {
+                                            match <$route as http_common::server::Route>::post(route, body).await {
                                                 Ok(result) => result,
                                                 Err(err) => return Ok(err.to_http_response()),
-                                            };
-                                            http_common::server::json_response(status_code, response.as_ref())
+                                            }
                                         },
 
                                         http::Method::PUT => {
@@ -214,11 +211,10 @@ macro_rules! make_service {
                                                 }).to_http_response()),
                                             };
 
-                                            let (status_code, response) = match <$route as http_common::server::Route>::put(route, body).await {
+                                            match <$route as http_common::server::Route>::put(route, body).await {
                                                 Ok(result) => result,
                                                 Err(err) => return Ok(err.to_http_response()),
-                                            };
-                                            http_common::server::json_response(status_code, Some(&response))
+                                            }
                                         },
 
                                         _ => return Ok((http_common::server::Error {
@@ -270,19 +266,14 @@ pub trait Route: Sized {
     ) -> Option<Self>;
 
     type DeleteBody: serde::de::DeserializeOwned + Send;
-    type DeleteResponse: serde::Serialize + Send + 'static;
-    async fn delete(
-        self,
-        _body: Option<Self::DeleteBody>,
-    ) -> RouteResponse<Option<Self::DeleteResponse>> {
+    async fn delete(self, _body: Option<Self::DeleteBody>) -> RouteResponse {
         Err(Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "method not allowed".into(),
         })
     }
 
-    type GetResponse: serde::Serialize + Send + 'static;
-    async fn get(self) -> RouteResponse<Self::GetResponse> {
+    async fn get(self) -> RouteResponse {
         Err(Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "method not allowed".into(),
@@ -290,11 +281,7 @@ pub trait Route: Sized {
     }
 
     type PostBody: serde::de::DeserializeOwned + Send;
-    type PostResponse: serde::Serialize + Send + 'static;
-    async fn post(
-        self,
-        _body: Option<Self::PostBody>,
-    ) -> RouteResponse<Option<Self::PostResponse>> {
+    async fn post(self, _body: Option<Self::PostBody>) -> RouteResponse {
         Err(Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "method not allowed".into(),
@@ -302,8 +289,7 @@ pub trait Route: Sized {
     }
 
     type PutBody: serde::de::DeserializeOwned + Send;
-    type PutResponse: serde::Serialize + Send + 'static;
-    async fn put(self, _body: Self::PutBody) -> RouteResponse<Self::PutResponse> {
+    async fn put(self, _body: Self::PutBody) -> RouteResponse {
         Err(Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "method not allowed".into(),
@@ -311,7 +297,7 @@ pub trait Route: Sized {
     }
 }
 
-pub type RouteResponse<T> = Result<(http::StatusCode, T), Error>;
+pub type RouteResponse = Result<hyper::Response<hyper::Body>, Error>;
 
 pub fn error_to_message(err: &impl std::error::Error) -> String {
     let mut message = String::new();
@@ -340,29 +326,52 @@ impl Error {
         let body = crate::ErrorBody {
             message: std::borrow::Cow::Borrowed(std::borrow::Borrow::borrow(&self.message)),
         };
-        let res = json_response(self.status_code, Some(&body));
+        let res = json_response(self.status_code, &body);
         res
     }
 }
 
 #[cfg(feature = "tokio1")]
+pub fn empty_response(status_code: hyper::StatusCode) -> hyper::Response<hyper::Body> {
+    let res = hyper::Response::builder()
+        .status(status_code)
+        .body(Default::default())
+        .expect("cannot fail to build hyper response");
+
+    res
+}
+
+#[cfg(feature = "tokio1")]
 pub fn json_response(
     status_code: hyper::StatusCode,
-    body: Option<&impl serde::Serialize>,
+    body: &impl serde::Serialize,
+) -> hyper::Response<hyper::Body> {
+    let body = serde_json::to_string(body).expect("cannot fail to serialize response to JSON");
+    let body = hyper::Body::from(body);
+
+    let res = hyper::Response::builder()
+        .status(status_code)
+        .header(hyper::header::CONTENT_TYPE, "application/json")
+        .body(body);
+
+    let res = res.expect("cannot fail to build hyper response");
+    res
+}
+
+#[cfg(feature = "tokio1")]
+pub fn zip_response(
+    status_code: hyper::StatusCode,
+    size: usize,
+    body: Vec<u8>,
 ) -> hyper::Response<hyper::Body> {
     let res = hyper::Response::builder().status(status_code);
-    // `res` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let res = if let Some(body) = body {
-        let body = serde_json::to_string(body).expect("cannot fail to serialize response to JSON");
-        let body = hyper::Body::from(body);
-        res.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        res.body(Default::default())
-    };
+
+    let res = res
+        .header(hyper::header::CONTENT_ENCODING, "zip")
+        .header(hyper::header::CONTENT_LENGTH, size.to_string())
+        .header(hyper::header::CONTENT_TYPE, "application/zip")
+        .body(hyper::Body::from(body));
+
     let res = res.expect("cannot fail to build hyper response");
     res
 }
@@ -432,15 +441,8 @@ mod test_server {
             }
 
             type DeleteBody = serde::de::IgnoredAny;
-            type DeleteResponse = ();
-
-            type GetResponse = ();
-
             type PostBody = serde::de::IgnoredAny;
-            type PostResponse = ();
-
             type PutBody = serde::de::IgnoredAny;
-            type PutResponse = ();
         }
     }
 }

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -333,7 +333,7 @@ impl Error {
 
 #[cfg(feature = "tokio1")]
 pub mod response {
-    pub fn empty() -> hyper::Response<hyper::Body> {
+    pub fn no_content() -> hyper::Response<hyper::Body> {
         let res = hyper::Response::builder()
             .status(hyper::StatusCode::NO_CONTENT)
             .body(Default::default())
@@ -366,7 +366,7 @@ pub mod response {
         let res = hyper::Response::builder().status(status_code);
 
         let res = res
-            .header(hyper::header::CONTENT_ENCODING, "zip")
+            .header(hyper::header::CONTENT_ENCODING, "deflate")
             .header(hyper::header::CONTENT_LENGTH, size.to_string())
             .header(hyper::header::CONTENT_TYPE, "application/zip")
             .body(hyper::Body::from(body));

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -326,54 +326,54 @@ impl Error {
         let body = crate::ErrorBody {
             message: std::borrow::Cow::Borrowed(std::borrow::Borrow::borrow(&self.message)),
         };
-        let res = json_response(self.status_code, &body);
+        let res = response::json(self.status_code, &body);
         res
     }
 }
 
 #[cfg(feature = "tokio1")]
-pub fn empty_response() -> hyper::Response<hyper::Body> {
-    let res = hyper::Response::builder()
-        .status(hyper::StatusCode::NO_CONTENT)
-        .body(Default::default())
-        .expect("cannot fail to build hyper response");
+pub mod response {
+    pub fn empty() -> hyper::Response<hyper::Body> {
+        let res = hyper::Response::builder()
+            .status(hyper::StatusCode::NO_CONTENT)
+            .body(Default::default())
+            .expect("cannot fail to build hyper response");
 
-    res
-}
+        res
+    }
 
-#[cfg(feature = "tokio1")]
-pub fn json_response(
-    status_code: hyper::StatusCode,
-    body: &impl serde::Serialize,
-) -> hyper::Response<hyper::Body> {
-    let body = serde_json::to_string(body).expect("cannot fail to serialize response to JSON");
-    let body = hyper::Body::from(body);
+    pub fn json(
+        status_code: hyper::StatusCode,
+        body: &impl serde::Serialize,
+    ) -> hyper::Response<hyper::Body> {
+        let body = serde_json::to_string(body).expect("cannot fail to serialize response to JSON");
+        let body = hyper::Body::from(body);
 
-    let res = hyper::Response::builder()
-        .status(status_code)
-        .header(hyper::header::CONTENT_TYPE, "application/json")
-        .body(body);
+        let res = hyper::Response::builder()
+            .status(status_code)
+            .header(hyper::header::CONTENT_TYPE, "application/json")
+            .body(body);
 
-    let res = res.expect("cannot fail to build hyper response");
-    res
-}
+        let res = res.expect("cannot fail to build hyper response");
+        res
+    }
 
-#[cfg(feature = "tokio1")]
-pub fn zip_response(
-    status_code: hyper::StatusCode,
-    size: usize,
-    body: Vec<u8>,
-) -> hyper::Response<hyper::Body> {
-    let res = hyper::Response::builder().status(status_code);
+    pub fn zip(
+        status_code: hyper::StatusCode,
+        size: usize,
+        body: Vec<u8>,
+    ) -> hyper::Response<hyper::Body> {
+        let res = hyper::Response::builder().status(status_code);
 
-    let res = res
-        .header(hyper::header::CONTENT_ENCODING, "zip")
-        .header(hyper::header::CONTENT_LENGTH, size.to_string())
-        .header(hyper::header::CONTENT_TYPE, "application/zip")
-        .body(hyper::Body::from(body));
+        let res = res
+            .header(hyper::header::CONTENT_ENCODING, "zip")
+            .header(hyper::header::CONTENT_LENGTH, size.to_string())
+            .header(hyper::header::CONTENT_TYPE, "application/zip")
+            .body(hyper::Body::from(body));
 
-    let res = res.expect("cannot fail to build hyper response");
-    res
+        let res = res.expect("cannot fail to build hyper response");
+        res
+    }
 }
 
 /// This server is never actually used, but is useful to ensure that the macro

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -332,9 +332,9 @@ impl Error {
 }
 
 #[cfg(feature = "tokio1")]
-pub fn empty_response(status_code: hyper::StatusCode) -> hyper::Response<hyper::Body> {
+pub fn empty_response() -> hyper::Response<hyper::Body> {
     let res = hyper::Response::builder()
-        .status(status_code)
+        .status(hyper::StatusCode::NO_CONTENT)
         .body(Default::default())
         .expect("cannot fail to build hyper response");
 

--- a/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
+++ b/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
@@ -57,15 +57,12 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::get_module_identities::Response { identities };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 
     type PostBody = aziot_identity_common_http::create_module_identity::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -88,7 +85,7 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_identity_common_http::create_module_identity::Response { identity };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
+++ b/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
@@ -42,10 +42,8 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
 
-    type GetResponse = aziot_identity_common_http::get_module_identities::Response;
-    async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+    async fn get(self) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -59,15 +57,15 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::get_module_identities::Response { identities };
-        Ok((hyper::StatusCode::OK, res))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PostBody = aziot_identity_common_http::create_module_identity::Request;
-    type PostResponse = aziot_identity_common_http::create_module_identity::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -90,9 +88,9 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_identity_common_http::create_module_identity::Response { identity };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/identity/aziot-identityd/src/http/get_caller_identity.rs
+++ b/identity/aziot-identityd/src/http/get_caller_identity.rs
@@ -32,10 +32,8 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
 
-    type GetResponse = aziot_identity_common_http::get_module_identity::Response;
-    async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+    async fn get(self) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -49,12 +47,11 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::get_module_identity::Response { identity };
-        Ok((hyper::StatusCode::OK, res))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PostBody = serde::de::IgnoredAny;
-    type PostResponse = ();
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/identity/aziot-identityd/src/http/get_caller_identity.rs
+++ b/identity/aziot-identityd/src/http/get_caller_identity.rs
@@ -47,7 +47,7 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::get_module_identity::Response { identity };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/identity/aziot-identityd/src/http/get_device_identity.rs
+++ b/identity/aziot-identityd/src/http/get_device_identity.rs
@@ -34,10 +34,7 @@ impl http_common::server::Route for Route {
     type DeleteBody = serde::de::IgnoredAny;
 
     type PostBody = aziot_identity_common_http::get_device_identity::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -56,7 +53,7 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::get_device_identity::Response { identity };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/identity/aziot-identityd/src/http/get_device_identity.rs
+++ b/identity/aziot-identityd/src/http/get_device_identity.rs
@@ -32,16 +32,12 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = aziot_identity_common_http::get_device_identity::Request;
-    type PostResponse = aziot_identity_common_http::get_device_identity::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -60,9 +56,9 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::get_device_identity::Response { identity };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/identity/aziot-identityd/src/http/get_trust_bundle.rs
+++ b/identity/aziot-identityd/src/http/get_trust_bundle.rs
@@ -32,10 +32,8 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
 
-    type GetResponse = aziot_identity_common_http::get_trust_bundle::Response;
-    async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+    async fn get(self) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -50,12 +48,11 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_identity_common_http::get_trust_bundle::Response { certificate };
-        Ok((hyper::StatusCode::OK, res))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PostBody = serde::de::IgnoredAny;
-    type PostResponse = ();
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/identity/aziot-identityd/src/http/get_trust_bundle.rs
+++ b/identity/aziot-identityd/src/http/get_trust_bundle.rs
@@ -48,7 +48,7 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_identity_common_http::get_trust_bundle::Response { certificate };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -53,11 +53,10 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
     async fn delete(
         self,
         _body: Option<Self::DeleteBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::DeleteResponse>> {
+    ) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -74,11 +73,10 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         }
 
-        Ok((hyper::StatusCode::NO_CONTENT, None))
+        Ok(http_common::server::empty_response())
     }
 
-    type GetResponse = aziot_identity_common_http::get_module_identity::Response;
-    async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+    async fn get(self) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -95,14 +93,13 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::get_module_identity::Response { identity };
-        Ok((hyper::StatusCode::OK, res))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PostBody = serde::de::IgnoredAny;
-    type PostResponse = ();
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = aziot_identity_common_http::update_module_identity::Response;
     // clippy fires this lint for the `_body` parameter of the inner fn in the `async-trait` expansion.
     // It's not clear why clippy does this, especially since it doesn't raise it for other functions
     // that also ignore their `_body` parameter like `fn delete` above.
@@ -112,7 +109,7 @@ impl http_common::server::Route for Route {
     async fn put(
         self,
         _body: Self::PutBody,
-    ) -> http_common::server::RouteResponse<Self::PutResponse> {
+    ) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -129,6 +126,7 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::update_module_identity::Response { identity };
-        Ok((hyper::StatusCode::OK, res))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 }

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -70,7 +70,7 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         }
 
-        Ok(http_common::server::response::empty())
+        Ok(http_common::server::response::no_content())
     }
 
     async fn get(self) -> http_common::server::RouteResponse {

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -53,10 +53,7 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    async fn delete(
-        self,
-        _body: Option<Self::DeleteBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn delete(self, _body: Option<Self::DeleteBody>) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -73,7 +70,7 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         }
 
-        Ok(http_common::server::empty_response())
+        Ok(http_common::server::response::empty())
     }
 
     async fn get(self) -> http_common::server::RouteResponse {
@@ -93,7 +90,7 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::get_module_identity::Response { identity };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 
@@ -106,10 +103,7 @@ impl http_common::server::Route for Route {
     //
     // So suppress it manually.
     #[allow(clippy::needless_pass_by_value)]
-    async fn put(
-        self,
-        _body: Self::PutBody,
-    ) -> http_common::server::RouteResponse {
+    async fn put(self, _body: Self::PutBody) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -126,7 +120,7 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
         let res = aziot_identity_common_http::update_module_identity::Response { identity };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 }

--- a/identity/aziot-identityd/src/http/reprovision_device.rs
+++ b/identity/aziot-identityd/src/http/reprovision_device.rs
@@ -34,10 +34,7 @@ impl http_common::server::Route for Route {
     type DeleteBody = serde::de::IgnoredAny;
 
     type PostBody = serde::de::IgnoredAny;
-    async fn post(
-        self,
-        _body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, _body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -54,7 +51,7 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
 
-        Ok(http_common::server::empty_response())
+        Ok(http_common::server::response::empty())
     }
 
     type PutBody = serde::de::IgnoredAny;

--- a/identity/aziot-identityd/src/http/reprovision_device.rs
+++ b/identity/aziot-identityd/src/http/reprovision_device.rs
@@ -51,7 +51,7 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
 
-        Ok(http_common::server::response::empty())
+        Ok(http_common::server::response::no_content())
     }
 
     type PutBody = serde::de::IgnoredAny;

--- a/identity/aziot-identityd/src/http/reprovision_device.rs
+++ b/identity/aziot-identityd/src/http/reprovision_device.rs
@@ -32,16 +32,12 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = serde::de::IgnoredAny;
-    type PostResponse = ();
     async fn post(
         self,
         _body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -58,9 +54,8 @@ impl http_common::server::Route for Route {
             Err(err) => return Err(super::to_http_error(&err)),
         };
 
-        Ok((hyper::StatusCode::NO_CONTENT, None))
+        Ok(http_common::server::empty_response())
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/key/aziot-keyd/src/http/create_delete_key.rs
+++ b/key/aziot-keyd/src/http/create_delete_key.rs
@@ -44,7 +44,7 @@ impl http_common::server::Route for Route {
         api.delete_key(&body.key_handle)
             .map_err(|err| super::to_http_error(&err))?;
 
-        Ok(http_common::server::response::empty())
+        Ok(http_common::server::response::no_content())
     }
 
     type PostBody = aziot_key_common_http::create_key_if_not_exists::Request;

--- a/key/aziot-keyd/src/http/create_delete_key.rs
+++ b/key/aziot-keyd/src/http/create_delete_key.rs
@@ -32,11 +32,10 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = aziot_key_common_http::delete::Request;
-    type DeleteResponse = ();
     async fn delete(
         self,
         body: Option<Self::DeleteBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::DeleteResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -48,17 +47,14 @@ impl http_common::server::Route for Route {
         api.delete_key(&body.key_handle)
             .map_err(|err| super::to_http_error(&err))?;
 
-        Ok((hyper::StatusCode::NO_CONTENT, None))
+        Ok(http_common::server::empty_response())
     }
 
-    type GetResponse = ();
-
     type PostBody = aziot_key_common_http::create_key_if_not_exists::Request;
-    type PostResponse = aziot_key_common_http::create_key_if_not_exists::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -85,9 +81,9 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_key_common_http::create_key_if_not_exists::Response { handle };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/key/aziot-keyd/src/http/create_delete_key.rs
+++ b/key/aziot-keyd/src/http/create_delete_key.rs
@@ -32,10 +32,7 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = aziot_key_common_http::delete::Request;
-    async fn delete(
-        self,
-        body: Option<Self::DeleteBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn delete(self, body: Option<Self::DeleteBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -47,14 +44,11 @@ impl http_common::server::Route for Route {
         api.delete_key(&body.key_handle)
             .map_err(|err| super::to_http_error(&err))?;
 
-        Ok(http_common::server::empty_response())
+        Ok(http_common::server::response::empty())
     }
 
     type PostBody = aziot_key_common_http::create_key_if_not_exists::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -81,7 +75,7 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_key_common_http::create_key_if_not_exists::Response { handle };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/key/aziot-keyd/src/http/create_delete_key_pair.rs
+++ b/key/aziot-keyd/src/http/create_delete_key_pair.rs
@@ -32,10 +32,7 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = aziot_key_common_http::delete::Request;
-    async fn delete(
-        self,
-        body: Option<Self::DeleteBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn delete(self, body: Option<Self::DeleteBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -47,14 +44,11 @@ impl http_common::server::Route for Route {
         api.delete_key_pair(&body.key_handle)
             .map_err(|err| super::to_http_error(&err))?;
 
-        Ok(http_common::server::empty_response())
+        Ok(http_common::server::response::empty())
     }
 
     type PostBody = aziot_key_common_http::create_key_pair_if_not_exists::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -73,7 +67,7 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_key_common_http::create_key_pair_if_not_exists::Response { handle };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/key/aziot-keyd/src/http/create_delete_key_pair.rs
+++ b/key/aziot-keyd/src/http/create_delete_key_pair.rs
@@ -44,7 +44,7 @@ impl http_common::server::Route for Route {
         api.delete_key_pair(&body.key_handle)
             .map_err(|err| super::to_http_error(&err))?;
 
-        Ok(http_common::server::response::empty())
+        Ok(http_common::server::response::no_content())
     }
 
     type PostBody = aziot_key_common_http::create_key_pair_if_not_exists::Request;

--- a/key/aziot-keyd/src/http/create_delete_key_pair.rs
+++ b/key/aziot-keyd/src/http/create_delete_key_pair.rs
@@ -32,11 +32,10 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = aziot_key_common_http::delete::Request;
-    type DeleteResponse = ();
     async fn delete(
         self,
         body: Option<Self::DeleteBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::DeleteResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -48,17 +47,14 @@ impl http_common::server::Route for Route {
         api.delete_key_pair(&body.key_handle)
             .map_err(|err| super::to_http_error(&err))?;
 
-        Ok((hyper::StatusCode::NO_CONTENT, None))
+        Ok(http_common::server::empty_response())
     }
 
-    type GetResponse = ();
-
     type PostBody = aziot_key_common_http::create_key_pair_if_not_exists::Request;
-    type PostResponse = aziot_key_common_http::create_key_pair_if_not_exists::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -77,9 +73,9 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_key_common_http::create_key_pair_if_not_exists::Response { handle };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/key/aziot-keyd/src/http/create_derived_key.rs
+++ b/key/aziot-keyd/src/http/create_derived_key.rs
@@ -30,10 +30,7 @@ impl http_common::server::Route for Route {
     type DeleteBody = serde::de::IgnoredAny;
 
     type PostBody = aziot_key_common_http::create_derived_key::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -48,7 +45,7 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_key_common_http::create_derived_key::Response { handle };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/key/aziot-keyd/src/http/create_derived_key.rs
+++ b/key/aziot-keyd/src/http/create_derived_key.rs
@@ -28,16 +28,12 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = aziot_key_common_http::create_derived_key::Request;
-    type PostResponse = aziot_key_common_http::create_derived_key::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -52,9 +48,9 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_key_common_http::create_derived_key::Response { handle };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/key/aziot-keyd/src/http/decrypt.rs
+++ b/key/aziot-keyd/src/http/decrypt.rs
@@ -28,16 +28,12 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = aziot_key_common_http::decrypt::Request;
-    type PostResponse = aziot_key_common_http::decrypt::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -71,9 +67,9 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::decrypt::Response {
             plaintext: http_common::ByteString(plaintext),
         };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/key/aziot-keyd/src/http/decrypt.rs
+++ b/key/aziot-keyd/src/http/decrypt.rs
@@ -30,10 +30,7 @@ impl http_common::server::Route for Route {
     type DeleteBody = serde::de::IgnoredAny;
 
     type PostBody = aziot_key_common_http::decrypt::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -67,7 +64,7 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::decrypt::Response {
             plaintext: http_common::ByteString(plaintext),
         };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/key/aziot-keyd/src/http/encrypt.rs
+++ b/key/aziot-keyd/src/http/encrypt.rs
@@ -28,16 +28,12 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = aziot_key_common_http::encrypt::Request;
-    type PostResponse = aziot_key_common_http::encrypt::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -71,9 +67,9 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::encrypt::Response {
             ciphertext: http_common::ByteString(ciphertext),
         };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/key/aziot-keyd/src/http/encrypt.rs
+++ b/key/aziot-keyd/src/http/encrypt.rs
@@ -30,10 +30,7 @@ impl http_common::server::Route for Route {
     type DeleteBody = serde::de::IgnoredAny;
 
     type PostBody = aziot_key_common_http::encrypt::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -67,7 +64,7 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::encrypt::Response {
             ciphertext: http_common::ByteString(ciphertext),
         };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/key/aziot-keyd/src/http/export_derived_key.rs
+++ b/key/aziot-keyd/src/http/export_derived_key.rs
@@ -30,10 +30,7 @@ impl http_common::server::Route for Route {
     type DeleteBody = serde::de::IgnoredAny;
 
     type PostBody = aziot_key_common_http::export_derived_key::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -50,7 +47,7 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::export_derived_key::Response {
             key: http_common::ByteString(derived_key),
         };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/key/aziot-keyd/src/http/export_derived_key.rs
+++ b/key/aziot-keyd/src/http/export_derived_key.rs
@@ -28,16 +28,12 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = aziot_key_common_http::export_derived_key::Request;
-    type PostResponse = aziot_key_common_http::export_derived_key::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -54,9 +50,9 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::export_derived_key::Response {
             key: http_common::ByteString(derived_key),
         };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
+++ b/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
@@ -39,16 +39,12 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = aziot_key_common_http::get_key_pair_public_parameter::Request;
-    type PostResponse = aziot_key_common_http::get_key_pair_public_parameter::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -66,9 +62,9 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::get_key_pair_public_parameter::Response {
             value: parameter_value,
         };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
+++ b/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
@@ -41,10 +41,7 @@ impl http_common::server::Route for Route {
     type DeleteBody = serde::de::IgnoredAny;
 
     type PostBody = aziot_key_common_http::get_key_pair_public_parameter::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -62,7 +59,7 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::get_key_pair_public_parameter::Response {
             value: parameter_value,
         };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/key/aziot-keyd/src/http/load.rs
+++ b/key/aziot-keyd/src/http/load.rs
@@ -50,10 +50,8 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
 
-    type GetResponse = aziot_key_common_http::load::Response;
-    async fn get(self) -> http_common::server::RouteResponse<Self::GetResponse> {
+    async fn get(self) -> http_common::server::RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -75,12 +73,11 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_key_common_http::load::Response { handle };
-        Ok((hyper::StatusCode::OK, res))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PostBody = serde::de::IgnoredAny;
-    type PostResponse = ();
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/key/aziot-keyd/src/http/load.rs
+++ b/key/aziot-keyd/src/http/load.rs
@@ -73,7 +73,7 @@ impl http_common::server::Route for Route {
         };
 
         let res = aziot_key_common_http::load::Response { handle };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/key/aziot-keyd/src/http/sign.rs
+++ b/key/aziot-keyd/src/http/sign.rs
@@ -30,10 +30,7 @@ impl http_common::server::Route for Route {
     type DeleteBody = serde::de::IgnoredAny;
 
     type PostBody = aziot_key_common_http::sign::Request;
-    async fn post(
-        self,
-        body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse {
+    async fn post(self, body: Option<Self::PostBody>) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -60,7 +57,7 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::sign::Response {
             signature: http_common::ByteString(signature),
         };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/key/aziot-keyd/src/http/sign.rs
+++ b/key/aziot-keyd/src/http/sign.rs
@@ -28,16 +28,12 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = aziot_key_common_http::sign::Request;
-    type PostResponse = aziot_key_common_http::sign::Response;
     async fn post(
         self,
         body: Option<Self::PostBody>,
-    ) -> http_common::server::RouteResponse<Option<Self::PostResponse>> {
+    ) -> http_common::server::RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -64,9 +60,9 @@ impl http_common::server::Route for Route {
         let res = aziot_key_common_http::sign::Response {
             signature: http_common::ByteString(signature),
         };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/tpm/aziot-tpmd/src/http/get_tpm_keys.rs
+++ b/tpm/aziot-tpmd/src/http/get_tpm_keys.rs
@@ -30,10 +30,8 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
 
-    type GetResponse = aziot_tpm_common_http::get_tpm_keys::Response;
-    async fn get(self) -> RouteResponse<Self::GetResponse> {
+    async fn get(self) -> RouteResponse {
         let mut api = self.api.lock().await;
         let api = &mut *api;
 
@@ -45,12 +43,12 @@ impl http_common::server::Route for Route {
             /// The TPM's Storage Root Key
             storage_root_key: http_common::ByteString(keys.storage_root_key),
         };
-        Ok((hyper::StatusCode::OK, res))
+
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PostBody = serde::de::IgnoredAny;
-    type PostResponse = ();
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/tpm/aziot-tpmd/src/http/get_tpm_keys.rs
+++ b/tpm/aziot-tpmd/src/http/get_tpm_keys.rs
@@ -44,7 +44,7 @@ impl http_common::server::Route for Route {
             storage_root_key: http_common::ByteString(keys.storage_root_key),
         };
 
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/tpm/aziot-tpmd/src/http/import_auth_key.rs
+++ b/tpm/aziot-tpmd/src/http/import_auth_key.rs
@@ -45,7 +45,7 @@ impl http_common::server::Route for Route {
             .map_err(|e| super::to_http_error(&e))?;
 
         let res = aziot_tpm_common_http::import_auth_key::Response {};
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 

--- a/tpm/aziot-tpmd/src/http/import_auth_key.rs
+++ b/tpm/aziot-tpmd/src/http/import_auth_key.rs
@@ -30,13 +30,9 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = aziot_tpm_common_http::import_auth_key::Response;
 
     type PostBody = aziot_tpm_common_http::import_auth_key::Request;
-    type PostResponse = aziot_tpm_common_http::import_auth_key::Response;
-    async fn post(self, body: Option<Self::PostBody>) -> RouteResponse<Option<Self::PostResponse>> {
+    async fn post(self, body: Option<Self::PostBody>) -> RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -49,9 +45,9 @@ impl http_common::server::Route for Route {
             .map_err(|e| super::to_http_error(&e))?;
 
         let res = aziot_tpm_common_http::import_auth_key::Response {};
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/tpm/aziot-tpmd/src/http/sign_with_auth_key.rs
+++ b/tpm/aziot-tpmd/src/http/sign_with_auth_key.rs
@@ -30,13 +30,9 @@ impl http_common::server::Route for Route {
     }
 
     type DeleteBody = serde::de::IgnoredAny;
-    type DeleteResponse = ();
-
-    type GetResponse = ();
 
     type PostBody = aziot_tpm_common_http::sign_with_auth_key::Request;
-    type PostResponse = aziot_tpm_common_http::sign_with_auth_key::Response;
-    async fn post(self, body: Option<Self::PostBody>) -> RouteResponse<Option<Self::PostResponse>> {
+    async fn post(self, body: Option<Self::PostBody>) -> RouteResponse {
         let body = body.ok_or_else(|| http_common::server::Error {
             status_code: http::StatusCode::BAD_REQUEST,
             message: "missing request body".into(),
@@ -52,9 +48,9 @@ impl http_common::server::Route for Route {
         let res = aziot_tpm_common_http::sign_with_auth_key::Response {
             digest: http_common::ByteString(digest),
         };
-        Ok((hyper::StatusCode::OK, Some(res)))
+        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        Ok(res)
     }
 
     type PutBody = serde::de::IgnoredAny;
-    type PutResponse = ();
 }

--- a/tpm/aziot-tpmd/src/http/sign_with_auth_key.rs
+++ b/tpm/aziot-tpmd/src/http/sign_with_auth_key.rs
@@ -48,7 +48,7 @@ impl http_common::server::Route for Route {
         let res = aziot_tpm_common_http::sign_with_auth_key::Response {
             digest: http_common::ByteString(digest),
         };
-        let res = http_common::server::json_response(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
         Ok(res)
     }
 


### PR DESCRIPTION
Adds `mod response`, which provides various response types for the HTTP server. Previously, the server only supported JSON response types, but others (zip, chunked) will be needed as part of the edged refactor.