### PR TITLE
Add chunked server response

### DIFF
--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -10,7 +10,7 @@ base64 = "0.13"
 futures-util = "0.3"
 headers = { version = "0.3", optional = true }
 http = "0.2"
-hyper = { version = "0.14", features = ["client", "http1", "http2", "server", "tcp"], optional = true }
+hyper = { version = "0.14", features = ["client", "http1", "http2", "server", "stream", "tcp"], optional = true }
 hyper-openssl = { version = "0.9", optional = true }
 hyper-proxy = { version = "0.9", features = ["openssl-tls"], default-features = false, optional = true }
 libc = "0.2"

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -342,6 +342,22 @@ pub mod response {
         res
     }
 
+    pub fn chunked<S, O, E>(status_code: hyper::StatusCode, body: S) -> hyper::Response<hyper::Body>
+    where
+        S: futures_util::stream::Stream<Item = Result<O, E>> + Send + 'static,
+        O: Into<hyper::body::Bytes> + 'static,
+        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
+    {
+        let body = hyper::Body::wrap_stream(body);
+
+        let res = hyper::Response::builder()
+            .status(status_code)
+            .body(body);
+
+        let res = res.expect("cannot fail to build hyper response");
+        res
+    }
+
     pub fn json(
         status_code: hyper::StatusCode,
         body: &impl serde::Serialize,


### PR DESCRIPTION
Adds support for chunked text server responses. This is used by edged's module logs API