### PR TITLE
Don't require content-type: application/json in server

### DIFF
--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -98,33 +98,33 @@ macro_rules! make_service {
                                         http::Method::DELETE => {
                                             let body = {
                                                 let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
-                                                if content_type.as_deref() == Some("application/json") {
-                                                    let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
-                                                        Ok(result) => match result {
+                                                match content_type.as_deref() {
+                                                    Some("application/json") | None => {
+                                                        let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
+                                                            Ok(result) => match result {
+                                                                Ok(body) => body,
+                                                                Err(err) => return Ok((http_common::server::Error {
+                                                                    status_code: http::StatusCode::BAD_REQUEST,
+                                                                    message: http_common::server::error_to_message(&err).into(),
+                                                                }).to_http_response()),
+                                                            },
+                                                            Err(timeout_err) => return Ok((http_common::server::Error {
+                                                                status_code: http::StatusCode::REQUEST_TIMEOUT,
+                                                                message: http_common::server::error_to_message(&timeout_err).into(),
+                                                            }).to_http_response()),
+                                                        };
+
+                                                        let body: <$route as http_common::server::Route>::DeleteBody = match serde_json::from_slice(&body) {
                                                             Ok(body) => body,
                                                             Err(err) => return Ok((http_common::server::Error {
-                                                                status_code: http::StatusCode::BAD_REQUEST,
+                                                                status_code: http::StatusCode::UNPROCESSABLE_ENTITY,
                                                                 message: http_common::server::error_to_message(&err).into(),
                                                             }).to_http_response()),
-                                                        },
-                                                        Err(timeout_err) => return Ok((http_common::server::Error {
-                                                            status_code: http::StatusCode::REQUEST_TIMEOUT,
-                                                            message: http_common::server::error_to_message(&timeout_err).into(),
-                                                        }).to_http_response()),
-                                                    };
+                                                        };
 
-                                                    let body: <$route as http_common::server::Route>::DeleteBody = match serde_json::from_slice(&body) {
-                                                        Ok(body) => body,
-                                                        Err(err) => return Ok((http_common::server::Error {
-                                                            status_code: http::StatusCode::UNPROCESSABLE_ENTITY,
-                                                            message: http_common::server::error_to_message(&err).into(),
-                                                        }).to_http_response()),
-                                                    };
-
-                                                    Some(body)
-                                                }
-                                                else {
-                                                    None
+                                                        Some(body)
+                                                    },
+                                                    _ => None,
                                                 }
                                             };
 
@@ -144,33 +144,33 @@ macro_rules! make_service {
                                         http::Method::POST => {
                                             let body = {
                                                 let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
-                                                if content_type.as_deref() == Some("application/json") {
-                                                    let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
-                                                        Ok(result) => match result {
+                                                match content_type.as_deref() {
+                                                    Some("application/json") | None => {
+                                                        let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
+                                                            Ok(result) => match result {
+                                                                Ok(body) => body,
+                                                                Err(err) => return Ok((http_common::server::Error {
+                                                                    status_code: http::StatusCode::BAD_REQUEST,
+                                                                    message: http_common::server::error_to_message(&err).into(),
+                                                                }).to_http_response()),
+                                                            },
+                                                            Err(timeout_err) => return Ok((http_common::server::Error {
+                                                                status_code: http::StatusCode::REQUEST_TIMEOUT,
+                                                                message: http_common::server::error_to_message(&timeout_err).into(),
+                                                            }).to_http_response()),
+                                                        };
+
+                                                        let body: <$route as http_common::server::Route>::PostBody = match serde_json::from_slice(&body) {
                                                             Ok(body) => body,
                                                             Err(err) => return Ok((http_common::server::Error {
-                                                                status_code: http::StatusCode::BAD_REQUEST,
+                                                                status_code: http::StatusCode::UNPROCESSABLE_ENTITY,
                                                                 message: http_common::server::error_to_message(&err).into(),
                                                             }).to_http_response()),
-                                                        },
-                                                        Err(timeout_err) => return Ok((http_common::server::Error {
-                                                            status_code: http::StatusCode::REQUEST_TIMEOUT,
-                                                            message: http_common::server::error_to_message(&timeout_err).into(),
-                                                        }).to_http_response()),
-                                                    };
+                                                        };
 
-                                                    let body: <$route as http_common::server::Route>::PostBody = match serde_json::from_slice(&body) {
-                                                        Ok(body) => body,
-                                                        Err(err) => return Ok((http_common::server::Error {
-                                                            status_code: http::StatusCode::UNPROCESSABLE_ENTITY,
-                                                            message: http_common::server::error_to_message(&err).into(),
-                                                        }).to_http_response()),
-                                                    };
-
-                                                    Some(body)
-                                                }
-                                                else {
-                                                    None
+                                                        Some(body)
+                                                    },
+                                                    _ => None,
                                                 }
                                             };
 
@@ -182,7 +182,7 @@ macro_rules! make_service {
 
                                         http::Method::PUT => {
                                             let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
-                                            if content_type.as_deref() != Some("application/json") {
+                                            if content_type.as_deref() != Some("application/json") && content_type.as_deref() != None {
                                                 return Ok((http_common::server::Error {
                                                     status_code: http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
                                                     message: "request body must be application/json".into(),


### PR DESCRIPTION
While we *should* require JSON requests to specify the correct content type, this requirement wasn't present in pre-tokio-refactor edged. Certain versions of edgeHub don't set the content-type header in their request and crash when this server rejects edgeHub's request.