### PR TITLE
Add cert_name parameter to set_est_auth (#210)

### DIFF
--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -121,6 +121,7 @@ pub fn run(
                                             &mut preloaded_certs,
                                             &mut preloaded_keys,
                                             &mut aziotcs_keys,
+                                            super::DEVICE_ID_ID,
                                         )
                                     } else {
                                         None
@@ -202,6 +203,7 @@ pub fn run(
                                             &mut preloaded_certs,
                                             &mut preloaded_keys,
                                             &mut aziotcs_keys,
+                                            super::DEVICE_ID_ID,
                                         )
                                     } else {
                                         None
@@ -506,33 +508,30 @@ pub fn set_est_auth(
         aziot_keys_common::PreloadedKeyLocation,
     >,
     aziotcs_keys: &mut aziot_keyd_config::Principal,
+    cert_name: &str,
 ) -> Option<aziot_certd_config::EstAuth> {
     auth.as_ref().map(|auth| {
         let auth_x509 = auth.x509.as_ref().map(|x509| {
+            let identity_cert_id = format!("{}-{}", super::EST_ID_ID, cert_name);
+
             let bootstrap_identity = match x509 {
                 super_config::EstAuthX509::BootstrapIdentity {
                     bootstrap_identity_cert,
                     bootstrap_identity_pk,
                 } => {
+                    let bootstrap_cert_id = format!("{}-{}", super::EST_BOOTSTRAP_ID, cert_name);
+
                     let bootstrap_identity_cert =
                         aziot_certd_config::PreloadedCert::Uri(bootstrap_identity_cert.to_owned());
-                    preloaded_certs.insert(
-                        super::EST_BOOTSTRAP_ID_DEVICE_ID.to_owned(),
-                        bootstrap_identity_cert,
-                    );
+                    preloaded_certs.insert(bootstrap_cert_id.to_owned(), bootstrap_identity_cert);
 
                     preloaded_keys.insert(
-                        super::EST_BOOTSTRAP_ID_DEVICE_ID.to_owned(),
+                        bootstrap_cert_id.to_owned(),
                         bootstrap_identity_pk.to_owned(),
                     );
-                    aziotcs_keys
-                        .keys
-                        .push(super::EST_BOOTSTRAP_ID_DEVICE_ID.to_owned());
+                    aziotcs_keys.keys.push(bootstrap_cert_id.to_owned());
 
-                    Some((
-                        super::EST_BOOTSTRAP_ID_DEVICE_ID.to_owned(),
-                        super::EST_BOOTSTRAP_ID_DEVICE_ID.to_owned(),
-                    ))
+                    Some((bootstrap_cert_id.to_owned(), bootstrap_cert_id))
                 }
 
                 super_config::EstAuthX509::Identity {
@@ -541,22 +540,18 @@ pub fn set_est_auth(
                 } => {
                     let identity_cert =
                         aziot_certd_config::PreloadedCert::Uri(identity_cert.to_owned());
-                    preloaded_certs.insert(super::EST_ID_DEVICE_ID.to_owned(), identity_cert);
+                    preloaded_certs.insert(identity_cert_id.to_owned(), identity_cert);
 
-                    preloaded_keys
-                        .insert(super::EST_ID_DEVICE_ID.to_owned(), identity_pk.to_owned());
+                    preloaded_keys.insert(identity_cert_id.to_owned(), identity_pk.to_owned());
 
                     None
                 }
             };
 
-            aziotcs_keys.keys.push(super::EST_ID_DEVICE_ID.to_owned());
+            aziotcs_keys.keys.push(identity_cert_id.to_owned());
 
             aziot_certd_config::EstAuthX509 {
-                identity: (
-                    super::EST_ID_DEVICE_ID.to_owned(),
-                    super::EST_ID_DEVICE_ID.to_owned(),
-                ),
+                identity: (identity_cert_id.to_owned(), identity_cert_id),
                 bootstrap_identity,
             }
         });

--- a/aziotctl/aziotctl-common/src/config/mod.rs
+++ b/aziotctl/aziotctl-common/src/config/mod.rs
@@ -21,12 +21,6 @@ const EST_ID_ID: &str = "est-id";
 /// The ID used for the private key and cert that is used as the client cert to authenticate with the EST server for the initial bootstrap.
 const EST_BOOTSTRAP_ID: &str = "est-bootstrap-id";
 
-/// The ID used for the private key and cert that is used as the client cert to authenticate with the EST server issuing device ID certs.
-const EST_ID_DEVICE_ID: &str = "est-id-device-id";
-
-/// The ID used for the private key and cert that is used as the client cert to authenticate with the EST server issuing device ID certs for the initial bootstrap.
-const EST_BOOTSTRAP_ID_DEVICE_ID: &str = "est-bootstrap-id-device-id";
-
 pub fn create_dir_all(
     path: &(impl AsRef<std::path::Path> + ?Sized),
     user: &nix::unistd::User,


### PR DESCRIPTION
This parameter is needed so that different cert IDs for the EST auth certs can be set for device ID and Edge CA certs.