### PR TITLE
CN fallback for X.509 registration (#212)

### DIFF
--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -136,7 +136,7 @@ pub enum DpsAttestationMethod {
     },
 
     X509 {
-        registration_id: String,
+        registration_id: Option<String>,
 
         #[serde(flatten)]
         identity: X509Identity,

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -124,7 +124,7 @@ pub enum DpsAttestationMethod {
         symmetric_key: String,
     },
     X509 {
-        registration_id: String,
+        registration_id: Option<String>,
         identity_cert: String,
         identity_pk: String,
     },

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -853,14 +853,6 @@ impl IdentityManager {
 
         // Create new certificate if needed.
         if device_id_cert.is_none() {
-            if let Ok(key_handle) = self.key_client.load_key_pair(identity_pk).await {
-                self.key_client
-                    .delete_key_pair(&key_handle)
-                    .await
-                    .map_err(|err| {
-                        Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                    })?;
-            }
             let new_cert_subject = match subject {
                 Some(subject) => subject.to_string(),
                 None => old_cert_subject_name.map_err(|err| {

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -606,12 +606,14 @@ impl IdentityManager {
                         identity_cert,
                         identity_pk,
                     } => {
-                        self.create_identity_cert_if_not_exist_or_expired(
-                            &identity_pk,
-                            &identity_cert,
-                            &device_id,
-                        )
-                        .await?;
+                        // IoT Hub doesn't require device ID to match identity certificate CN
+                        let _ = self
+                            .create_identity_cert_if_not_exist_or_expired(
+                                &identity_pk,
+                                &identity_cert,
+                                Some(&device_id),
+                            )
+                            .await?;
                         aziot_identity_common::Credentials::X509 {
                             identity_cert,
                             identity_pk,
@@ -671,12 +673,21 @@ impl IdentityManager {
                         identity_cert,
                         identity_pk,
                     } => {
-                        self.create_identity_cert_if_not_exist_or_expired(
-                            &identity_pk,
-                            &identity_cert,
-                            &registration_id,
-                        )
-                        .await?;
+                        // DPS requires registration ID to match identity certificate CN
+                        let cert_subject_name = self
+                            .create_identity_cert_if_not_exist_or_expired(
+                                &identity_pk,
+                                &identity_cert,
+                                registration_id.as_ref(),
+                            )
+                            .await?;
+
+                        let registration_id = match registration_id {
+                            Some(registration_id) => registration_id,
+                            None => cert_subject_name.map_err(|err| {
+                                Error::Internal(InternalError::CreateCertificate(Box::new(err)))
+                            })?,
+                        };
 
                         let dps_auth_kind = aziot_dps_client_async::DpsAuthKind::X509 {
                             identity_cert: identity_cert.clone(),
@@ -802,15 +813,24 @@ impl IdentityManager {
         &self,
         identity_pk: &str,
         identity_cert: &str,
-        subject: &str,
-    ) -> Result<(), Error> {
+        subject: Option<&String>,
+    ) -> Result<Result<String, Error>, Error> {
         // Retrieve existing cert and check it for expiry.
-        let device_id_cert = match self.cert_client.get_cert(identity_cert).await {
+        let (device_id_cert, old_cert_subject_name) = match self
+            .cert_client
+            .get_cert(identity_cert)
+            .await
+        {
             Ok(pem) => {
                 let cert = openssl::x509::X509::from_pem(&pem).map_err(|err| {
                     Error::Internal(InternalError::CreateCertificate(Box::new(err)))
                 })?;
                 let cert_expiration = cert.as_ref().not_after();
+                let cert_subject = cert.as_ref().subject_name();
+                let cert_subject = cert_subject.entries_by_nid(openssl::nid::Nid::COMMONNAME).next()
+                  .map_or(Err(Error::Internal(InternalError::CreateCertificate("old device identity certificate does not contain common name field required for registration".to_string().into()))), |common_name_entry| {
+                    String::from_utf8(common_name_entry.data().as_slice().into()).map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))
+                });
                 let current_time = openssl::asn1::Asn1Time::days_from_now(0).map_err(|err| {
                     Error::Internal(InternalError::CreateCertificate(Box::new(err)))
                 })?;
@@ -821,21 +841,33 @@ impl IdentityManager {
                 if expiration_time.days < 1 {
                     log::info!("{} has expired. Renewing certificate", identity_cert);
 
-                    None
+                    (None, cert_subject)
                 } else {
-                    Some(pem)
+                    (Some(pem), cert_subject)
                 }
             }
             Err(_) => {
-                // TODO: Need to check if key exists.
-                // If this function fails, delete any key it creates but don't delete an existing key.
-
-                None
+                (None, Err(Error::Internal(InternalError::CreateCertificate("old device identity certificate, which should contain the common name field required for registration, could not be retrieved".to_string().into()))))
             }
         };
 
         // Create new certificate if needed.
         if device_id_cert.is_none() {
+            if let Ok(key_handle) = self.key_client.load_key_pair(identity_pk).await {
+                self.key_client
+                    .delete_key_pair(&key_handle)
+                    .await
+                    .map_err(|err| {
+                        Error::Internal(InternalError::CreateCertificate(Box::new(err)))
+                    })?;
+            }
+            let new_cert_subject = match subject {
+                Some(subject) => subject.to_string(),
+                None => old_cert_subject_name.map_err(|err| {
+                    Error::Internal(InternalError::CreateCertificate(Box::new(err)))
+                })?,
+            };
+
             let key_handle = self
                 .key_client
                 .create_key_pair_if_not_exists(identity_pk, Some("rsa-2048:*"))
@@ -852,31 +884,27 @@ impl IdentityManager {
                 .load_public_key(&key_handle)
                 .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
 
-            let result = async {
-                let csr = create_csr(&subject, &public_key, &private_key, None).map_err(|err| {
-                    Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                })?;
+            let csr = create_csr(&new_cert_subject.as_str(), &public_key, &private_key, None)
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
 
-                let _ = self
-                    .cert_client
-                    .create_cert(&identity_cert, &csr, None)
-                    .await
-                    .map_err(|err| {
-                        Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                    })?;
+            let new_cert_pem = self
+                .cert_client
+                .create_cert(&identity_cert, &csr, None)
+                .await
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
 
-                Ok::<(), Error>(())
-            }
-            .await;
+            let cert = openssl::x509::X509::from_pem(&new_cert_pem)
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
+            let cert_subject = cert.as_ref().subject_name();
+            let cert_subject = cert_subject.entries_by_nid(openssl::nid::Nid::COMMONNAME).next()
+                .map_or(Err(Error::Internal(InternalError::CreateCertificate("new device identity certificate does not contain common name field required for registration".to_string().into()))), |common_name_entry| {
+                    String::from_utf8(common_name_entry.data().as_slice().into()).map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))
+            });
 
-            if let Err(err) = result {
-                // TODO: need to delete key from keyd.
-
-                return Err(err);
-            }
+            Ok(cert_subject)
+        } else {
+            Ok(old_cert_subject_name)
         }
-
-        Ok(())
     }
 
     pub async fn reconcile_hub_identities(&self, settings: config::Settings) -> Result<(), Error> {


### PR DESCRIPTION
In 1.1, iotedge had a fallback mechanism for DPS X.509 attestation. In 1.2, however, new options for obtaining device identity certificate became available. In the new world, CS could be configured to issue identity certificate in one of these configurations:

1. receive a CSR with any subject name. This subject would be IS's config.toml registration_id value.
2. receive a CSR and common name is configured within CS config.toml. This will override any common name specified in the CSR.

With this fix, the behavior is changed to bring back parity with 1.1 behavior (i.e. if registration_id is missing, fallback to identity cert's subject name as registration_id). The CSR issued by IS to renew the identity cert will contain subject name set as one of the following values (in order of precedence):
- First, the IS config.toml X.509 attestation registration_id is used in the CSR to renew the identity cert
- If registration_id is missing, the current identity certificate's subject name is used in the CSR to renew the identity cert
- When the identity certificate is returned, the latest valid/renewed cert's subject is used, if the registration_id is missing.

Note that if registration_id is set to a value different from the identity certificate subject name returned by CS, DPS will reject the registration request (as of DPS API version 2019-04-15). So, it is upto the user to avoid this scenario currently.