### PR TITLE
EST request and response fixes.

### DIFF
--- a/cert/aziot-certd/src/est.rs
+++ b/cert/aziot-certd/src/est.rs
@@ -3,13 +3,24 @@
 use http_common::MaybeProxyConnector;
 
 pub(crate) async fn create_cert(
-    csr: Vec<u8>,
+    csr: &[u8],
     url: &url::Url,
     basic_auth: Option<(&str, &str)>,
     client_cert: Option<(&[u8], &openssl::pkey::PKeyRef<openssl::pkey::Private>)>,
     trusted_certs: Vec<openssl::x509::X509>,
     proxy_uri: Option<hyper::Uri>,
 ) -> Result<Vec<u8>, crate::Error> {
+    // Request body is PKCS#10, which is a PEM without the header and footer, so remove them.
+    let csr = csr
+        .strip_prefix(b"-----BEGIN CERTIFICATE REQUEST-----\n")
+        .map_or(csr, |mut csr| {
+            while let Some(csr_) = csr.strip_suffix(b"\n") {
+                csr = csr_;
+            }
+            csr.strip_suffix(b"-----END CERTIFICATE REQUEST-----")
+                .unwrap_or(csr)
+        });
+
     let proxy_connector = match client_cert {
         Some((device_id_certs, device_id_private_key)) => MaybeProxyConnector::new(
             proxy_uri,
@@ -59,7 +70,7 @@ pub(crate) async fn create_cert(
     let simple_enroll_request = simple_enroll_request
         .header(hyper::header::CONTENT_TYPE, "application/pkcs10")
         .header("content-transfer-encoding", "base64")
-        .body(csr.into());
+        .body(csr.to_owned().into());
 
     let ca_certs_request = ca_certs_request.body(Default::default());
 
@@ -146,6 +157,9 @@ async fn get_pkcs7_response(
     // but the EST server response does not contain this wrapper. Add it.
     let mut pkcs7 = b"-----BEGIN PKCS7-----\n"[..].to_owned();
     pkcs7.extend_from_slice(&body);
+    if pkcs7.last() != Some(&b'\n') {
+        pkcs7.push(b'\n');
+    }
     pkcs7.extend_from_slice(b"-----END PKCS7-----\n");
 
     let pkcs7 = openssl::pkcs7::Pkcs7::from_pem(&pkcs7)

--- a/cert/aziot-certd/src/est.rs
+++ b/cert/aziot-certd/src/est.rs
@@ -21,17 +21,8 @@ pub(crate) async fn create_cert(
                 .unwrap_or(csr)
         });
 
-    let proxy_connector = match client_cert {
-        Some((device_id_certs, device_id_private_key)) => MaybeProxyConnector::new(
-            proxy_uri,
-            Some((device_id_private_key, device_id_certs)),
-            &trusted_certs,
-        )
-        .map_err(|err| crate::Error::Internal(crate::InternalError::CreateCert(Box::new(err))))?,
-        None => MaybeProxyConnector::new(proxy_uri, None, &[]).map_err(|err| {
-            crate::Error::Internal(crate::InternalError::CreateCert(Box::new(err)))
-        })?,
-    };
+    let proxy_connector = MaybeProxyConnector::new(proxy_uri, client_cert, &trusted_certs)
+        .map_err(|err| crate::Error::Internal(crate::InternalError::CreateCert(Box::new(err))))?;
 
     let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(proxy_connector);
 

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -489,7 +489,7 @@ fn create_cert<'a>(
                                     })?;
 
                                 let x509 = est::create_cert(
-                                    csr.to_owned(),
+                                    csr,
                                     url,
                                     auth_basic,
                                     Some((&identity_cert, &identity_private_key)),
@@ -716,7 +716,7 @@ fn create_cert<'a>(
                                             })?;
 
                                         let x509 = est::create_cert(
-                                            identity_csr,
+                                            &identity_csr,
                                             url,
                                             auth_basic,
                                             Some((
@@ -766,7 +766,7 @@ fn create_cert<'a>(
                         // We need to only use basic auth with the EST server.
 
                         let x509 = est::create_cert(
-                            csr.to_owned(),
+                            csr,
                             url,
                             auth_basic,
                             None,

--- a/identity/aziot-cloud-client-async-common/src/lib.rs
+++ b/identity/aziot-cloud-client-async-common/src/lib.rs
@@ -78,7 +78,7 @@ pub async fn get_x509_connector(
 
     let proxy_connector = MaybeProxyConnector::new(
         proxy_uri,
-        Some((&device_id_private_key, &device_id_certs)),
+        Some((&device_id_certs, &device_id_private_key)),
         &[],
     )?;
     Ok(proxy_connector)


### PR DESCRIPTION
- Strip PEM header and footer when creating a PKCS#10 request.

- When adding PEM footer to PKCS#7 response, ensure the footer goes on
  a new line.

- Fix est::create_cert to use trusted_certs for the EST server connection
  even when using basic auth.

  aa62e9cc61b907f886c2317a3784bf08187564ea fixed this bug in
  MaybeProxyConnector::new itself, but this code had the bug in the call to
  MaybeProxyConnector::new