### PR TITLE
Update tokio to v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,9 +2270,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2282,6 +2282,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
+ "winapi 0.3.9",
 ]
 
 [[package]]


### PR DESCRIPTION
tokio v0.11.0 carries a fix to prevent `tokio::time::Instant` from panicking
if `std::time::Instant` happens to go backwards for any reason. We've observed
this happening in Linux VMs and possibly even on Linux hosts, so this change
updates to the latest tokio to pull in that fix.