### PR TITLE
Set default retries to 1 and sleep between retries

### DIFF
--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -32,7 +32,7 @@
 # means that the client will make a total of 3 attempts).
 #
 # cloud_timeout_sec = 10
-# cloud_retries = 0
+# cloud_retries = 1
 
 # ==============================================================================
 # Provisioning

--- a/identity/aziot-hub-client-async/src/lib.rs
+++ b/identity/aziot-hub-client-async/src/lib.rs
@@ -291,6 +291,7 @@ impl Client {
             }
 
             current_attempt += 1;
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         };
 
         Ok(res)

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -45,7 +45,7 @@ impl Settings {
     }
 
     pub fn default_cloud_retries() -> u32 {
-        0
+        1
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]


### PR DESCRIPTION
This should minimize the amount of create/update device identity failures due to Hub throttling. 