### PR TITLE
Expand build targets to Debian 11 and RHEL 8

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -22,6 +22,8 @@ jobs:
         - 'centos:7'
         - 'debian:9'
         - 'debian:10'
+        - 'debian:11'
+        - 'platform:el8'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         test_name:

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -27,6 +27,8 @@ jobs:
         - 'centos:7'
         - 'debian:9'
         - 'debian:10'
+        - 'debian:11'
+        - 'platform:el8'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         test_name:

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -16,6 +16,8 @@ jobs:
         - 'centos:7'
         - 'debian:9-slim'
         - 'debian:10-slim'
+        - 'debian:11-slim'
+        - 'redhat/ub8:latest'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         arch:
@@ -28,6 +30,11 @@ jobs:
         - container_os: 'centos:7'
           arch: 'arm32v7'
         - container_os: 'centos:7'
+          arch: 'aarch64'
+        # More investigation needed for RHEL 8. Excluding for now.
+        - container_os: 'redhat/ub8:latest'
+          arch: 'arm32v7'
+        - container_os: 'redhat/ub8:latest'
           arch: 'aarch64'
 
     steps:

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -17,7 +17,7 @@ jobs:
         - 'debian:9-slim'
         - 'debian:10-slim'
         - 'debian:11-slim'
-        - 'redhat/ub8:latest'
+        - 'redhat/ubi8:latest'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         arch:
@@ -32,9 +32,9 @@ jobs:
         - container_os: 'centos:7'
           arch: 'aarch64'
         # More investigation needed for RHEL 8. Excluding for now.
-        - container_os: 'redhat/ub8:latest'
+        - container_os: 'redhat/ubi8:latest'
           arch: 'arm32v7'
-        - container_os: 'redhat/ub8:latest'
+        - container_os: 'redhat/ubi8:latest'
           arch: 'aarch64'
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
         - 'debian:9-slim'
         - 'debian:10-slim'
         - 'debian:11-slim'
-        - 'redhat/ub8:latest'
+        - 'redhat/ubi8:latest'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         arch:
@@ -73,7 +73,7 @@ jobs:
         - 'debian:9-slim'
         - 'debian:10-slim'
         - 'debian:11-slim'
-        - 'redhat/ub8:latest'
+        - 'redhat/ubi8:latest'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         pkcs11_backend:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,8 @@ jobs:
         - 'centos:7'
         - 'debian:9-slim'
         - 'debian:10-slim'
+        - 'debian:11-slim'
+        - 'redhat/ub8:latest'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         arch:
@@ -70,6 +72,8 @@ jobs:
         - 'centos:7'
         - 'debian:9-slim'
         - 'debian:10-slim'
+        - 'debian:11-slim'
+        - 'redhat/ub8:latest'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         pkcs11_backend:

--- a/Makefile
+++ b/Makefile
@@ -267,12 +267,10 @@ rpm:
 
 	# Copy spec file to rpmbuild specs directory
 	mkdir -p $(RPMBUILDDIR)/SPECS
-	sed -e 's/@version@/$(PACKAGE_VERSION)/g; s/@release@/$(PACKAGE_RELEASE)/g' contrib/centos/aziot-identity-service.spec >$(RPMBUILDDIR)/SPECS/aziot-identity-service.spec
-
-	which openssl # Assert that openssl exists and the empty output of `openssl version -e` is not because it never even ran
-	ENGINESDIR="$$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/' | sed 's/\//\\\//g')"; \
-	ENGINESDIR="$${ENGINESDIR:-$(libdir)/openssl/engines}"; \
-	sed -ie "s/@enginesdir@/$$ENGINESDIR/g" $(RPMBUILDDIR)/SPECS/aziot-identity-service.spec
+	ENGINESDIR='/usr/lib64/openssl/engines'; \
+	ENGINESDIR=$$(if [ ! -d $$ENGINESDIR ]; then echo $$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/'); else echo $$ENGINESDIR; fi); \
+    ENGINESDIR="$$(echo $$ENGINESDIR | sed -e 's/\//\\\//g')"; \
+	sed -e "s/@version@/$(PACKAGE_VERSION)/g; s/@release@/$(PACKAGE_RELEASE)/g; s/@enginesdir@/$$ENGINESDIR/g" contrib/centos/aziot-identity-service.spec >$(RPMBUILDDIR)/SPECS/aziot-identity-service.spec
 
 	# Copy preset file to be included in the package
 	cp contrib/centos/00-aziot.preset $(RPMBUILDDIR)/SOURCES

--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,11 @@ rpm:
 	mkdir -p $(RPMBUILDDIR)/SPECS
 	sed -e 's/@version@/$(PACKAGE_VERSION)/g; s/@release@/$(PACKAGE_RELEASE)/g' contrib/centos/aziot-identity-service.spec >$(RPMBUILDDIR)/SPECS/aziot-identity-service.spec
 
+	which openssl # Assert that openssl exists and the empty output of `openssl version -e` is not because it never even ran
+	ENGINESDIR="$$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/' | sed 's/\//\\\//g')"; \
+	ENGINESDIR="$${ENGINESDIR:-$(libdir)/openssl/engines}"; \
+	sed -ie "s/@enginesdir@/$$ENGINESDIR/g" $(RPMBUILDDIR)/SPECS/aziot-identity-service.spec
+
 	# Copy preset file to be included in the package
 	cp contrib/centos/00-aziot.preset $(RPMBUILDDIR)/SOURCES
 

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ rpm:
 	mkdir -p $(RPMBUILDDIR)/SPECS
 	ENGINESDIR='/usr/lib64/openssl/engines'; \
 	ENGINESDIR=$$(if [ ! -d $$ENGINESDIR ]; then echo $$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/'); else echo $$ENGINESDIR; fi); \
-    ENGINESDIR="$$(echo $$ENGINESDIR | sed -e 's/\//\\\//g')"; \
+	ENGINESDIR="$$(echo $$ENGINESDIR | sed -e 's/\//\\\//g')"; \
 	sed -e "s/@version@/$(PACKAGE_VERSION)/g; s/@release@/$(PACKAGE_RELEASE)/g; s/@enginesdir@/$$ENGINESDIR/g" contrib/centos/aziot-identity-service.spec >$(RPMBUILDDIR)/SPECS/aziot-identity-service.spec
 
 	# Copy preset file to be included in the package

--- a/Makefile
+++ b/Makefile
@@ -267,10 +267,12 @@ rpm:
 
 	# Copy spec file to rpmbuild specs directory
 	mkdir -p $(RPMBUILDDIR)/SPECS
-	ENGINESDIR='/usr/lib64/openssl/engines'; \
-	ENGINESDIR=$$(if [ ! -d $$ENGINESDIR ]; then echo $$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/'); else echo $$ENGINESDIR; fi); \
-	ENGINESDIR="$$(echo $$ENGINESDIR | sed -e 's/\//\\\//g')"; \
-	sed -e "s/@version@/$(PACKAGE_VERSION)/g; s/@release@/$(PACKAGE_RELEASE)/g; s/@enginesdir@/$$ENGINESDIR/g" contrib/centos/aziot-identity-service.spec >$(RPMBUILDDIR)/SPECS/aziot-identity-service.spec
+
+	# Ask openssl for its engine dir and on versions <1.1 fallback to a hardcoded path.
+	which openssl # Assert that openssl exists and that the empty output of `openssl version -e` is not because it never even ran
+	ENGINESDIR="$$(openssl version -e 2> /dev/null | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/')"; \
+	ENGINESDIR="$${ENGINESDIR:-%\{_libdir\}/openssl/engines}"; \
+	sed -e "s/@version@/$(PACKAGE_VERSION)/g; s/@release@/$(PACKAGE_RELEASE)/g; s|@enginesdir@|$$ENGINESDIR|g" contrib/centos/aziot-identity-service.spec >$(RPMBUILDDIR)/SPECS/aziot-identity-service.spec
 
 	# Copy preset file to be included in the package
 	cp contrib/centos/00-aziot.preset $(RPMBUILDDIR)/SOURCES

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -60,10 +60,6 @@ get_package() {
             artifact_name='centos-7'
             ;;
 
-        'platform:el8')
-            artifact_name='el-8'
-            ;;
-
         'debian:9')
             artifact_name='debian-9-slim'
             ;;
@@ -74,6 +70,10 @@ get_package() {
 
         'debian:11')
             artifact_name='debian-11-slim'
+            ;;
+
+        'platform:el8')
+            artifact_name='el-8'
             ;;
 
         'ubuntu:18.04')
@@ -121,12 +121,7 @@ get_package() {
             printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
             ;;
 
-        'platform:el8')
-            unzip -j package.zip 'el8/amd64/aziot-identity-service-*.x86_64.rpm' -x '*-debuginfo-*.rpm' '*-devel-*.rpm' >&2
-            printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
-            ;;
-
-         'debian:9')
+        'debian:9')
             unzip -j package.zip 'debian9/amd64/aziot-identity-service_*_amd64.deb' >&2
             printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
             ;;
@@ -139,6 +134,11 @@ get_package() {
         'debian:11')
             unzip -j package.zip 'debian11/amd64/aziot-identity-service_*_amd64.deb' >&2
             printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
+            ;;
+
+        'platform:el8')
+            unzip -j package.zip 'el8/amd64/aziot-identity-service-*.x86_64.rpm' -x '*-debuginfo-*.rpm' '*-devel-*.rpm' >&2
+            printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
             ;;
 
         'ubuntu:18.04')
@@ -236,14 +236,7 @@ case "$OS" in
         vm_image='OpenLogic:CentOS:7_8-gen2:7.8.2020100701'
         ;;
 
-    'platform:el8')
-        # az vm image list --all \
-        #     --publisher 'almalinux' --offer 'almalinux' --sku '8_4-gen2' \
-        #     --query "[?publisher == 'almalinux' && offer == 'almalinux'].{ sku: sku, version: version }" --output table
-        vm_image='almalinux:almalinux:8_4-gen2:8.4.20210729'
-        ;;
-
-     'debian:9')
+    'debian:9')
         # az vm image list --all \
         #     --publisher 'credativ' --offer 'Debian' --sku '9' \
         #     --query "[?publisher == 'credativ' && offer == 'Debian'].{ sku: sku, version: version }" --output table
@@ -266,7 +259,14 @@ case "$OS" in
         vm_image='Debian:debian-11:11-gen2:0.20210814.734'
         ;;
 
-     'ubuntu:18.04')
+    'platform:el8')
+        # az vm image list --all \
+        #     --publisher 'almalinux' --offer 'almalinux' --sku '8_4-gen2' \
+        #     --query "[?publisher == 'almalinux' && offer == 'almalinux'].{ sku: sku, version: version }" --output table
+        vm_image='almalinux:almalinux:8_4-gen2:8.4.20210729'
+        ;;
+
+    'ubuntu:18.04')
         # az vm image list --all \
         #     --publisher 'Canonical' --offer 'UbuntuServer' --sku '18' \
         #     --query "[?publisher == 'Canonical' && offer == 'UbuntuServer'].{ sku: sku, version: version }" --output table

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -4,7 +4,7 @@
 #
 # e2e-tests.sh <test_name>
 #
-# See https://azure.github.io/iot-identity-service/dev/e2e-tests.html for details of some env vars that need to be defined.
+# See https://github.com/Azure/iot-identity-service/blob/main/docs-dev/e2e-tests.md for details of some env vars that need to be defined.
 #
 # <test_name>:
 #     manual-symmetric-key

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -784,7 +784,7 @@ fi
 
 echo 'Updating VM...' >&2
 case "$OS" in
-    centos:*|platform:el8:*)
+    centos:*)
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
             set -euxo pipefail
 
@@ -803,6 +803,18 @@ case "$OS" in
             sudo apt-get upgrade -y
         '
         ;;
+
+    platform:el*)
+        ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
+            set -euxo pipefail
+
+            sudo yum -y update
+
+            # The get-twin tests need perl
+            sudo yum -y install perl
+        '
+        ;;
+
 
     *)
         echo "Unsupported OS $OS" >&2
@@ -837,7 +849,7 @@ fi
 
 echo 'Installing package...' >&2
 case "$OS" in
-    centos:*|platform:el8:*)
+    centos:*|platform:el*)
         scp -i "$PWD/vm-ssh-key" "$package" "aziot@$vm_public_ip:/home/aziot/aziot-identity-service.rpm"
 
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '

--- a/ci/e2e-tests.sh
+++ b/ci/e2e-tests.sh
@@ -60,12 +60,20 @@ get_package() {
             artifact_name='centos-7'
             ;;
 
+        'platform:el8')
+            artifact_name='el-8'
+            ;;
+
         'debian:9')
             artifact_name='debian-9-slim'
             ;;
 
         'debian:10')
             artifact_name='debian-10-slim'
+            ;;
+
+        'debian:11')
+            artifact_name='debian-11-slim'
             ;;
 
         'ubuntu:18.04')
@@ -113,13 +121,23 @@ get_package() {
             printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
             ;;
 
-        'debian:9')
+        'platform:el8')
+            unzip -j package.zip 'el8/amd64/aziot-identity-service-*.x86_64.rpm' -x '*-debuginfo-*.rpm' '*-devel-*.rpm' >&2
+            printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
+            ;;
+
+         'debian:9')
             unzip -j package.zip 'debian9/amd64/aziot-identity-service_*_amd64.deb' >&2
             printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
             ;;
 
         'debian:10')
             unzip -j package.zip 'debian10/amd64/aziot-identity-service_*_amd64.deb' >&2
+            printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
+            ;;
+
+        'debian:11')
+            unzip -j package.zip 'debian11/amd64/aziot-identity-service_*_amd64.deb' >&2
             printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
             ;;
 
@@ -218,7 +236,14 @@ case "$OS" in
         vm_image='OpenLogic:CentOS:7_8-gen2:7.8.2020100701'
         ;;
 
-    'debian:9')
+    'platform:el8')
+        # az vm image list --all \
+        #     --publisher 'almalinux' --offer 'almalinux' --sku '8_4-gen2' \
+        #     --query "[?publisher == 'almalinux' && offer == 'almalinux'].{ sku: sku, version: version }" --output table
+        vm_image='almalinux:almalinux:8_4-gen2:8.4.20210729'
+        ;;
+
+     'debian:9')
         # az vm image list --all \
         #     --publisher 'credativ' --offer 'Debian' --sku '9' \
         #     --query "[?publisher == 'credativ' && offer == 'Debian'].{ sku: sku, version: version }" --output table
@@ -234,7 +259,14 @@ case "$OS" in
         vm_image='Debian:debian-10:10-gen2:0.20201023.432'
         ;;
 
-    'ubuntu:18.04')
+    'debian:11')
+        # az vm image list --all \
+        #     --publisher 'Debian' --offer 'debian-11' --sku '11-gen2' \
+        #     --query "[?publisher == 'Debian' && offer == 'debian-11'].{ sku: sku, version: version }" --output table
+        vm_image='Debian:debian-11:11-gen2:0.20210814.734'
+        ;;
+
+     'ubuntu:18.04')
         # az vm image list --all \
         #     --publisher 'Canonical' --offer 'UbuntuServer' --sku '18' \
         #     --query "[?publisher == 'Canonical' && offer == 'UbuntuServer'].{ sku: sku, version: version }" --output table
@@ -752,7 +784,7 @@ fi
 
 echo 'Updating VM...' >&2
 case "$OS" in
-    centos:*)
+    centos:*|platform:el8:*)
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
             set -euxo pipefail
 
@@ -805,7 +837,7 @@ fi
 
 echo 'Installing package...' >&2
 case "$OS" in
-    centos:*)
+    centos:*|platform:el8:*)
         scp -i "$PWD/vm-ssh-key" "$package" "aziot@$vm_public_ip:/home/aziot/aziot-identity-service.rpm"
 
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -14,7 +14,7 @@ case "$OS:$ARCH" in
         yum install -y epel-release
         yum install -y \
             curl gcc gcc-c++ git jq make pkgconfig cmake \
-            clang llvm-devel openssl-devel
+            clang llvm-devel openssl-devel which openssl
         ;;
 
     'centos:7:arm32v7'|'centos:7:aarch64')

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -5,19 +5,19 @@
 # WARNING: This script is destructive to your machine's environment and globally-installed files. For example, the Ubuntu-specific parts of the script
 # modify the contents of /etc/apt. The script is intended to be run inside a container of the corresponding OS, not directly on your machine.
 
-OS="$(. /etc/os-release; if [ -z ${PLATFORM_ID+x} ]; then echo "$ID:$VERSION_ID"; else echo "$PLATFORM_ID"; fi)"
+OS="$(. /etc/os-release; echo "${PLATFORM_ID:-$ID:$VERSION_ID}")"
 
 # OS packages
 
 case "$OS:$ARCH" in
-    'centos:7:amd64'|'platform:el8:amd64')
+    'centos:7:amd64')
         yum install -y epel-release
         yum install -y \
             curl gcc gcc-c++ git jq make pkgconfig cmake \
             clang llvm-devel openssl-devel
         ;;
 
-    'centos:7:arm32v7'|'centos:7:aarch64'|'platform:el8:arm32v7'|'platform:el8:aarch64')
+    'centos:7:arm32v7'|'centos:7:aarch64')
         echo "Cross-compilation on $OS $ARCH is not supported" >&2
         exit 1
         ;;
@@ -56,6 +56,18 @@ case "$OS:$ARCH" in
             ca-certificates curl gcc g++ gcc-aarch64-linux-gnu g++-aarch64-linux-gnu git jq make pkg-config cmake \
             libc-dev libc-dev:arm64 libclang1 libssl-dev:arm64 llvm-dev
         ;;
+
+    'platform:el8:amd64')
+        yum install -y \
+            curl gcc gcc-c++ git jq make pkgconfig cmake \
+            clang llvm-devel openssl-devel
+        ;;
+
+    'platform:el8:aarch64'|'platform:el8:arm32v7')
+        echo "Cross-compilation on $OS $ARCH is not supported" >&2
+        exit 1
+        ;;
+
 
     'ubuntu:18.04:arm32v7'|'ubuntu:20.04:arm32v7')
         export DEBIAN_FRONTEND=noninteractive

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -5,26 +5,24 @@
 # WARNING: This script is destructive to your machine's environment and globally-installed files. For example, the Ubuntu-specific parts of the script
 # modify the contents of /etc/apt. The script is intended to be run inside a container of the corresponding OS, not directly on your machine.
 
-
-OS="$(. /etc/os-release; echo "$ID:$VERSION_ID")"
-
+OS="$(. /etc/os-release; if [ -z "$PLATFORM_ID" ]; then echo "$ID:$VERSION_ID"; else echo "$PLATFORM_ID"; fi)"
 
 # OS packages
 
 case "$OS:$ARCH" in
-    'centos:7:amd64')
+    'centos:7:amd64'|'platform:el8:amd64')
         yum install -y epel-release
         yum install -y \
             curl gcc gcc-c++ git jq make pkgconfig cmake \
             clang llvm-devel openssl-devel
         ;;
 
-    'centos:7:arm32v7'|'centos:7:aarch64')
-        echo 'Cross-compilation on CentOS 7 is not supported' >&2
+    'centos:7:arm32v7'|'centos:7:aarch64'|'platform:el8:arm32v7'|'platform:el8:aarch64')
+        echo "Cross-compilation on $OS $ARCH is not supported" >&2
         exit 1
         ;;
 
-    'debian:9:amd64'|'debian:10:amd64'|'ubuntu:18.04:amd64'|'ubuntu:20.04:amd64')
+    'debian:9:amd64'|'debian:10:amd64'|'debian:11:amd64'|'ubuntu:18.04:amd64'|'ubuntu:20.04:amd64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 
@@ -35,7 +33,7 @@ case "$OS:$ARCH" in
             libclang1 libssl-dev llvm-dev
         ;;
 
-    'debian:9:arm32v7'|'debian:10:arm32v7')
+    'debian:9:arm32v7'|'debian:10:arm32v7'|'debian:11:arm32v7')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 
@@ -47,7 +45,7 @@ case "$OS:$ARCH" in
             libc-dev libc-dev:armhf libclang1 libssl-dev:armhf llvm-dev
         ;;
 
-    'debian:9:aarch64'|'debian:10:aarch64')
+    'debian:9:aarch64'|'debian:10:aarch64'|'debian:11:aarch64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 

--- a/ci/install-runtime-deps.sh
+++ b/ci/install-runtime-deps.sh
@@ -3,14 +3,20 @@
 # This script is meant to be sourced.
 
 
-OS="$(. /etc/os-release; echo "$ID:$VERSION_ID")"
-
+OS="$(. /etc/os-release; echo "${PLATFORM_ID:-$ID:$VERSION_ID}")"
 
 case "$OS" in
-    'centos:7')
+    'centos:7'|'platform:el8')
         # openssl 1.0
 
-        yum install -y epel-release
+        if [ "$OS" = 'platform:el8' ] && [ "$(. /etc/os-release; echo "$ID")" = 'rhel' ]; then
+            # If using RHEL 8 UBI images without a subscription then they only have access to a 
+            # subset of packages. Workaround to enable EPEL.
+            yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+        else
+            yum install -y epel-release
+        fi
+
         yum install -y curl jq openssl
 
         case "${PKCS11_BACKEND:-}" in
@@ -32,7 +38,7 @@ case "$OS" in
         esac
         ;;
 
-    'debian:9'|'debian:10'|'ubuntu:18.04'|'ubuntu:20.04')
+    'debian:9'|'debian:10'|'debian:11'|'ubuntu:18.04'|'ubuntu:20.04')
         # openssl 1.1.0 for Debian 9, 1.1.1 for the others
 
         apt-get update -y

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -46,7 +46,7 @@ case "$OS" in
         ;;
 
     'debian:9'|'debian:10'|'debian:11'|'ubuntu:18.04'|'ubuntu:20.04')
-        DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y dh-make dh-systemd
+        DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y dh-make debhelper
 
         make ARCH="$ARCH" PACKAGE_VERSION="$PACKAGE_VERSION" PACKAGE_RELEASE="$PACKAGE_RELEASE" V=1 deb
 

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -11,11 +11,21 @@ mkdir -p packages
 
 
 case "$OS" in
-    'centos:7')
+    'centos:7'|'platform:el8')
         case "$ARCH" in
             'arm32v7'|'aarch64')
-                echo 'Cross-compilation on CentOS 7 is not supported' >&2
+                echo "Cross-compilation on $OS is not supported" >&2
                 exit 1
+                ;;
+        esac
+
+        case "$OS" in
+            'centos:7')
+                TARGET_DIR="centos7/$ARCH"
+                ;;
+
+            'platform:el8')
+                TARGET_DIR="el8/$ARCH"
                 ;;
         esac
 
@@ -25,17 +35,17 @@ case "$OS" in
 
         make ARCH="$ARCH" PACKAGE_VERSION="$PACKAGE_VERSION" PACKAGE_RELEASE="$PACKAGE_RELEASE" V=1 rpm
 
-        rm -rf "packages/centos7/$ARCH"
-        mkdir -p "packages/centos7/$ARCH"
+        rm -rf "packages/$TARGET_DIR"
+        mkdir -p "packages/$TARGET_DIR"
         cp \
             ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.x86_64.rpm" \
             ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-debuginfo-$PACKAGE_VERSION-$PACKAGE_RELEASE.x86_64.rpm" \
             ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-devel-$PACKAGE_VERSION-$PACKAGE_RELEASE.x86_64.rpm" \
             ~/"rpmbuild/SRPMS/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.src.rpm" \
-            "packages/centos7/$ARCH/"
+            "packages/$TARGET_DIR/"
         ;;
 
-    'debian:9'|'debian:10'|'ubuntu:18.04'|'ubuntu:20.04')
+    'debian:9'|'debian:10'|'debian:11'|'ubuntu:18.04'|'ubuntu:20.04')
         DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y dh-make dh-systemd
 
         make ARCH="$ARCH" PACKAGE_VERSION="$PACKAGE_VERSION" PACKAGE_RELEASE="$PACKAGE_RELEASE" V=1 deb
@@ -48,6 +58,11 @@ case "$OS" in
 
             'debian:10')
                 TARGET_DIR="debian10/$ARCH"
+                DBGSYM_EXT='deb'
+                ;;
+
+            'debian:11')
+                TARGET_DIR="debian11/$ARCH"
                 DBGSYM_EXT='deb'
                 ;;
 

--- a/ci/test-aziot-key-openssl-engine-shared.sh
+++ b/ci/test-aziot-key-openssl-engine-shared.sh
@@ -7,13 +7,13 @@ cd /src
 . ./ci/install-runtime-deps.sh
 
 case "$OS" in
-    'centos:7'|'platform:el8')
+    'centos:7')
         cp \
             ./target/debug/libaziot_key_openssl_engine_shared.so \
             /usr/lib64/openssl/engines/libaziot_keys.so
         ;;
 
-    'debian:9'|'debian:10'|'debian:11'|'ubuntu:18.04'|'ubuntu:20.04')
+    'debian:9'|'debian:10'|'debian:11'|'platform:el8'|'ubuntu:18.04'|'ubuntu:20.04')
         cp \
             ./target/debug/libaziot_key_openssl_engine_shared.so \
             "$(openssl version -e | sed -E 's/^ENGINESDIR: "(.*)"$/\1/')/aziot_keys.so"

--- a/ci/test-aziot-key-openssl-engine-shared.sh
+++ b/ci/test-aziot-key-openssl-engine-shared.sh
@@ -7,13 +7,13 @@ cd /src
 . ./ci/install-runtime-deps.sh
 
 case "$OS" in
-    'centos:7')
+    'centos:7'|'platform:el8')
         cp \
             ./target/debug/libaziot_key_openssl_engine_shared.so \
             /usr/lib64/openssl/engines/libaziot_keys.so
         ;;
 
-    'debian:9'|'debian:10'|'ubuntu:18.04'|'ubuntu:20.04')
+    'debian:9'|'debian:10'|'debian:11'|'ubuntu:18.04'|'ubuntu:20.04')
         cp \
             ./target/debug/libaziot_key_openssl_engine_shared.so \
             "$(openssl version -e | sed -E 's/^ENGINESDIR: "(.*)"$/\1/')/aziot_keys.so"

--- a/contrib/centos/aziot-identity-service.spec
+++ b/contrib/centos/aziot-identity-service.spec
@@ -33,7 +33,7 @@ This package contains the Azure IoT device runtime, comprised of the following s
 This package also contains the following libraries:
 
 - libaziot_keys.so - The library used by the Keys Service to communicate with HSMs for key operations.
-- <openssl engines directory>/openssl/engines/libaziot_keys.so - An openssl engine that can be used to work with asymmetric keys managed by the Azure IoT Keys Service.
+- @enginesdir@/libaziot_keys.so - An openssl engine that can be used to work with asymmetric keys managed by the Azure IoT Keys Service.
 
 Lastly, this package contains the aziotctl binary that is used to configure and manage the services.
 
@@ -74,7 +74,7 @@ make -j \
     sysconfdir=%{_sysconfdir} \
     unitdir=%{_unitdir} \
     presetdir=%{_presetdir} \
-    OPENSSL_ENGINES_DIR=/usr/lib64/openssl/engines \
+    OPENSSL_ENGINES_DIR=@enginesdir@ \
     RELEASE=1 \
     V=1 \
     install-rpm
@@ -152,7 +152,7 @@ fi
 %{_libdir}/libaziot_keys.so
 
 # libaziot-key-openssl-engine-shared
-%{_libdir}/openssl/engines/libaziot_keys.so
+@enginesdir@/libaziot_keys.so
 
 # Default configs and config directories
 %attr(400, aziotcs, aziotcs) %{_sysconfdir}/aziot/certd/config.toml.default

--- a/contrib/centos/aziot-identity-service.spec
+++ b/contrib/centos/aziot-identity-service.spec
@@ -33,7 +33,7 @@ This package contains the Azure IoT device runtime, comprised of the following s
 This package also contains the following libraries:
 
 - libaziot_keys.so - The library used by the Keys Service to communicate with HSMs for key operations.
-- @enginesdir@/libaziot_keys.so - An openssl engine that can be used to work with asymmetric keys managed by the Azure IoT Keys Service.
+- <openssl engines directory>/libaziot_keys.so - An openssl engine that can be used to work with asymmetric keys managed by the Azure IoT Keys Service.
 
 Lastly, this package contains the aziotctl binary that is used to configure and manage the services.
 

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -2,8 +2,7 @@ Source: aziot-identity-service
 Section: admin
 Priority: optional
 Maintainer: Azure IoT Edge Devs
-Build-Depends: debhelper (>=9),
-               dh-systemd
+Build-Depends: debhelper (>=9.20160709)
 Standards-Version: 3.9.8
 Homepage: https://github.com/azure/iot-identity-service
 Vcs-Browser: https://github.com/azure/iot-identity-service

--- a/docs-dev/packages.md
+++ b/docs-dev/packages.md
@@ -17,7 +17,7 @@ This repository contains three services - `aziot-certd`, `aziot-identityd` and `
 </tr>
 <tr>
 <td>RHEL 8 compatible</td>
-<td><code>almalinux:8.4</code></td>
+<td><code>redhat/ubi8:latest</code></td>
 </tr>
 <tr>
 <td>Debian 9 / Raspberry Pi OS 9</td>
@@ -78,7 +78,7 @@ docker run -it --rm \
     -e 'ARCH=amd64' \
     -e 'PACKAGE_VERSION=1.2.0' \
     -e 'PACKAGE_RELEASE=0' \
-    almalinux:8.4 \
+    redhat/ubi8:latest \
     '/src/ci/package.sh'
 ```
 
@@ -130,6 +130,8 @@ The first file is the binary package, the second through fourth file together co
 
 1. The script must be run on an `x86_64` host, even for building ARM32 and ARM64 packages. The ARM32 and ARM64 packages are built via cross-compilation.
 
-1. Building ARM32 and ARM64 packages for either CentOS 7 or RHEL 8 is currently not supported, because they do not have functional cross compilers for those architectures. (It has the `gcc` cross compiler itself but not a cross `glibc` for the compiled binary to link to, because the cross compiler is only intended for cross-compiling the kernel.)
+1. Building ARM32 and ARM64 packages for CentOS 7 is currently not supported, because CentOS 7 does do not have functional cross compilers for those architectures. (It has the `gcc` cross compiler itself but not a cross `glibc` for the compiled binary to link to, because the cross compiler is only intended for cross-compiling the kernel.)
+
+1. Building ARM32 and ARM64 packages for RHEL 8 is currently not supported. More investigation would be required to determine feasibility.
 
 1. The packages script is also run in our CI, via the `.github/workflows/packages.yaml` file.

--- a/docs-dev/packages.md
+++ b/docs-dev/packages.md
@@ -16,12 +16,20 @@ This repository contains three services - `aziot-certd`, `aziot-identityd` and `
 <td><code>centos:7</code></td>
 </tr>
 <tr>
-<td>Debian 9 / Raspbian 9</td>
+<td>RHEL 8 compatible</td>
+<td><code>almalinux:8.4</code></td>
+</tr>
+<tr>
+<td>Debian 9 / Raspberry Pi OS 9</td>
 <td><code>debian:9-slim</code></td>
 </tr>
 <tr>
-<td>Debian 10 / Raspbian 10</td>
+<td>Debian 10 / Raspberry Pi OS 10</td>
 <td><code>debian:10-slim</code></td>
+</tr>
+<tr>
+<td>Debian 11 / Raspberry Pi OS 11</td>
+<td><code>debian:11-slim</code></td>
 </tr>
 <tr>
 <td>Ubuntu 18.04</td>
@@ -62,7 +70,7 @@ In addition, the script also needs the `PACKAGE_VERSION` and `PACKAGE_RELEASE` e
 
 Finally, the script expects the source directory to be at `/src`, and will create the packages under `/src/packages`.
 
-For an example to put it all together, let's say you want to build the CentOS 7 package for `x86_64`, with version 1.2.0 and release 0, ie the package version is `1.2.0-0`. Let's say your clone of this repository is at `~/src/iot-identity-service`. You would run:
+For an example to put it all together, let's say you want to build the RHEL 8-compatible package for `x86_64`, with version 1.2.0 and release 0, ie the package version is `1.2.0-0`. Let's say your clone of this repository is at `~/src/iot-identity-service`. You would run:
 
 ```sh
 docker run -it --rm \
@@ -70,17 +78,17 @@ docker run -it --rm \
     -e 'ARCH=amd64' \
     -e 'PACKAGE_VERSION=1.2.0' \
     -e 'PACKAGE_RELEASE=0' \
-    centos:7 \
+    almalinux:8.4 \
     '/src/ci/package.sh'
 ```
 
 and at the end you would have these files under `~/src/iot-identity-service/packages`:
 
 ```
-centos7/amd64/aziot-identity-service-1.2.0-0.src.rpm
-centos7/amd64/aziot-identity-service-1.2.0-0.x86_64.rpm
-centos7/amd64/aziot-identity-service-debuginfo-1.2.0-0.x86_64.rpm
-centos7/amd64/aziot-identity-service-devel-1.2.0-0.x86_64.rpm
+el8/amd64/aziot-identity-service-1.2.0-0.src.rpm
+el8/amd64/aziot-identity-service-1.2.0-0.x86_64.rpm
+el8/amd64/aziot-identity-service-debuginfo-1.2.0-0.x86_64.rpm
+el8/amd64/aziot-identity-service-devel-1.2.0-0.x86_64.rpm
 ```
 
 These files in order are:
@@ -91,7 +99,7 @@ These files in order are:
 1. A devel package containing the `aziot-keys.h` C header, which contains the API definitions of `libaziot_keys.so`. A user would install this package if they wanted to make their own implementation of `libaziot_keys.so`. It's not needed for a production device.
 
 
-For another example, let's say you want to build the Debian 10 package for ARM32, with version `1.2.0` and revision 0, ie the package version is `1.2.0-0`. You would run:
+For another example, let's say you want to build the Debian 11 package for ARM32, with version `1.2.0` and revision 0, ie the package version is `1.2.0-0`. You would run:
 
 ```sh
 docker run -it --rm \
@@ -99,18 +107,18 @@ docker run -it --rm \
     -e 'ARCH=arm32v7' \
     -e 'PACKAGE_VERSION=1.2.0' \
     -e 'PACKAGE_RELEASE=0' \
-    debian:10-slim \
+    debian:11-slim \
     '/src/ci/package.sh'
 ```
 
 and at the end you would have these files under `~/src/iot-identity-service/packages`:
 
 ```
-aziot-identity-service_1.2.0-0_armhf.deb
-aziot-identity-service_1.2.0-0.debian.tar.xz
-aziot-identity-service_1.2.0-0.dsc
-aziot-identity-service_1.2.0.orig.tar.gz
-aziot-identity-service-dbgsym_1.2.0-0_armhf.deb
+debian11/arm32v7/aziot-identity-service_1.2.0-0_armhf.deb
+debian11/arm32v7/aziot-identity-service_1.2.0-0.debian.tar.xz
+debian11/arm32v7/aziot-identity-service_1.2.0-0.dsc
+debian11/arm32v7/aziot-identity-service_1.2.0.orig.tar.gz
+debian11/arm32v7/aziot-identity-service-dbgsym_1.2.0-0_armhf.deb
 ```
 
 The first file is the binary package, the second through fourth file together constitute the source package, and the fifth is the debug symbols package. The meanings are the same as the CentOS example. Note that there is no `-dev` package equivalent of the CentOS `-devel` package; the C header is included in the binary package.
@@ -122,6 +130,6 @@ The first file is the binary package, the second through fourth file together co
 
 1. The script must be run on an `x86_64` host, even for building ARM32 and ARM64 packages. The ARM32 and ARM64 packages are built via cross-compilation.
 
-1. Building ARM32 and ARM64 packages for CentOS 7 is currently not supported, because CentOS 7 does not have functional cross compilers for those architectures. (It has the `gcc` cross compiler itself but not a cross `glibc` for the compiled binary to link to, because the cross compiler is only intended for cross-compiling the kernel.)
+1. Building ARM32 and ARM64 packages for either CentOS 7 or RHEL 8 is currently not supported, because they do not have functional cross compilers for those architectures. (It has the `gcc` cross compiler itself but not a cross `glibc` for the compiled binary to link to, because the cross compiler is only intended for cross-compiling the kernel.)
 
 1. The packages script is also run in our CI, via the `.github/workflows/packages.yaml` file.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,11 +11,15 @@ The Azure IoT Identity Service can be installed on your device by installing the
 </thead>
 <tbody>
 <tr>
-<td>Debian 9, Raspbian 9</td>
+<td>Debian 9, Raspberry Pi OS 9</td>
 <td>amd64, arm32v7, aarch64</td>
 </tr>
 <tr>
-<td>Debian 10, Raspbian 10</td>
+<td>Debian 10, Raspberry Pi OS 10</td>
+<td>amd64, arm32v7, aarch64</td>
+</tr>
+<tr>
+<td>Debian 11, Raspberry Pi OS 11</td>
 <td>amd64, arm32v7, aarch64</td>
 </tr>
 <tr>
@@ -28,6 +32,10 @@ The Azure IoT Identity Service can be installed on your device by installing the
 </tr>
 <tr>
 <td>CentOS 7</td>
+<td>amd64</td>
+</tr>
+<tr>
+<td>RHEL 8</td>
 <td>amd64</td>
 </tr>
 </tbody>

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -98,33 +98,33 @@ macro_rules! make_service {
                                         http::Method::DELETE => {
                                             let body = {
                                                 let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
-                                                if content_type.as_deref() == Some("application/json") {
-                                                    let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
-                                                        Ok(result) => match result {
+                                                match content_type.as_deref() {
+                                                    Some("application/json") | None => {
+                                                        let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
+                                                            Ok(result) => match result {
+                                                                Ok(body) => body,
+                                                                Err(err) => return Ok((http_common::server::Error {
+                                                                    status_code: http::StatusCode::BAD_REQUEST,
+                                                                    message: http_common::server::error_to_message(&err).into(),
+                                                                }).to_http_response()),
+                                                            },
+                                                            Err(timeout_err) => return Ok((http_common::server::Error {
+                                                                status_code: http::StatusCode::REQUEST_TIMEOUT,
+                                                                message: http_common::server::error_to_message(&timeout_err).into(),
+                                                            }).to_http_response()),
+                                                        };
+
+                                                        let body: <$route as http_common::server::Route>::DeleteBody = match serde_json::from_slice(&body) {
                                                             Ok(body) => body,
                                                             Err(err) => return Ok((http_common::server::Error {
-                                                                status_code: http::StatusCode::BAD_REQUEST,
+                                                                status_code: http::StatusCode::UNPROCESSABLE_ENTITY,
                                                                 message: http_common::server::error_to_message(&err).into(),
                                                             }).to_http_response()),
-                                                        },
-                                                        Err(timeout_err) => return Ok((http_common::server::Error {
-                                                            status_code: http::StatusCode::REQUEST_TIMEOUT,
-                                                            message: http_common::server::error_to_message(&timeout_err).into(),
-                                                        }).to_http_response()),
-                                                    };
+                                                        };
 
-                                                    let body: <$route as http_common::server::Route>::DeleteBody = match serde_json::from_slice(&body) {
-                                                        Ok(body) => body,
-                                                        Err(err) => return Ok((http_common::server::Error {
-                                                            status_code: http::StatusCode::UNPROCESSABLE_ENTITY,
-                                                            message: http_common::server::error_to_message(&err).into(),
-                                                        }).to_http_response()),
-                                                    };
-
-                                                    Some(body)
-                                                }
-                                                else {
-                                                    None
+                                                        Some(body)
+                                                    },
+                                                    _ => None,
                                                 }
                                             };
 
@@ -144,7 +144,46 @@ macro_rules! make_service {
                                         http::Method::POST => {
                                             let body = {
                                                 let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
-                                                if content_type.as_deref() == Some("application/json") {
+                                                match content_type.as_deref() {
+                                                    Some("application/json") | None => {
+                                                        let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
+                                                            Ok(result) => match result {
+                                                                Ok(body) => body,
+                                                                Err(err) => return Ok((http_common::server::Error {
+                                                                    status_code: http::StatusCode::BAD_REQUEST,
+                                                                    message: http_common::server::error_to_message(&err).into(),
+                                                                }).to_http_response()),
+                                                            },
+                                                            Err(timeout_err) => return Ok((http_common::server::Error {
+                                                                status_code: http::StatusCode::REQUEST_TIMEOUT,
+                                                                message: http_common::server::error_to_message(&timeout_err).into(),
+                                                            }).to_http_response()),
+                                                        };
+
+                                                        let body: <$route as http_common::server::Route>::PostBody = match serde_json::from_slice(&body) {
+                                                            Ok(body) => body,
+                                                            Err(err) => return Ok((http_common::server::Error {
+                                                                status_code: http::StatusCode::UNPROCESSABLE_ENTITY,
+                                                                message: http_common::server::error_to_message(&err).into(),
+                                                            }).to_http_response()),
+                                                        };
+
+                                                        Some(body)
+                                                    },
+                                                    _ => None,
+                                                }
+                                            };
+
+                                            match <$route as http_common::server::Route>::post(route, body).await {
+                                                Ok(result) => result,
+                                                Err(err) => return Ok(err.to_http_response()),
+                                            }
+                                        },
+
+                                        http::Method::PUT => {
+                                            let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
+                                            let body = match content_type.as_deref() {
+                                                Some("application/json") | None => {
                                                     let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
                                                         Ok(result) => match result {
                                                             Ok(body) => body,
@@ -159,7 +198,7 @@ macro_rules! make_service {
                                                         }).to_http_response()),
                                                     };
 
-                                                    let body: <$route as http_common::server::Route>::PostBody = match serde_json::from_slice(&body) {
+                                                    let body: <$route as http_common::server::Route>::PutBody = match serde_json::from_slice(&body) {
                                                         Ok(body) => body,
                                                         Err(err) => return Ok((http_common::server::Error {
                                                             status_code: http::StatusCode::UNPROCESSABLE_ENTITY,
@@ -167,48 +206,14 @@ macro_rules! make_service {
                                                         }).to_http_response()),
                                                     };
 
-                                                    Some(body)
-                                                }
-                                                else {
-                                                    None
-                                                }
-                                            };
-
-                                            match <$route as http_common::server::Route>::post(route, body).await {
-                                                Ok(result) => result,
-                                                Err(err) => return Ok(err.to_http_response()),
-                                            }
-                                        },
-
-                                        http::Method::PUT => {
-                                            let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
-                                            if content_type.as_deref() != Some("application/json") {
-                                                return Ok((http_common::server::Error {
-                                                    status_code: http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                                                    message: "request body must be application/json".into(),
-                                                }).to_http_response());
-                                            }
-
-                                            let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
-                                                Ok(result) => match result {
-                                                    Ok(body) => body,
-                                                    Err(err) => return Ok((http_common::server::Error {
-                                                        status_code: http::StatusCode::BAD_REQUEST,
-                                                        message: http_common::server::error_to_message(&err).into(),
-                                                    }).to_http_response()),
+                                                    body
                                                 },
-                                                Err(timeout_err) => return Ok((http_common::server::Error {
-                                                    status_code: http::StatusCode::REQUEST_TIMEOUT,
-                                                    message: http_common::server::error_to_message(&timeout_err).into(),
-                                                }).to_http_response()),
-                                            };
-
-                                            let body: <$route as http_common::server::Route>::PutBody = match serde_json::from_slice(&body) {
-                                                Ok(body) => body,
-                                                Err(err) => return Ok((http_common::server::Error {
-                                                    status_code: http::StatusCode::UNPROCESSABLE_ENTITY,
-                                                    message: http_common::server::error_to_message(&err).into(),
-                                                }).to_http_response()),
+                                                _ => {
+                                                    return Ok((http_common::server::Error {
+                                                        status_code: http::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                                                        message: "request body must be application/json".into(),
+                                                    }).to_http_response());
+                                                },
                                             };
 
                                             match <$route as http_common::server::Route>::put(route, body).await {

--- a/key/test-aziot-key-openssl-engine-shared.sh
+++ b/key/test-aziot-key-openssl-engine-shared.sh
@@ -163,10 +163,10 @@ echo "Client key: $client_key_handle"
 # Otherwise, all keys would've been created with PKCS#11, except for the handle validation key
 # which would've been created on the filesystem.
 #
-# softhsm supports CKM_GENERIC_SECRET_KEY_GEN starting from v2.5. Only ubuntu:20.04 and RHEL8 have this version.
+# softhsm supports CKM_GENERIC_SECRET_KEY_GEN starting from v2.5. Only ubuntu:20.04, RHEL8, and Debian 11 have this version.
 if [ -z "${PKCS11_LIB_PATH:-}" ]; then
     expected_num_keys=4
-elif [ "$OS" = 'ubuntu:20.04' || "$OS" = 'platform:el8' ]; then
+elif [ "$(printf '%s\n' "2.5.0" "$(softhsm2-util -v)" | sort -V | head -n1)" = "2.5.0" ]; then
     expected_num_keys=0
 else
     expected_num_keys=1

--- a/key/test-aziot-key-openssl-engine-shared.sh
+++ b/key/test-aziot-key-openssl-engine-shared.sh
@@ -163,10 +163,10 @@ echo "Client key: $client_key_handle"
 # Otherwise, all keys would've been created with PKCS#11, except for the handle validation key
 # which would've been created on the filesystem.
 #
-# softhsm supports CKM_GENERIC_SECRET_KEY_GEN starting from v2.5. Only ubuntu:20.04 has this version.
+# softhsm supports CKM_GENERIC_SECRET_KEY_GEN starting from v2.5. Only ubuntu:20.04 and RHEL8 have this version.
 if [ -z "${PKCS11_LIB_PATH:-}" ]; then
     expected_num_keys=4
-elif [ "$OS" = 'ubuntu:20.04' ]; then
+elif [ "$OS" = 'ubuntu:20.04' || "$OS" = 'platform:el8' ]; then
     expected_num_keys=0
 else
     expected_num_keys=1


### PR DESCRIPTION
Adding Debian11 and RHEL8-compatible options to the possible build targets.

Removed reference to the the db-systemd package since it doesn't appear to exist on Bullseye.  Per Debian [bug 822670](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=822670) it was merged into debhelper.  It persisted in Debian 10 to provide a transition window

Validated changes to the e2e-tests.sh script by manually triggering it for 'manual-symmetric-key' on both Debian 11 and RHEL 8 (AlmaLinux).  For the AlmaLinux VM I had to first accept the terms of the VM before subsequent test runs would work (i.e. `az vm image terms accept --urn 'almalinux:almalinux:8_4-gen2:8.4.20210729'`)