### PR TITLE
Add headers option to request_no_content

### DIFF
--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -29,7 +29,9 @@ pub use proxy::{get_proxy_uri, MaybeProxyConnector};
 #[cfg(feature = "tokio1")]
 mod request;
 #[cfg(feature = "tokio1")]
-pub use request::{request, request_no_content, request_with_headers};
+pub use request::{
+    request, request_no_content, request_with_headers, request_with_headers_no_content,
+};
 
 pub mod server;
 

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -29,7 +29,7 @@ pub use proxy::{get_proxy_uri, MaybeProxyConnector};
 #[cfg(feature = "tokio1")]
 mod request;
 #[cfg(feature = "tokio1")]
-pub use request::{request, request_no_content};
+pub use request::{request, request_no_content, request_with_headers};
 
 pub mod server;
 

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::str::FromStr;
+
 pub async fn request<TUri, THeader, TRequest, TResponse>(
     client: &hyper::Client<super::Connector, hyper::Body>,
     method: http::Method,
     uri: TUri,
-    headers: Option<&[(headers::HeaderName, THeader)]>,
+    headers: Option<&[(THeader, THeader)]>,
     body: Option<&TRequest>,
 ) -> std::io::Result<TResponse>
 where
@@ -16,13 +18,15 @@ where
     let mut req = hyper::Request::builder().method(method).uri(uri);
 
     if let Some(headers) = headers {
-        let headers_map = req.headers_mut().unwrap(); // .ok_or(std::io::Error::new(std::io::ErrorKind::Other))?;
-        for (key, value) in headers {
-            headers_map.insert(
-                key,
-                headers::HeaderValue::from_str(value.as_ref())
-                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
-            );
+        if let Some(headers_map) = req.headers_mut() {
+            for (key, value) in headers {
+                headers_map.insert(
+                    headers::HeaderName::from_str(key.as_ref())
+                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
+                    headers::HeaderValue::from_str(value.as_ref())
+                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
+                );
+            }
         }
     }
 

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -1,25 +1,26 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-pub async fn request<TUri, TRequest, TResponse>(
+pub async fn request<TUri, THeader, TRequest, TResponse>(
     client: &hyper::Client<super::Connector, hyper::Body>,
     method: http::Method,
     uri: TUri,
-    additional_headers: Option<&[(headers::HeaderName, &str)]>,
+    headers: Option<&[(headers::HeaderName, THeader)]>,
     body: Option<&TRequest>,
 ) -> std::io::Result<TResponse>
 where
     TUri: Into<hyper::Uri>,
+    THeader: AsRef<str>,
     TRequest: serde::Serialize,
     TResponse: serde::de::DeserializeOwned,
 {
     let mut req = hyper::Request::builder().method(method).uri(uri);
 
-    if let Some(additional_headers) = additional_headers {
-        let headers = req.headers_mut().unwrap(); // .ok_or(std::io::Error::new(std::io::ErrorKind::Other))?;
-        for (key, value) in additional_headers {
-            headers.insert(
+    if let Some(headers) = headers {
+        let headers_map = req.headers_mut().unwrap(); // .ok_or(std::io::Error::new(std::io::ErrorKind::Other))?;
+        for (key, value) in headers {
+            headers_map.insert(
                 key,
-                headers::HeaderValue::from_str(value)
+                headers::HeaderValue::from_str(value.as_ref())
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
             );
         }

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -13,20 +13,19 @@ where
     TRequest: serde::Serialize,
     TResponse: serde::de::DeserializeOwned,
 {
-    request_with_headers::<_, &str, _, _>(client, method, uri, None, body).await
+    request_with_headers(client, method, uri, None, body).await
 }
 
-pub async fn request_with_headers<TUri, THeader, TRequest, TResponse>(
+pub async fn request_with_headers<TUri, TRequest, TResponse>(
     client: &hyper::Client<super::Connector, hyper::Body>,
     method: http::Method,
     uri: TUri,
-    headers: Option<&[(THeader, THeader)]>,
+    headers: Option<&[(&str, &str)]>,
     body: Option<&TRequest>,
 ) -> std::io::Result<TResponse>
 where
     hyper::Uri: TryFrom<TUri>,
     <hyper::Uri as TryFrom<TUri>>::Error: Into<http::Error>,
-    THeader: AsRef<str>,
     TRequest: serde::Serialize,
     TResponse: serde::de::DeserializeOwned,
 {
@@ -36,9 +35,9 @@ where
         if let Some(headers_map) = req.headers_mut() {
             for (key, value) in headers {
                 headers_map.insert(
-                    headers::HeaderName::from_str(key.as_ref())
+                    headers::HeaderName::from_str(key)
                         .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
-                    headers::HeaderValue::from_str(value.as_ref())
+                    headers::HeaderValue::from_str(value)
                         .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
                 );
             }

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -29,6 +29,87 @@ where
     TRequest: serde::Serialize,
     TResponse: serde::de::DeserializeOwned,
 {
+    let (res_status_code, headers, body) = make_call(client, method, uri, headers, body).await?;
+    validate_json(headers)?;
+
+    match res_status_code {
+        hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
+            let res = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            Ok(res)
+        }
+
+        res_status_code
+            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
+        {
+            let res: super::ErrorBody<'static> = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
+        }
+
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "malformed HTTP response",
+        )),
+    }
+}
+
+pub async fn request_no_content<TRequest>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: &str,
+    body: Option<&TRequest>,
+) -> std::io::Result<()>
+where
+    TRequest: serde::Serialize,
+{
+    request_with_headers_no_content(client, method, uri, None, body).await
+}
+
+pub async fn request_with_headers_no_content<TRequest>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: &str,
+    headers: Option<&[(&str, &str)]>,
+    body: Option<&TRequest>,
+) -> std::io::Result<()>
+where
+    TRequest: serde::Serialize,
+{
+    let (res_status_code, headers, body) = make_call(client, method, uri, headers, body).await?;
+
+    match res_status_code {
+        hyper::StatusCode::NO_CONTENT => Ok(()),
+
+        res_status_code
+            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
+        {
+            validate_json(headers)?;
+
+            let res: super::ErrorBody<'static> = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
+        }
+
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "malformed HTTP response",
+        )),
+    }
+}
+
+async fn make_call<TUri, TRequest>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: TUri,
+    headers: Option<&[(&str, &str)]>,
+    body: Option<&TRequest>,
+) -> std::io::Result<(hyper::StatusCode, hyper::HeaderMap, hyper::body::Bytes)>
+where
+    hyper::Uri: TryFrom<TUri>,
+    <hyper::Uri as TryFrom<TUri>>::Error: Into<http::Error>,
+    TRequest: serde::Serialize,
+{
     let mut req = hyper::Request::builder().method(method).uri(uri);
 
     if let Some(headers) = headers {
@@ -60,144 +141,39 @@ where
     };
     let req = req.expect("cannot fail to create hyper request");
 
-    let res = client
+    let response = client
         .request(req)
         .await
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
 
     let (
         http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
+            status, headers, ..
         },
         body,
-    ) = res.into_parts();
+    ) = response.into_parts();
 
-    let mut is_json = false;
+    let body = hyper::body::to_bytes(body)
+        .await
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+    Ok((status, headers, body))
+}
+
+fn validate_json(headers: hyper::HeaderMap) -> std::io::Result<()> {
     for (header_name, header_value) in headers {
         if header_name == Some(hyper::header::CONTENT_TYPE) {
             let value = header_value
                 .to_str()
                 .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
             if value == "application/json" {
-                is_json = true;
+                return Ok(());
             }
         }
     }
 
-    if !is_json {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "malformed HTTP response",
-        ));
-    }
-
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let res: TResponse = match res_status_code {
-        hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
-            let res = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            res
-        }
-
-        res_status_code
-            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-        {
-            let res: super::ErrorBody<'static> = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
-        }
-
-        _ => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "malformed HTTP response",
-            ))
-        }
-    };
-    Ok(res)
-}
-
-pub async fn request_no_content<TRequest>(
-    client: &hyper::Client<super::Connector, hyper::Body>,
-    method: http::Method,
-    uri: &str,
-    body: Option<&TRequest>,
-) -> std::io::Result<()>
-where
-    TRequest: serde::Serialize,
-{
-    let req = hyper::Request::builder().method(method).uri(uri);
-    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let req = if let Some(body) = body {
-        let body = serde_json::to_vec(body)
-            .expect("serializing request body to JSON cannot fail")
-            .into();
-        req.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        req.body(Default::default())
-    };
-    let req = req.expect("cannot fail to create hyper request");
-
-    let res = client
-        .request(req)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let (
-        http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
-        },
-        body,
-    ) = res.into_parts();
-
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    match res_status_code {
-        hyper::StatusCode::NO_CONTENT => Ok(()),
-
-        res_status_code
-            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-        {
-            let mut is_json = false;
-            for (header_name, header_value) in headers {
-                if header_name == Some(hyper::header::CONTENT_TYPE) {
-                    let value = header_value
-                        .to_str()
-                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                    if value == "application/json" {
-                        is_json = true;
-                    }
-                }
-            }
-
-            if !is_json {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "malformed HTTP response",
-                ));
-            }
-
-            let res: super::ErrorBody<'static> = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
-        }
-
-        _ => Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "malformed HTTP response",
-        )),
-    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "malformed HTTP response, expected content type application/json",
+    ))
 }

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -66,14 +66,16 @@ where
     request_with_headers_no_content(client, method, uri, None, body).await
 }
 
-pub async fn request_with_headers_no_content<TRequest>(
+pub async fn request_with_headers_no_content<TUri, TRequest>(
     client: &hyper::Client<super::Connector, hyper::Body>,
     method: http::Method,
-    uri: &str,
+    uri: TUri,
     headers: Option<&[(&str, &str)]>,
     body: Option<&TRequest>,
 ) -> std::io::Result<()>
 where
+    hyper::Uri: TryFrom<TUri>,
+    <hyper::Uri as TryFrom<TUri>>::Error: Into<http::Error>,
     TRequest: serde::Serialize,
 {
     let (res_status_code, headers, body) = make_call(client, method, uri, headers, body).await?;

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-pub async fn request<TRequest, TResponse>(
+pub async fn request<TUri, TRequest, TResponse>(
     client: &hyper::Client<super::Connector, hyper::Body>,
     method: http::Method,
-    uri: &str,
+    uri: TUri,
     body: Option<&TRequest>,
 ) -> std::io::Result<TResponse>
 where
+    TUri: Into<hyper::Uri>,
     TRequest: serde::Serialize,
     TResponse: serde::de::DeserializeOwned,
 {

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -155,6 +155,11 @@ where
         body,
     ) = response.into_parts();
 
+    println!(
+        "Status: {:#?}\nHeaders: {:#?}\nBody: {:#?}",
+        status, headers, body
+    );
+
     let body = hyper::body::to_bytes(body)
         .await
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -113,6 +113,7 @@ where
     TRequest: serde::Serialize,
 {
     let mut req = hyper::Request::builder().method(method).uri(uri);
+    println!("Uri: {:#?}", req.uri_ref());
 
     if let Some(headers) = headers {
         if let Some(headers_map) = req.headers_mut() {

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -33,7 +33,7 @@ where
     validate_json(headers)?;
 
     match res_status_code {
-        hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
+        res_status_code if res_status_code.is_success() => {
             let res = serde_json::from_slice(&body)
                 .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
             Ok(res)
@@ -81,7 +81,7 @@ where
     let (res_status_code, headers, body) = make_call(client, method, uri, headers, body).await?;
 
     match res_status_code {
-        hyper::StatusCode::NO_CONTENT |  hyper::StatusCode::OK | hyper::StatusCode::CREATED => Ok(()),
+        res_status_code if res_status_code.is_success() => Ok(()),
 
         res_status_code
             if res_status_code.is_client_error() || res_status_code.is_server_error() =>
@@ -113,7 +113,6 @@ where
     TRequest: serde::Serialize,
 {
     let mut req = hyper::Request::builder().method(method).uri(uri);
-    println!("Uri: {:#?}", req.uri_ref());
 
     if let Some(headers) = headers {
         if let Some(headers_map) = req.headers_mut() {
@@ -155,11 +154,6 @@ where
         },
         body,
     ) = response.into_parts();
-
-    println!(
-        "Status: {:#?}\nHeaders: {:#?}\nBody: {:#?}",
-        status, headers, body
-    );
 
     let body = hyper::body::to_bytes(body)
         .await

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -81,7 +81,7 @@ where
     let (res_status_code, headers, body) = make_call(client, method, uri, headers, body).await?;
 
     match res_status_code {
-        hyper::StatusCode::NO_CONTENT => Ok(()),
+        hyper::StatusCode::NO_CONTENT |  hyper::StatusCode::OK | hyper::StatusCode::CREATED => Ok(()),
 
         res_status_code
             if res_status_code.is_client_error() || res_status_code.is_server_error() =>


### PR DESCRIPTION
This pr adds a headers function for request_no_content. It also slightly changes the behavior or request_no_content, allowing responses other than 204 to return Ok. This is because sometimes when docker-rs calls the no_content function, the http response has content, we just don't care about the content and want to drop it. 

This pr also pulls the shared code of both request functions in to shared functions to reduce copied code and make them easier to read.