### PR TITLE
Fixes for EST cert issuance (#200)

### DIFF
--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -155,6 +155,7 @@ pub struct CertIssuance {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Est {
+    #[serde(default)]
     pub trusted_certs: Vec<Url>,
     pub auth: EstAuth,
     pub urls: BTreeMap<String, Url>,

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -64,7 +64,7 @@ where
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
 
     let res: TResponse = match res_status_code {
-        hyper::StatusCode::OK => {
+        hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
             let res = serde_json::from_slice(&body)
                 .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
             res


### PR DESCRIPTION
- Allow the trusted_certs to be empty. Makes using servers with publicly-rooted TLS certs easier.
- Treat HTTP 201 (Created) as Ok.