### PR TITLE
http server: don't try to parse empty bodies

### DIFF
--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -96,24 +96,27 @@ macro_rules! make_service {
                                 return Box::pin(async move {
                                     let response = match method {
                                         http::Method::DELETE => {
-                                            let body = {
+                                            let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
+                                                Ok(result) => match result {
+                                                    Ok(body) => body,
+                                                    Err(err) => return Ok((http_common::server::Error {
+                                                        status_code: http::StatusCode::BAD_REQUEST,
+                                                        message: http_common::server::error_to_message(&err).into(),
+                                                    }).to_http_response()),
+                                                },
+                                                Err(timeout_err) => return Ok((http_common::server::Error {
+                                                    status_code: http::StatusCode::REQUEST_TIMEOUT,
+                                                    message: http_common::server::error_to_message(&timeout_err).into(),
+                                                }).to_http_response()),
+                                            };
+
+                                            let body = if body.len() == 0 {
+                                                None
+                                            } else {
                                                 let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
+
                                                 match content_type.as_deref() {
                                                     Some("application/json") | None => {
-                                                        let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
-                                                            Ok(result) => match result {
-                                                                Ok(body) => body,
-                                                                Err(err) => return Ok((http_common::server::Error {
-                                                                    status_code: http::StatusCode::BAD_REQUEST,
-                                                                    message: http_common::server::error_to_message(&err).into(),
-                                                                }).to_http_response()),
-                                                            },
-                                                            Err(timeout_err) => return Ok((http_common::server::Error {
-                                                                status_code: http::StatusCode::REQUEST_TIMEOUT,
-                                                                message: http_common::server::error_to_message(&timeout_err).into(),
-                                                            }).to_http_response()),
-                                                        };
-
                                                         let body: <$route as http_common::server::Route>::DeleteBody = match serde_json::from_slice(&body) {
                                                             Ok(body) => body,
                                                             Err(err) => return Ok((http_common::server::Error {
@@ -142,23 +145,27 @@ macro_rules! make_service {
                                         },
 
                                         http::Method::POST => {
-                                            let body = {
+                                            let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
+                                                Ok(result) => match result {
+                                                    Ok(body) => body,
+                                                    Err(err) => return Ok((http_common::server::Error {
+                                                        status_code: http::StatusCode::BAD_REQUEST,
+                                                        message: http_common::server::error_to_message(&err).into(),
+                                                    }).to_http_response()),
+                                                },
+                                                Err(timeout_err) => return Ok((http_common::server::Error {
+                                                    status_code: http::StatusCode::REQUEST_TIMEOUT,
+                                                    message: http_common::server::error_to_message(&timeout_err).into(),
+                                                }).to_http_response()),
+                                            };
+
+                                            let body = if body.len() == 0 {
+                                                None
+                                            } else {
                                                 let content_type = headers.get(hyper::header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
                                                 match content_type.as_deref() {
                                                     Some("application/json") | None => {
-                                                        let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
-                                                            Ok(result) => match result {
-                                                                Ok(body) => body,
-                                                                Err(err) => return Ok((http_common::server::Error {
-                                                                    status_code: http::StatusCode::BAD_REQUEST,
-                                                                    message: http_common::server::error_to_message(&err).into(),
-                                                                }).to_http_response()),
-                                                            },
-                                                            Err(timeout_err) => return Ok((http_common::server::Error {
-                                                                status_code: http::StatusCode::REQUEST_TIMEOUT,
-                                                                message: http_common::server::error_to_message(&timeout_err).into(),
-                                                            }).to_http_response()),
-                                                        };
+
 
                                                         let body: <$route as http_common::server::Route>::PostBody = match serde_json::from_slice(&body) {
                                                             Ok(body) => body,

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -97,13 +97,11 @@ macro_rules! make_service {
                                     let response = match method {
                                         http::Method::DELETE => {
                                             let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
-                                                Ok(result) => match result {
-                                                    Ok(body) => body,
-                                                    Err(err) => return Ok((http_common::server::Error {
-                                                        status_code: http::StatusCode::BAD_REQUEST,
-                                                        message: http_common::server::error_to_message(&err).into(),
-                                                    }).to_http_response()),
-                                                },
+                                                Ok(Ok(body)) => body,
+                                                Ok(Err(err)) => return Ok((http_common::server::Error {
+                                                    status_code: http::StatusCode::BAD_REQUEST,
+                                                    message: http_common::server::error_to_message(&err).into(),
+                                                }).to_http_response()),
                                                 Err(timeout_err) => return Ok((http_common::server::Error {
                                                     status_code: http::StatusCode::REQUEST_TIMEOUT,
                                                     message: http_common::server::error_to_message(&timeout_err).into(),
@@ -146,13 +144,11 @@ macro_rules! make_service {
 
                                         http::Method::POST => {
                                             let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
-                                                Ok(result) => match result {
-                                                    Ok(body) => body,
-                                                    Err(err) => return Ok((http_common::server::Error {
-                                                        status_code: http::StatusCode::BAD_REQUEST,
-                                                        message: http_common::server::error_to_message(&err).into(),
-                                                    }).to_http_response()),
-                                                },
+                                                Ok(Ok(body)) => body,
+                                                Ok(Err(err)) => return Ok((http_common::server::Error {
+                                                    status_code: http::StatusCode::BAD_REQUEST,
+                                                    message: http_common::server::error_to_message(&err).into(),
+                                                }).to_http_response()),
                                                 Err(timeout_err) => return Ok((http_common::server::Error {
                                                     status_code: http::StatusCode::REQUEST_TIMEOUT,
                                                     message: http_common::server::error_to_message(&timeout_err).into(),
@@ -192,13 +188,11 @@ macro_rules! make_service {
                                             let body = match content_type.as_deref() {
                                                 Some("application/json") | None => {
                                                     let body = match tokio::time::timeout(HYPER_REQUEST_TIMEOUT, hyper::body::to_bytes(body)).await {
-                                                        Ok(result) => match result {
-                                                            Ok(body) => body,
-                                                            Err(err) => return Ok((http_common::server::Error {
-                                                                status_code: http::StatusCode::BAD_REQUEST,
-                                                                message: http_common::server::error_to_message(&err).into(),
-                                                            }).to_http_response()),
-                                                        },
+                                                        Ok(Ok(body)) => body,
+                                                        Ok(Err(err)) => return Ok((http_common::server::Error {
+                                                            status_code: http::StatusCode::BAD_REQUEST,
+                                                            message: http_common::server::error_to_message(&err).into(),
+                                                        }).to_http_response()),
                                                         Err(timeout_err) => return Ok((http_common::server::Error {
                                                             status_code: http::StatusCode::REQUEST_TIMEOUT,
                                                             message: http_common::server::error_to_message(&timeout_err).into(),


### PR DESCRIPTION
https://github.com/Azure/iot-identity-service/commit/f6294bdd027284a27a03d83b4c5dc736d98e0a32 allowed the content-type header to be omitted because some Edge modules do not provide it even when content is provided. But that commit introduced a bug where the server would parse empty bodies as JSON, since empty bodies do not provide a content-type header.

This PR fixes the DELETE and POST methods to only parse nonzero-length bodies. PUT always requires a body, so it was left as-is.