### PR TITLE
EST request and response fixes.

### DIFF
--- a/cert/aziot-certd/src/est.rs
+++ b/cert/aziot-certd/src/est.rs
@@ -3,24 +3,26 @@
 use http_common::MaybeProxyConnector;
 
 pub(crate) async fn create_cert(
-    csr: Vec<u8>,
+    mut csr: &[u8],
     url: &url::Url,
     basic_auth: Option<(&str, &str)>,
     client_cert: Option<(&[u8], &openssl::pkey::PKeyRef<openssl::pkey::Private>)>,
     trusted_certs: Vec<openssl::x509::X509>,
     proxy_uri: Option<hyper::Uri>,
 ) -> Result<Vec<u8>, crate::Error> {
-    let proxy_connector = match client_cert {
-        Some((device_id_certs, device_id_private_key)) => MaybeProxyConnector::new(
-            proxy_uri,
-            Some((&device_id_private_key, &device_id_certs)),
-            &trusted_certs,
-        )
-        .map_err(|err| crate::Error::Internal(crate::InternalError::CreateCert(Box::new(err))))?,
-        None => MaybeProxyConnector::new(proxy_uri, None, &[]).map_err(|err| {
-            crate::Error::Internal(crate::InternalError::CreateCert(Box::new(err)))
-        })?,
-    };
+    // Request body is PKCS#10, which is a PEM without the header and footer, so remove them.
+    if csr.starts_with(b"-----BEGIN CERTIFICATE REQUEST-----\n") {
+        csr = &csr[(b"-----BEGIN CERTIFICATE REQUEST-----\n".len())..];
+        while csr.ends_with(b"\n") {
+            csr = &csr[..(csr.len() - b"\n".len())];
+        }
+        if csr.ends_with(b"-----END CERTIFICATE REQUEST-----") {
+            csr = &csr[..(csr.len() - b"-----END CERTIFICATE REQUEST-----".len())];
+        }
+    }
+
+    let proxy_connector = MaybeProxyConnector::new(proxy_uri, client_cert, &trusted_certs)
+        .map_err(|err| crate::Error::Internal(crate::InternalError::CreateCert(Box::new(err))))?;
 
     let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(proxy_connector);
 
@@ -59,7 +61,7 @@ pub(crate) async fn create_cert(
     let simple_enroll_request = simple_enroll_request
         .header(hyper::header::CONTENT_TYPE, "application/pkcs10")
         .header("content-transfer-encoding", "base64")
-        .body(csr.into());
+        .body(csr.to_owned().into());
 
     let ca_certs_request = ca_certs_request.body(Default::default());
 
@@ -146,6 +148,9 @@ async fn get_pkcs7_response(
     // but the EST server response does not contain this wrapper. Add it.
     let mut pkcs7 = b"-----BEGIN PKCS7-----\n"[..].to_owned();
     pkcs7.extend_from_slice(&body);
+    if pkcs7.last() != Some(&b'\n') {
+        pkcs7.push(b'\n');
+    }
     pkcs7.extend_from_slice(b"-----END PKCS7-----\n");
 
     let pkcs7 = openssl::pkcs7::Pkcs7::from_pem(&pkcs7)

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -488,7 +488,7 @@ fn create_cert<'a>(
                                     })?;
 
                                 let x509 = est::create_cert(
-                                    csr.to_owned(),
+                                    csr,
                                     url,
                                     auth_basic,
                                     Some((&identity_cert, &identity_private_key)),
@@ -703,7 +703,7 @@ fn create_cert<'a>(
                                             })?;
 
                                         let x509 = est::create_cert(
-                                            identity_csr,
+                                            &identity_csr,
                                             url,
                                             auth_basic,
                                             Some((
@@ -753,7 +753,7 @@ fn create_cert<'a>(
                         // We need to only use basic auth with the EST server.
 
                         let x509 = est::create_cert(
-                            csr.to_owned(),
+                            csr,
                             url,
                             auth_basic,
                             None,

--- a/http-common/src/proxy.rs
+++ b/http-common/src/proxy.rs
@@ -99,7 +99,7 @@ pub enum MaybeProxyConnector<C> {
 impl MaybeProxyConnector<hyper_openssl::HttpsConnector<hyper::client::HttpConnector>> {
     pub fn new(
         proxy_uri: Option<hyper::Uri>,
-        identity: Option<(&openssl::pkey::PKeyRef<openssl::pkey::Private>, &[u8])>,
+        identity: Option<(&[u8], &openssl::pkey::PKeyRef<openssl::pkey::Private>)>,
         trusted_certs: &[openssl::x509::X509],
     ) -> io::Result<Self> {
         let mut http_connector = hyper::client::HttpConnector::new();
@@ -138,7 +138,7 @@ impl MaybeProxyConnector<hyper_openssl::HttpsConnector<hyper::client::HttpConnec
 }
 
 fn make_tls_connector(
-    identity: Option<(&openssl::pkey::PKeyRef<openssl::pkey::Private>, &[u8])>,
+    identity: Option<(&[u8], &openssl::pkey::PKeyRef<openssl::pkey::Private>)>,
     trusted_certs: &[openssl::x509::X509],
 ) -> io::Result<openssl::ssl::SslConnectorBuilder> {
     let mut tls_connector = openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls())?;
@@ -148,7 +148,7 @@ fn make_tls_connector(
         cert_store.add_cert(trusted_cert.clone())?;
     }
 
-    if let Some((key, certs)) = identity {
+    if let Some((certs, private_key)) = identity {
         let mut device_id_certs = openssl::x509::X509::stack_from_pem(certs)?.into_iter();
         let client_cert = device_id_certs.next().ok_or_else(|| {
             io::Error::new(io::ErrorKind::Other, "device identity cert not found")
@@ -160,7 +160,7 @@ fn make_tls_connector(
             tls_connector.add_extra_chain_cert(cert)?;
         }
 
-        tls_connector.set_private_key(key)?;
+        tls_connector.set_private_key(private_key)?;
     }
 
     Ok(tls_connector)

--- a/identity/aziot-cloud-client-async-common/src/lib.rs
+++ b/identity/aziot-cloud-client-async-common/src/lib.rs
@@ -78,7 +78,7 @@ pub async fn get_x509_connector(
 
     let proxy_connector = MaybeProxyConnector::new(
         proxy_uri,
-        Some((&device_id_private_key, &device_id_certs)),
+        Some((&device_id_certs, &device_id_private_key)),
         &[],
     )?;
     Ok(proxy_connector)


### PR DESCRIPTION
Cherry-pick from main of d0a103564366e1496c9c08ec73a196b7e99a0f3f
with some rewriting since release/1.2's rustc is older and doesn't support
`<[T]>::strip_{prefix,suffix}`

- Strip PEM header and footer when creating a PKCS#10 request.

- When adding PEM footer to PKCS#7 response, ensure the footer goes on
  a new line.

- Fix est::create_cert to use trusted_certs for the EST server connection
  even when using basic auth.

  aa62e9cc61b907f886c2317a3784bf08187564ea fixed this bug in
  MaybeProxyConnector::new itself, but this code had the bug in the call to
  MaybeProxyConnector::new