### PR TITLE
Add retry logic to identity client (#292)

### DIFF
--- a/aziotctl/src/internal/check/checks/read_certs.rs
+++ b/aziotctl/src/internal/check/checks/read_certs.rs
@@ -43,6 +43,7 @@ impl ReadCerts {
         let cert_client = aziot_cert_client_async::Client::new(
             aziot_cert_common_http::ApiVersion::V2020_09_01,
             aziot_certd.clone(),
+            0,
         );
 
         let mut err_aggregated = String::new();

--- a/aziotctl/src/internal/check/checks/read_key_pairs.rs
+++ b/aziotctl/src/internal/check/checks/read_key_pairs.rs
@@ -43,6 +43,7 @@ impl ReadKeyPairs {
         let key_client = aziot_key_client_async::Client::new(
             aziot_key_common_http::ApiVersion::V2020_09_01,
             aziot_keyd.clone(),
+            0,
         );
 
         let mut key_engine = {

--- a/aziotctl/src/system.rs
+++ b/aziotctl/src/system.rs
@@ -93,6 +93,7 @@ async fn reprovision(uri: &url::Url) -> Result<()> {
     let client = aziot_identity_client_async::Client::new(
         aziot_identity_common_http::ApiVersion::V2020_09_01,
         connector,
+        0,
     );
 
     match client.reprovision().await {

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -29,7 +29,10 @@ pub use proxy::{get_proxy_uri, MaybeProxyConnector};
 #[cfg(feature = "tokio1")]
 mod request;
 #[cfg(feature = "tokio1")]
-pub use request::{request, request_no_content};
+pub use request::{
+    request, request_no_content, request_no_content_with_retry, request_with_headers,
+    request_with_headers_no_content, request_with_retry,
+};
 
 pub mod server;
 

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::convert::TryFrom;
+use std::str::FromStr;
+
 pub async fn request<TRequest, TResponse>(
     client: &hyper::Client<super::Connector, hyper::Body>,
     method: http::Method,
@@ -10,82 +13,38 @@ where
     TRequest: serde::Serialize,
     TResponse: serde::de::DeserializeOwned,
 {
-    let req = hyper::Request::builder().method(method).uri(uri);
-    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let req = if let Some(body) = body {
-        let body = serde_json::to_vec(body)
-            .expect("serializing request body to JSON cannot fail")
-            .into();
-        req.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        req.body(Default::default())
-    };
-    let req = req.expect("cannot fail to create hyper request");
+    request_internal(client, method, uri, None, None, body, true).await
+}
 
-    let res = client
-        .request(req)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+pub async fn request_with_retry<TRequest, TResponse>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: &str,
+    body: Option<&TRequest>,
+    max_retries: u32,
+) -> std::io::Result<TResponse>
+where
+    TRequest: serde::Serialize,
+    TResponse: serde::de::DeserializeOwned,
+{
+    request_internal(client, method, uri, None, Some(max_retries), body, true).await
+}
 
-    let (
-        http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
-        },
-        body,
-    ) = res.into_parts();
-
-    let mut is_json = false;
-    for (header_name, header_value) in headers {
-        if header_name == Some(hyper::header::CONTENT_TYPE) {
-            let value = header_value
-                .to_str()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            if value == "application/json" {
-                is_json = true;
-            }
-        }
-    }
-
-    if !is_json {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "malformed HTTP response",
-        ));
-    }
-
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-
-    let res: TResponse = match res_status_code {
-        hyper::StatusCode::OK | hyper::StatusCode::CREATED => {
-            let res = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            res
-        }
-
-        res_status_code
-            if res_status_code.is_client_error() || res_status_code.is_server_error() =>
-        {
-            let res: super::ErrorBody<'static> = serde_json::from_slice(&body)
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, res.message));
-        }
-
-        _ => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "malformed HTTP response",
-            ))
-        }
-    };
-    Ok(res)
+pub async fn request_with_headers<TUri, TRequest, TResponse>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: TUri,
+    headers: Option<&[(&str, &str)]>,
+    body: Option<&TRequest>,
+) -> std::io::Result<TResponse>
+where
+    hyper::Uri: TryFrom<TUri>,
+    <hyper::Uri as TryFrom<TUri>>::Error: Into<http::Error>,
+    TRequest: serde::Serialize,
+    TResponse: serde::de::DeserializeOwned,
+    TUri: Clone,
+{
+    request_internal(client, method, uri, headers, None, body, true).await
 }
 
 pub async fn request_no_content<TRequest>(
@@ -97,73 +56,200 @@ pub async fn request_no_content<TRequest>(
 where
     TRequest: serde::Serialize,
 {
-    let req = hyper::Request::builder().method(method).uri(uri);
-    // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
-    //
-    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
-    #[allow(clippy::option_if_let_else)]
-    let req = if let Some(body) = body {
-        let body = serde_json::to_vec(body)
-            .expect("serializing request body to JSON cannot fail")
-            .into();
-        req.header(hyper::header::CONTENT_TYPE, "application/json")
-            .body(body)
-    } else {
-        req.body(Default::default())
-    };
-    let req = req.expect("cannot fail to create hyper request");
+    request_internal::<_, _, ()>(client, method, uri, None, None, body, false).await
+}
 
-    let res = client
-        .request(req)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+pub async fn request_no_content_with_retry<TRequest>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: &str,
+    body: Option<&TRequest>,
+    max_retries: u32,
+) -> std::io::Result<()>
+where
+    TRequest: serde::Serialize,
+{
+    request_internal::<_, _, ()>(client, method, uri, None, Some(max_retries), body, false).await
+}
 
-    let (
-        http::response::Parts {
-            status: res_status_code,
-            headers,
-            ..
-        },
-        body,
-    ) = res.into_parts();
+pub async fn request_with_headers_no_content<TUri, TRequest>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: TUri,
+    headers: Option<&[(&str, &str)]>,
+    body: Option<&TRequest>,
+) -> std::io::Result<()>
+where
+    hyper::Uri: TryFrom<TUri>,
+    <hyper::Uri as TryFrom<TUri>>::Error: Into<http::Error>,
+    TRequest: serde::Serialize,
+    TUri: Clone,
+{
+    request_internal::<_, _, ()>(client, method, uri, headers, None, body, false).await
+}
 
-    let body = hyper::body::to_bytes(body)
-        .await
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+// Note that if has_response is false, TResponse must be (). This is a workaround until generic specialization is stable.
+async fn request_internal<TUri, TRequest, TResponse>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: TUri,
+    headers: Option<&[(&str, &str)]>,
+    max_retries: Option<u32>,
+    body: Option<&TRequest>,
+    has_response: bool,
+) -> std::io::Result<TResponse>
+where
+    hyper::Uri: TryFrom<TUri>,
+    <hyper::Uri as TryFrom<TUri>>::Error: Into<http::Error>,
+    TRequest: serde::Serialize,
+    TResponse: serde::de::DeserializeOwned,
+    TUri: Clone,
+{
+    let (res_status_code, headers, body) =
+        make_call(client, method, uri, headers, max_retries.unwrap_or(0), body).await?;
 
     match res_status_code {
-        hyper::StatusCode::NO_CONTENT => Ok(()),
+        // Successful call with response
+        res_status_code if has_response && res_status_code.is_success() => {
+            validate_json(headers)?;
 
+            let res = serde_json::from_slice(&body)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            Ok(res)
+        }
+
+        // Successful call with no response
+        res_status_code
+            if res_status_code.is_success()
+                || res_status_code == hyper::StatusCode::NOT_MODIFIED =>
+        {
+            let res = serde_json::from_slice(b"null").expect("Deserializing null type cannot fail");
+            Ok(res)
+        }
+
+        // Expected error
         res_status_code
             if res_status_code.is_client_error() || res_status_code.is_server_error() =>
         {
-            let mut is_json = false;
-            for (header_name, header_value) in headers {
-                if header_name == Some(hyper::header::CONTENT_TYPE) {
-                    let value = header_value
-                        .to_str()
-                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
-                    if value == "application/json" {
-                        is_json = true;
-                    }
-                }
-            }
-
-            if !is_json {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "malformed HTTP response",
-                ));
-            }
+            validate_json(headers)?;
 
             let res: super::ErrorBody<'static> = serde_json::from_slice(&body)
                 .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
             Err(std::io::Error::new(std::io::ErrorKind::Other, res.message))
         }
 
+        // Unknown error
         _ => Err(std::io::Error::new(
             std::io::ErrorKind::Other,
             "malformed HTTP response",
         )),
+    }
+}
+
+// Note max_retries only retries ConnectionClosed. ConnectionClosed represents too many requests for IS.
+async fn make_call<TUri, TRequest>(
+    client: &hyper::Client<super::Connector, hyper::Body>,
+    method: http::Method,
+    uri: TUri,
+    headers: Option<&[(&str, &str)]>,
+    max_retries: u32,
+    body: Option<&TRequest>,
+) -> std::io::Result<(hyper::StatusCode, hyper::HeaderMap, hyper::body::Bytes)>
+where
+    hyper::Uri: TryFrom<TUri>,
+    <hyper::Uri as TryFrom<TUri>>::Error: Into<http::Error>,
+    TRequest: serde::Serialize,
+    TUri: Clone,
+{
+    let mut retry_num = 0;
+    loop {
+        let mut req = hyper::Request::builder()
+            .method(method.clone())
+            .uri(uri.clone());
+
+        if let Some(headers) = headers {
+            if let Some(headers_map) = req.headers_mut() {
+                for (key, value) in headers {
+                    headers_map.insert(
+                        headers::HeaderName::from_str(key)
+                            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
+                        headers::HeaderValue::from_str(value)
+                            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?,
+                    );
+                }
+            }
+        }
+
+        // `req` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
+        //
+        // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
+        #[allow(clippy::option_if_let_else)]
+        let req = if let Some(body) = body {
+            let body = serde_json::to_vec(body)
+                .expect("serializing request body to JSON cannot fail")
+                .into();
+
+            req.header(hyper::header::CONTENT_TYPE, "application/json")
+                .body(body)
+        } else {
+            req.body(Default::default())
+        };
+        let req = req.expect("cannot fail to create hyper request");
+
+        let response = client.request(req).await;
+        match response {
+            Ok(response) => {
+                let (
+                    http::response::Parts {
+                        status, headers, ..
+                    },
+                    body,
+                ) = response.into_parts();
+
+                let body = hyper::body::to_bytes(body)
+                    .await
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+
+                return Ok((status, headers, body));
+            }
+            Err(err) if err.is_closed() && retry_num < max_retries => {
+                log::warn!(
+                    "Connection Closed. Retrying (attempt {} of {}).",
+                    retry_num + 1,
+                    max_retries + 1,
+                );
+
+                retry_num += 1;
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                continue;
+            }
+            Err(err) => return Err(std::io::Error::new(std::io::ErrorKind::Other, err)),
+        }
+    }
+}
+
+fn validate_json(headers: hyper::HeaderMap) -> std::io::Result<()> {
+    for (header_name, header_value) in headers {
+        if header_name == Some(hyper::header::CONTENT_TYPE) {
+            let value = header_value
+                .to_str()
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            if value == "application/json" {
+                return Ok(());
+            }
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "malformed HTTP response, expected content type application/json",
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn unit_type_deserializes() {
+        serde_json::from_slice::<()>(b"null").expect("Deserializing null type cannot fail");
     }
 }

--- a/identity/aziot-identity-client-async/src/lib.rs
+++ b/identity/aziot-identity-client-async/src/lib.rs
@@ -8,15 +8,21 @@
 pub struct Client {
     api_version: aziot_identity_common_http::ApiVersion,
     inner: hyper::Client<http_common::Connector, hyper::Body>,
+    max_retries: u32,
 }
 
 impl Client {
     pub fn new(
         api_version: aziot_identity_common_http::ApiVersion,
         connector: http_common::Connector,
+        max_retries: u32,
     ) -> Self {
         let inner = hyper::Client::builder().build(connector);
-        Client { api_version, inner }
+        Client {
+            api_version,
+            inner,
+            max_retries,
+        }
     }
 
     pub async fn reprovision(&self) -> Result<(), std::io::Error> {
@@ -24,7 +30,7 @@ impl Client {
             id_type: "aziot".to_owned(),
         };
 
-        http_common::request_no_content(
+        http_common::request_no_content_with_retry(
             &self.inner,
             http::Method::POST,
             &format!(
@@ -32,6 +38,7 @@ impl Client {
                 self.api_version
             ),
             Some(&body),
+            self.max_retries,
         )
         .await?;
 

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -117,6 +117,7 @@ impl Api {
             let key_client = aziot_key_client_async::Client::new(
                 aziot_key_common_http::ApiVersion::V2020_09_01,
                 key_service_connector.clone(),
+                1,
             );
             let key_client = Arc::new(key_client);
             key_client
@@ -139,6 +140,7 @@ impl Api {
             let cert_client = aziot_cert_client_async::Client::new(
                 aziot_cert_common_http::ApiVersion::V2020_09_01,
                 cert_service_connector,
+                1,
             );
             let cert_client = Arc::new(cert_client);
             cert_client

--- a/iotedged/src/main.rs
+++ b/iotedged/src/main.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<(), Error> {
         let key_client = aziot_key_client_async::Client::new(
             aziot_key_common_http::ApiVersion::V2020_09_01,
             key_connector,
+            1,
         );
         let key_client = std::sync::Arc::new(key_client);
         key_client
@@ -50,6 +51,7 @@ async fn main() -> Result<(), Error> {
         let cert_client = aziot_cert_client_async::Client::new(
             aziot_cert_common_http::ApiVersion::V2020_09_01,
             cert_connector,
+            1,
         );
         let cert_client = std::sync::Arc::new(cert_client);
         cert_client

--- a/key/aziot-key-client-async/src/lib.rs
+++ b/key/aziot-key-client-async/src/lib.rs
@@ -8,15 +8,21 @@
 pub struct Client {
     api_version: aziot_key_common_http::ApiVersion,
     inner: hyper::Client<http_common::Connector, hyper::Body>,
+    max_retries: u32,
 }
 
 impl Client {
     pub fn new(
         api_version: aziot_key_common_http::ApiVersion,
         connector: http_common::Connector,
+        max_retries: u32,
     ) -> Self {
         let inner = hyper::Client::builder().build(connector);
-        Client { api_version, inner }
+        Client {
+            api_version,
+            inner,
+            max_retries,
+        }
     }
 
     pub async fn create_key_pair_if_not_exists(
@@ -30,18 +36,19 @@ impl Client {
         };
 
         let res: aziot_key_common_http::create_key_pair_if_not_exists::Response =
-            http_common::request(
+            http_common::request_with_retry(
                 &self.inner,
                 http::Method::POST,
                 &format!("http://keyd.sock/keypair?api-version={}", self.api_version),
                 Some(&body),
+                self.max_retries,
             )
             .await?;
         Ok(res.handle)
     }
 
     pub async fn load_key_pair(&self, id: &str) -> std::io::Result<aziot_key_common::KeyHandle> {
-        let res: aziot_key_common_http::load::Response = http_common::request::<(), _>(
+        let res: aziot_key_common_http::load::Response = http_common::request_with_retry::<(), _>(
             &self.inner,
             http::Method::GET,
             &format!(
@@ -53,6 +60,7 @@ impl Client {
                 self.api_version,
             ),
             None,
+            self.max_retries,
         )
         .await?;
         Ok(res.handle)
@@ -68,7 +76,7 @@ impl Client {
         };
 
         let res: aziot_key_common_http::get_key_pair_public_parameter::Response =
-            http_common::request(
+            http_common::request_with_retry(
                 &self.inner,
                 http::Method::POST,
                 &format!(
@@ -80,6 +88,7 @@ impl Client {
                     self.api_version,
                 ),
                 Some(&body),
+                self.max_retries,
             )
             .await?;
         Ok(res.value)
@@ -108,18 +117,20 @@ impl Client {
             }
         };
 
-        let res: aziot_key_common_http::create_key_if_not_exists::Response = http_common::request(
-            &self.inner,
-            http::Method::POST,
-            &format!("http://keyd.sock/key?api-version={}", self.api_version),
-            Some(&body),
-        )
-        .await?;
+        let res: aziot_key_common_http::create_key_if_not_exists::Response =
+            http_common::request_with_retry(
+                &self.inner,
+                http::Method::POST,
+                &format!("http://keyd.sock/key?api-version={}", self.api_version),
+                Some(&body),
+                self.max_retries,
+            )
+            .await?;
         Ok(res.handle)
     }
 
     pub async fn load_key(&self, id: &str) -> std::io::Result<aziot_key_common::KeyHandle> {
-        let res: aziot_key_common_http::load::Response = http_common::request::<(), _>(
+        let res: aziot_key_common_http::load::Response = http_common::request_with_retry::<(), _>(
             &self.inner,
             http::Method::GET,
             &format!(
@@ -131,6 +142,7 @@ impl Client {
                 self.api_version,
             ),
             None,
+            self.max_retries,
         )
         .await?;
         Ok(res.handle)
@@ -146,16 +158,18 @@ impl Client {
             derivation_data: http_common::ByteString(derivation_data.to_owned()),
         };
 
-        let res: aziot_key_common_http::create_derived_key::Response = http_common::request(
-            &self.inner,
-            http::Method::POST,
-            &format!(
-                "http://keyd.sock/derivedkey?api-version={}",
-                self.api_version
-            ),
-            Some(&body),
-        )
-        .await?;
+        let res: aziot_key_common_http::create_derived_key::Response =
+            http_common::request_with_retry(
+                &self.inner,
+                http::Method::POST,
+                &format!(
+                    "http://keyd.sock/derivedkey?api-version={}",
+                    self.api_version
+                ),
+                Some(&body),
+                self.max_retries,
+            )
+            .await?;
         Ok(res.handle)
     }
 
@@ -167,16 +181,18 @@ impl Client {
             handle: handle.clone(),
         };
 
-        let res: aziot_key_common_http::export_derived_key::Response = http_common::request(
-            &self.inner,
-            http::Method::POST,
-            &format!(
-                "http://keyd.sock/derivedkey/export?api-version={}",
-                self.api_version
-            ),
-            Some(&body),
-        )
-        .await?;
+        let res: aziot_key_common_http::export_derived_key::Response =
+            http_common::request_with_retry(
+                &self.inner,
+                http::Method::POST,
+                &format!(
+                    "http://keyd.sock/derivedkey/export?api-version={}",
+                    self.api_version
+                ),
+                Some(&body),
+                self.max_retries,
+            )
+            .await?;
         Ok(res.key.0)
     }
 
@@ -203,11 +219,12 @@ impl Client {
             },
         };
 
-        let res: aziot_key_common_http::sign::Response = http_common::request(
+        let res: aziot_key_common_http::sign::Response = http_common::request_with_retry(
             &self.inner,
             http::Method::POST,
             &format!("http://keyd.sock/sign?api-version={}", self.api_version),
             Some(&body),
+            self.max_retries,
         )
         .await?;
         let signature = res.signature.0;
@@ -241,11 +258,12 @@ impl Client {
             plaintext: http_common::ByteString(plaintext.to_owned()),
         };
 
-        let res: aziot_key_common_http::encrypt::Response = http_common::request(
+        let res: aziot_key_common_http::encrypt::Response = http_common::request_with_retry(
             &self.inner,
             http::Method::POST,
             &format!("http://keyd.sock/encrypt?api-version={}", self.api_version),
             Some(&body),
+            self.max_retries,
         )
         .await?;
         let ciphertext = res.ciphertext.0;
@@ -279,11 +297,12 @@ impl Client {
             ciphertext: http_common::ByteString(ciphertext.to_owned()),
         };
 
-        let res: aziot_key_common_http::decrypt::Response = http_common::request(
+        let res: aziot_key_common_http::decrypt::Response = http_common::request_with_retry(
             &self.inner,
             http::Method::POST,
             &format!("http://keyd.sock/decrypt?api-version={}", self.api_version),
             Some(&body),
+            self.max_retries,
         )
         .await?;
         let plaintext = res.plaintext.0;


### PR DESCRIPTION
This adds retry logic so that edged will retry some requests. A follow-up pr for the iotedge repo will make edged use the new functionality.