### PR TITLE
Treat 304 NOT MODIFIED as success for request_no_content

### DIFF
--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -81,7 +81,12 @@ where
     let (res_status_code, headers, body) = make_call(client, method, uri, headers, body).await?;
 
     match res_status_code {
-        res_status_code if res_status_code.is_success() => Ok(()),
+        res_status_code
+            if res_status_code.is_success()
+                || res_status_code == hyper::StatusCode::NOT_MODIFIED =>
+        {
+            Ok(())
+        }
 
         res_status_code
             if res_status_code.is_client_error() || res_status_code.is_server_error() =>


### PR DESCRIPTION
This function is used by edged to call Docker's DELETE or STOP API. Docker may return 304 NOT MODIFIED when trying to delete or stop a module that is already in the requested state. Treat this status code as success.