### PR TITLE
Subject DN configuration backport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
 name = "aziot-certd"
 version = "0.1.0"
 dependencies = [
+ "async-recursion",
  "async-trait",
  "aziot-cert-common-http",
  "aziot-certd-config",
@@ -149,6 +150,7 @@ dependencies = [
  "libc",
  "openssl",
  "serde",
+ "serde_with",
  "toml",
  "url",
 ]
@@ -758,7 +760,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -869,6 +871,41 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
+]
+
+[[package]]
+name = "darling"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1343,6 +1380,12 @@ dependencies = [
  "tokio-openssl",
  "tower-service",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2049,6 +2092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2147,29 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edeeaecd5445109b937a3a335dc52780ca7779c4b4b7374cc6340dedfe44cfca"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2153,6 +2225,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"

--- a/aziotctl/Cargo.toml
+++ b/aziotctl/Cargo.toml
@@ -44,7 +44,7 @@ aziot-keys-common = { path = "../key/aziot-keys-common" }
 aziot-tpmd-config = { path = "../tpm/aziot-tpmd-config" }
 aziotctl-common = { path = "./aziotctl-common" }
 config-common = { path = "../config-common" }
-http-common = { path = "../http-common", features = ["tokio1"] }
+http-common = { path = "../http-common" }
 mini-sntp = { path = "../mini-sntp" }
 openssl2 = { path = "../openssl2" }
 openssl-sys2 = { path = "../openssl-sys2" }

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -335,11 +335,14 @@ pub fn run(
                     aziotcs_keys.keys.push(super::EST_ID_ID.to_owned());
 
                     Some(aziot_certd_config::EstAuthX509 {
-                        identity: (super::EST_ID_ID.to_owned(), super::EST_ID_ID.to_owned()),
-                        bootstrap_identity: Some((
-                            super::EST_BOOTSTRAP_ID.to_owned(),
-                            super::EST_BOOTSTRAP_ID.to_owned(),
-                        )),
+                        identity: aziot_certd_config::CertificateWithPrivateKey {
+                            cert: super::EST_ID_ID.to_owned(),
+                            pk: super::EST_ID_ID.to_owned(),
+                        },
+                        bootstrap_identity: Some(aziot_certd_config::CertificateWithPrivateKey {
+                            cert: super::EST_BOOTSTRAP_ID.to_owned(),
+                            pk: super::EST_BOOTSTRAP_ID.to_owned(),
+                        }),
                     })
                 }
 
@@ -356,7 +359,10 @@ pub fn run(
                     aziotcs_keys.keys.push(super::EST_ID_ID.to_owned());
 
                     Some(aziot_certd_config::EstAuthX509 {
-                        identity: (super::EST_ID_ID.to_owned(), super::EST_ID_ID.to_owned()),
+                        identity: aziot_certd_config::CertificateWithPrivateKey {
+                            cert: super::EST_ID_ID.to_owned(),
+                            pk: super::EST_ID_ID.to_owned(),
+                        },
                         bootstrap_identity: None,
                     })
                 }
@@ -376,8 +382,8 @@ pub fn run(
                 .collect();
 
             Some(aziot_certd_config::Est {
-                auth,
                 trusted_certs,
+                auth,
                 urls,
             })
         } else {
@@ -391,7 +397,7 @@ pub fn run(
                 cert_issuance_certs
                     .insert(super::LOCAL_CA.to_owned(), into_cert_options(cert, None));
 
-                Some(aziot_certd_config::LocalCa {
+                Some(aziot_certd_config::CertificateWithPrivateKey {
                     cert: super::LOCAL_CA.to_owned(),
                     pk: super::LOCAL_CA.to_owned(),
                 })
@@ -406,7 +412,7 @@ pub fn run(
                 preloaded_keys.insert(super::LOCAL_CA.to_owned(), pk);
                 aziotcs_keys.keys.push(super::LOCAL_CA.to_owned());
 
-                Some(aziot_certd_config::LocalCa {
+                Some(aziot_certd_config::CertificateWithPrivateKey {
                     cert: super::LOCAL_CA.to_owned(),
                     pk: super::LOCAL_CA.to_owned(),
                 })
@@ -494,7 +500,9 @@ fn into_cert_options(
     };
 
     aziot_certd_config::CertIssuanceOptions {
-        common_name: opts.common_name,
+        subject: opts
+            .common_name
+            .map(aziot_certd_config::CertSubject::CommonName),
         expiry_days: opts.expiry_days,
         method,
     }
@@ -531,7 +539,10 @@ pub fn set_est_auth(
                     );
                     aziotcs_keys.keys.push(bootstrap_cert_id.to_owned());
 
-                    Some((bootstrap_cert_id.to_owned(), bootstrap_cert_id))
+                    Some(aziot_certd_config::CertificateWithPrivateKey {
+                        cert: bootstrap_cert_id.clone(),
+                        pk: bootstrap_cert_id,
+                    })
                 }
 
                 super_config::EstAuthX509::Identity {
@@ -551,7 +562,10 @@ pub fn set_est_auth(
             aziotcs_keys.keys.push(identity_cert_id.to_owned());
 
             aziot_certd_config::EstAuthX509 {
-                identity: (identity_cert_id.to_owned(), identity_cert_id),
+                identity: aziot_certd_config::CertificateWithPrivateKey {
+                    cert: identity_cert_id.clone(),
+                    pk: identity_cert_id,
+                },
                 bootstrap_identity,
             }
         });

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -500,11 +500,9 @@ fn into_cert_options(
     };
 
     aziot_certd_config::CertIssuanceOptions {
-        subject: opts
-            .common_name
-            .map(aziot_certd_config::CertSubject::CommonName),
-        expiry_days: opts.expiry_days,
         method,
+        expiry_days: opts.expiry_days,
+        subject: opts.subject,
     }
 }
 

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -227,7 +227,8 @@ pub enum X509Identity {
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct CertIssuanceOptions {
-    pub common_name: Option<String>,
+    #[serde(flatten)]
+    pub method: CertIssuanceMethod,
 
     #[serde(
         default,
@@ -236,7 +237,7 @@ pub struct CertIssuanceOptions {
     pub expiry_days: Option<u32>,
 
     #[serde(flatten)]
-    pub method: CertIssuanceMethod,
+    pub subject: Option<aziot_certd_config::CertSubject>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -151,8 +151,8 @@ pub enum DpsAttestationMethod {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct CertIssuance {
-    pub est: Option<Est>,
     pub local_ca: Option<LocalCa>,
+    pub est: Option<Est>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
@@ -1,12 +1,12 @@
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.est]
+trusted_certs = ["est-server-ca-1"]
 username = "estuser"
 password = "estpwd"
 identity_cert = "est-id"
 identity_pk = "est-id"
 bootstrap_identity_cert = "est-bootstrap-id"
 bootstrap_identity_pk = "est-bootstrap-id"
-trusted_certs = ["est-server-ca-1"]
 
 [cert_issuance.est.urls]
 default = "https://example.org/.well-known/est"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
@@ -12,8 +12,8 @@ bootstrap_identity_pk = "est-bootstrap-id"
 default = "https://example.org/.well-known/est"
 
 [cert_issuance.device-id]
-common_name = "my-device"
 method = "est"
+common_name = "my-device"
 
 [preloaded_certs]
 est-bootstrap-id = "file:///var/secrets/est-bootstrap-id.pem"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-custom-bootstrap/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-custom-bootstrap/certd.toml
@@ -1,12 +1,12 @@
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.est]
+trusted_certs = ["est-server-ca-1"]
 username = "estuser"
 password = "estpwd"
 identity_cert = "est-id"
 identity_pk = "est-id"
 bootstrap_identity_cert = "est-bootstrap-id"
 bootstrap_identity_pk = "est-bootstrap-id"
-trusted_certs = ["est-server-ca-1"]
 
 [cert_issuance.est.urls]
 default = "https://example.org/.well-known/est"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/certd.toml
@@ -18,7 +18,11 @@ identity_cert = "est-id-device-id"
 identity_pk = "est-id-device-id"
 bootstrap_identity_cert = "est-bootstrap-id-device-id"
 bootstrap_identity_pk = "est-bootstrap-id-device-id"
-common_name = "my-device"
+
+[cert_issuance.device-id.subject]
+CN = "my-device"
+L = "AQ"
+ST = "Antarctica"
 
 [preloaded_certs]
 est-bootstrap-id = "file:///var/secrets/est-bootstrap-id.pem"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/config.toml
@@ -1,0 +1,33 @@
+[provisioning]
+source = "dps"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
+id_scope = "0ab1234C5D6"
+
+[provisioning.attestation]
+method = "x509"
+registration_id = "my-device"
+
+[provisioning.attestation.identity_cert]
+method = "est"
+url = "https://example.org/.well-known/custom/est"
+bootstrap_identity_cert = "file:///var/secrets/est-custom-bootstrap-id.pem"
+bootstrap_identity_pk = "pkcs11:slot-id=0;object=est-custom-bootstrap-id?pin-value=1234"
+subject = { L = "AQ", ST = "Antarctica", CN = "my-device" }
+
+[aziot_keys]
+pkcs11_lib_path = "/usr/lib/libmypkcs11.so"
+pkcs11_base_slot = "pkcs11:slot-id=0?pin-value=1234"
+
+[cert_issuance.est]
+trusted_certs = [
+    "file:///var/secrets/est-id-ca.pem",
+]
+
+[cert_issuance.est.auth]
+username = "estuser"
+password = "estpwd"
+bootstrap_identity_cert = "file:///var/secrets/est-bootstrap-id.pem"
+bootstrap_identity_pk = "pkcs11:slot-id=0;object=est-bootstrap-id?pin-value=1234"
+
+[cert_issuance.est.urls]
+default = "https://example.org/.well-known/est"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/identityd.toml
@@ -1,0 +1,13 @@
+hostname = "my-device"
+homedir = "/var/lib/aziot/identityd"
+
+[provisioning]
+source = "dps"
+global_endpoint = "https://global.azure-devices-provisioning.net/"
+scope_id = "0ab1234C5D6"
+
+[provisioning.attestation]
+method = "x509"
+registration_id = "my-device"
+identity_cert = "device-id"
+identity_pk = "device-id"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/keyd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/keyd.toml
@@ -1,0 +1,16 @@
+[aziot_keys]
+homedir_path = "/var/lib/aziot/keyd"
+pkcs11_base_slot = "pkcs11:slot-id=0?pin-value=1234"
+pkcs11_lib_path = "/usr/lib/libmypkcs11.so"
+
+[preloaded_keys]
+est-bootstrap-id = "pkcs11:slot-id=0;object=est%2Dbootstrap%2Did?pin-value=1234"
+est-bootstrap-id-device-id = "pkcs11:slot-id=0;object=est%2Dcustom%2Dbootstrap%2Did?pin-value=1234"
+
+[[principal]]
+uid = 5556
+keys = ["aziot_identityd_master_id", "device-id"]
+
+[[principal]]
+uid = 5555
+keys = ["est-bootstrap-id-device-id", "est-id-device-id", "est-bootstrap-id", "est-id"]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/certd.toml
@@ -10,8 +10,8 @@ identity_pk = "est-id"
 default = "https://example.org/.well-known/est"
 
 [cert_issuance.device-id]
-common_name = "my-device"
 method = "est"
+common_name = "my-device"
 
 [preloaded_certs]
 est-id = "file:///var/secrets/est-id.pem"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/certd.toml
@@ -1,10 +1,10 @@
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.est]
+trusted_certs = ["est-server-ca-1"]
 username = "estuser"
 password = "estpwd"
 identity_cert = "est-id"
 identity_pk = "est-id"
-trusted_certs = ["est-server-ca-1"]
 
 [cert_issuance.est.urls]
 default = "https://example.org/.well-known/est"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/certd.toml
@@ -4,8 +4,8 @@ cert = "local-ca"
 pk = "local-ca"
 
 [cert_issuance.device-id]
-common_name = "my-device"
 method = "local_ca"
+common_name = "my-device"
 
 [preloaded_certs]
 local-ca = "file:///var/secrets/local-ca.pem"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/certd.toml
@@ -7,7 +7,11 @@ password = "password"
 identity_cert = "est-id-device-id"
 identity_pk = "est-id-device-id"
 expiry_days = 365
-common_name = "my-device"
+
+[cert_issuance.device-id.subject]
+CN = "my-device"
+L = "AQ"
+ST = "Antarctica"
 
 [preloaded_certs]
 est-id-device-id = "file:///var/secrets/est-id.pem"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/config.toml
@@ -1,0 +1,17 @@
+[provisioning]
+source = "manual"
+iothub_hostname = "example.azure-devices.net"
+device_id = "my-device"
+
+[provisioning.authentication]
+method = "x509"
+
+[provisioning.authentication.identity_cert]
+method = "est"
+subject = { L = "AQ", ST = "Antarctica", CN = "my-device" }
+expiry_days = 365
+url = "https://example.org/.well-known/est"
+username = "user"
+password = "password"
+identity_cert = "file:///var/secrets/est-id.pem"
+identity_pk = "pkcs11:slot-id=0;object=est-id?pin-value=1234"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/identityd.toml
@@ -1,0 +1,12 @@
+hostname = "my-device"
+homedir = "/var/lib/aziot/identityd"
+
+[provisioning]
+source = "manual"
+iothub_hostname = "example.azure-devices.net"
+device_id = "my-device"
+
+[provisioning.authentication]
+method = "x509"
+identity_cert = "device-id"
+identity_pk = "device-id"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/keyd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/keyd.toml
@@ -1,0 +1,13 @@
+[aziot_keys]
+homedir_path = "/var/lib/aziot/keyd"
+
+[preloaded_keys]
+est-id-device-id = "pkcs11:slot-id=0;object=est%2Did?pin-value=1234"
+
+[[principal]]
+uid = 5556
+keys = ["aziot_identityd_master_id", "device-id"]
+
+[[principal]]
+uid = 5555
+keys = ["est-id-device-id"]

--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -71,10 +71,15 @@
 # [provisioning.authentication]
 # method = "x509"
 #
+## identity certificate
 # identity_cert = "file:///var/secrets/device-id.pem"                # file URI, or...
-# identity_cert = { method = "est", common_name = "my-device" }      # dynamically issued via EST, or...
-# identity_cert = { method = "local_ca", common_name = "my-device" } # dynamically issued by a local CA
-#
+# [provisioning.authentication.identity_cert]                        # dynamically issued via...
+# method = "est"                                                     # - EST
+# method = "local_ca"                                                # - a local CA
+# common_name = "my-device"                                          # with the given common name, or...
+# subject = { L = "AQ", ST = "Antarctica", CN = "my-device" }        # with the given DN fields
+# 
+## identity key
 # identity_pk = "file:///var/secrets/device-id.key.pem"              # file URI, or...
 # identity_pk = "pkcs11:slot-id=0;object=device%20id?pin-value=1234" # PKCS#11 URI
 

--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -78,7 +78,7 @@
 # method = "local_ca"                                                # - a local CA
 # common_name = "my-device"                                          # with the given common name, or...
 # subject = { L = "AQ", ST = "Antarctica", CN = "my-device" }        # with the given DN fields
-# 
+#
 ## identity key
 # identity_pk = "file:///var/secrets/device-id.key.pem"              # file URI, or...
 # identity_pk = "pkcs11:slot-id=0;object=device%20id?pin-value=1234" # PKCS#11 URI
@@ -109,10 +109,15 @@
 # method = "x509"
 # registration_id = "my-device"
 #
+## identity certificate
 # identity_cert = "file:///var/secrets/device-id.pem"                # file URI, or...
-# identity_cert = { method = "est", common_name = "my-device" }      # dynamically issued via EST, or...
-# identity_cert = { method = "local_ca", common_name = "my-device" } # dynamically issued by a local CA
+# [provisioning.authentication.identity_cert]                        # dynamically issued via...
+# method = "est"                                                     # - EST
+# method = "local_ca"                                                # - a local CA
+# common_name = "my-device"                                          # with the given common name, or...
+# subject = { L = "AQ", ST = "Antarctica", CN = "my-device" }        # with the given DN fields
 #
+## identity key
 # identity_pk = "file:///var/secrets/device-id.key.pem"              # file URI, or...
 # identity_pk = "pkcs11:slot-id=0;object=device%20id?pin-value=1234" # PKCS#11 URI
 

--- a/aziotctl/src/internal/check/checks/cert_expiry.rs
+++ b/aziotctl/src/internal/check/checks/cert_expiry.rs
@@ -122,10 +122,12 @@ impl EstIdentityBootstrapCerts {
             .and_then(|est| est.auth.x509.as_ref())
             .map(|x509| {
                 (
-                    (&x509.identity.0, "x509 identity"),
-                    x509.bootstrap_identity
-                        .as_ref()
-                        .map(|(cert, _)| (cert, "x509 bootstrap")),
+                    (&x509.identity.cert, "x509 identity"),
+                    x509.bootstrap_identity.as_ref().map(
+                        |aziot_certd_config::CertificateWithPrivateKey { cert, .. }| {
+                            (cert, "x509 bootstrap")
+                        },
+                    ),
                 )
             });
 

--- a/aziotd/Cargo.toml
+++ b/aziotd/Cargo.toml
@@ -17,5 +17,5 @@ aziot-identityd = { path = "../identity/aziot-identityd" }
 aziot-keyd = { path = "../key/aziot-keyd" }
 aziot-tpmd = { path = "../tpm/aziot-tpmd" }
 config-common = { path = "../config-common" }
-http-common = { path = "../http-common", features = ["tokio1"] }
+http-common = { path = "../http-common" }
 logger = { path = "../logger" }

--- a/cert/aziot-cert-client-async/Cargo.toml
+++ b/cert/aziot-cert-client-async/Cargo.toml
@@ -11,4 +11,4 @@ percent-encoding = "2"
 
 aziot-cert-common-http = { path = "../aziot-cert-common-http" }
 aziot-key-common = { path = "../../key/aziot-key-common" }
-http-common = { path = "../../http-common" }
+http-common = { path = "../../http-common", features = ["tokio1"] }

--- a/cert/aziot-cert-client-async/Cargo.toml
+++ b/cert/aziot-cert-client-async/Cargo.toml
@@ -11,4 +11,4 @@ percent-encoding = "2"
 
 aziot-cert-common-http = { path = "../aziot-cert-common-http" }
 aziot-key-common = { path = "../../key/aziot-key-common" }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }

--- a/cert/aziot-certd-config/Cargo.toml
+++ b/cert/aziot-certd-config/Cargo.toml
@@ -10,6 +10,7 @@ hex = "0.4"
 libc = "0.2"
 openssl = "0.10"
 serde = { version = "1", features = ["derive"] }
+serde_with = "1"
 url = { version = "2", features = ["serde"] }
 
 http-common = { path = "../../http-common" }

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -165,17 +165,17 @@ pub struct CertificateWithPrivateKey {
 /// Details for issuing a single cert.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct CertIssuanceOptions {
+    /// The method used to issue a certificate.
     #[serde(flatten)]
-    pub subject: Option<CertSubject>,
+    pub method: CertIssuanceMethod,
 
     /// Number of days between cert issuance and expiry. Applies to local_ca and self_signed issuance methods.
     /// If not provided, defaults to 30.
     #[serde(default, deserialize_with = "deserialize_expiry_days")]
     pub expiry_days: Option<u32>,
 
-    /// The method used to issue a certificate.
     #[serde(flatten)]
-    pub method: CertIssuanceMethod,
+    pub subject: Option<CertSubject>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -282,7 +282,6 @@ module-server = { method = "local_ca" }
 
 [cert_issuance.device-id]
 method = "est"
-expiry_days = 365
 url = "https://estendpoint.com/.well-known/est/device-id/"
 username = "username"
 password = "password"
@@ -290,11 +289,8 @@ identity_cert = "device-id"
 identity_pk = "device-id"
 bootstrap_identity_cert = "bootstrap"
 bootstrap_identity_pk = "bootstrap"
-
-[cert_issuance.device-id.subject]
-L = "AQ"
-ST = "Antarctica"
-CN = "test-device"
+expiry_days = 365
+subject = { "L" = "AQ", "ST" = "Antarctica", "CN" = "test-device" }
 
 [cert_issuance.est]
 identity_cert = "est-id"
@@ -369,8 +365,8 @@ certs = ["test"]
                                     url: None,
                                     auth: None
                                 },
-                                subject: Some(CertSubject::CommonName("custom-name".to_owned())),
                                 expiry_days: None,
+                                subject: Some(CertSubject::CommonName("custom-name".to_owned())),
                             }
                         ),
                         (
@@ -399,6 +395,7 @@ certs = ["test"]
                                         })
                                     })
                                 },
+                                expiry_days: Some(365),
                                 subject: Some(CertSubject::Subject(
                                     vec![
                                         ("L".to_owned(), "AQ".to_owned()),
@@ -408,23 +405,22 @@ certs = ["test"]
                                     .into_iter()
                                     .collect()
                                 )),
-                                expiry_days: Some(365)
                             }
                         ),
                         (
                             "module-id",
                             CertIssuanceOptions {
                                 method: CertIssuanceMethod::SelfSigned,
-                                subject: Some(CertSubject::CommonName("custom-name".to_owned())),
                                 expiry_days: Some(90),
+                                subject: Some(CertSubject::CommonName("custom-name".to_owned())),
                             }
                         ),
                         (
                             "module-server",
                             CertIssuanceOptions {
                                 method: CertIssuanceMethod::LocalCa,
-                                subject: None,
                                 expiry_days: None,
+                                subject: None,
                             }
                         ),
                     ]
@@ -550,8 +546,16 @@ aziot_certd = "unix:///run/aziot/certd.sock"
                                 url: None,
                                 auth: None,
                             },
-                            subject: Some(CertSubject::CommonName("custom-name".to_owned())),
                             expiry_days: None,
+                            subject: Some(CertSubject::Subject(
+                                vec![
+                                    ("L".to_owned(), "AQ".to_owned()),
+                                    ("ST".to_owned(), "Antarctica".to_owned()),
+                                    ("CN".to_owned(), "test-device".to_owned()),
+                                ]
+                                .into_iter()
+                                .collect(),
+                            )),
                         },
                     ),
                     (
@@ -580,24 +584,24 @@ aziot_certd = "unix:///run/aziot/certd.sock"
                                     }),
                                 }),
                             },
-                            subject: Some(CertSubject::CommonName("test-device".to_owned())),
                             expiry_days: Some(365),
+                            subject: Some(CertSubject::CommonName("test-device".to_owned())),
                         },
                     ),
                     (
                         "module-id",
                         CertIssuanceOptions {
                             method: CertIssuanceMethod::SelfSigned,
-                            subject: Some(CertSubject::CommonName("custom-name".to_owned())),
                             expiry_days: Some(90),
+                            subject: Some(CertSubject::CommonName("custom-name".to_owned())),
                         },
                     ),
                     (
                         "module-server",
                         CertIssuanceOptions {
                             method: CertIssuanceMethod::LocalCa,
-                            subject: None,
                             expiry_days: None,
+                            subject: None,
                         },
                     ),
                 ]

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -11,12 +11,21 @@
 
 pub mod util;
 
-use serde::Serialize;
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+use std::path::{Path, PathBuf};
 
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+use serde::de::Error as _;
+use serde::{Deserialize, Serialize};
+use serde_with::{skip_serializing_none, with_prefix};
+use url::Url;
+
+use http_common::Connector;
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct Config {
     /// Path of home directory.
-    pub homedir_path: std::path::PathBuf,
+    pub homedir_path: PathBuf,
 
     /// Configuration of how new certificates should be issued.
     #[serde(default)]
@@ -24,7 +33,7 @@ pub struct Config {
 
     /// Map of preloaded certs from their ID to their location.
     #[serde(default)]
-    pub preloaded_certs: std::collections::BTreeMap<String, PreloadedCert>,
+    pub preloaded_certs: BTreeMap<String, PreloadedCert>,
 
     /// Map of service names to endpoint URIs.
     ///
@@ -45,130 +54,107 @@ pub struct Config {
 }
 
 /// Configuration of how new certificates should be issued.
-#[derive(Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct CertIssuance {
     /// Configuration of parameters for issuing certs via EST.
     pub est: Option<Est>,
 
     /// Configuration of parameters for issuing certs via a local CA cert.
-    pub local_ca: Option<LocalCa>,
+    pub local_ca: Option<CertificateWithPrivateKey>,
 
     /// Map of certificate IDs to the details used to issue them.
     #[serde(flatten)]
-    pub certs: std::collections::BTreeMap<String, CertIssuanceOptions>,
+    pub certs: BTreeMap<String, CertIssuanceOptions>,
 }
 
 /// Configuration of parameters for issuing certs via EST.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct Est {
-    /// Authentication parameters for the EST server.
-    pub auth: EstAuth,
-
     /// List of certs that should be treated as trusted roots for validating the EST server's TLS certificate.
+    #[serde(default)]
     pub trusted_certs: Vec<String>,
+
+    /// Authentication parameters for the EST server.
+    // NOTE: DO NOT MOVE. Tables must be after values!
+    #[serde(flatten)]
+    pub auth: EstAuth,
 
     /// Map of certificate IDs to EST endpoint URLs.
     ///
     /// The special key "default" is used as a fallback for certs whose ID is not explicitly listed in this map.
-    pub urls: std::collections::BTreeMap<String, url::Url>,
+    pub urls: BTreeMap<String, Url>,
 }
 
 /// Authentication parameters for the EST server.
 ///
 /// Note that EST servers may be configured to have only basic auth, only TLS client cert auth, or both.
-#[derive(Clone, Debug, PartialEq)]
+#[skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(try_from = "EstAuthInner")]
 pub struct EstAuth {
     /// Authentication parameters when using basic HTTP authentication.
+    #[serde(flatten)]
     pub basic: Option<EstAuthBasic>,
 
     /// Authentication parameters when using TLS client cert authentication.
+    #[serde(flatten)]
     pub x509: Option<EstAuthX509>,
 }
 
+#[derive(Deserialize)]
+struct EstAuthInner {
+    #[serde(flatten)]
+    pub basic: Option<EstAuthBasic>,
+    #[serde(flatten)]
+    pub x509: Option<EstAuthX509>,
+}
+
+impl TryFrom<EstAuthInner> for EstAuth {
+    type Error = serde::de::value::Error;
+
+    fn try_from(value: EstAuthInner) -> Result<Self, Self::Error> {
+        let EstAuthInner { basic, x509 } = value;
+        if basic.is_none() && x509.is_none() {
+            Err(Self::Error::missing_field(
+                "empty authentication parameters",
+            ))
+        } else {
+            Ok(Self { basic, x509 })
+        }
+    }
+}
+
 /// Authentication parameters when using basic HTTP authentication.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct EstAuthBasic {
     pub username: String,
     pub password: String,
 }
 
 /// Authentication parameters when using TLS client cert authentication.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct EstAuthX509 {
     /// Cert ID and private key ID for the identity cert.
     ///
     /// If this cert does not exist, it will be requested from the EST server,
     /// with the bootstrap identity cert used as the initial TLS client cert.
-    pub identity: (String, String),
+    #[serde(flatten, with = "prefix_identity")]
+    pub identity: CertificateWithPrivateKey,
 
     /// Cert ID and private key ID for the bootstrap identity cert.
     ///
     /// This is needed if the cert indicated by `identity` does not exist
     /// and thus also needs to be requested from the EST server.
-    pub bootstrap_identity: Option<(String, String)>,
+    #[serde(flatten, with = "prefix_bootstrap_identity")]
+    pub bootstrap_identity: Option<CertificateWithPrivateKey>,
 }
 
-#[derive(Debug, Default, serde::Deserialize, serde::Serialize)]
-pub(crate) struct EstInner {
-    #[serde(flatten)]
-    auth: EstAuthInner,
-
-    #[serde(default)]
-    trusted_certs: Vec<String>,
-
-    urls: std::collections::BTreeMap<String, url::Url>,
-}
-
-#[derive(Debug, Default, serde::Deserialize, serde::Serialize)]
-pub(crate) struct EstAuthInner {
-    username: Option<String>,
-    password: Option<String>,
-
-    identity_cert: Option<String>,
-    identity_pk: Option<String>,
-    bootstrap_identity_cert: Option<String>,
-    bootstrap_identity_pk: Option<String>,
-}
-
-impl<'de> serde::Deserialize<'de> for Est {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        let inner: EstInner = serde::Deserialize::deserialize(deserializer)?;
-
-        let auth = deserialize_auth_inner(&inner.auth).map_err(serde::de::Error::missing_field)?;
-
-        let trusted_certs = inner.trusted_certs;
-
-        let urls = inner.urls;
-
-        Ok(Est {
-            auth,
-            trusted_certs,
-            urls,
-        })
-    }
-}
-
-impl serde::Serialize for Est {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        let mut inner = EstInner::default();
-
-        serialize_auth_inner(&self.auth, &mut inner.auth);
-        inner.trusted_certs = self.trusted_certs.clone();
-        inner.urls = self.urls.clone();
-
-        inner.serialize(serializer)
-    }
-}
+with_prefix!(prefix_identity "identity_");
+with_prefix!(prefix_bootstrap_identity "bootstrap_identity_");
 
 /// Configuration of parameters for issuing certs via a local CA cert.
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LocalCa {
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct CertificateWithPrivateKey {
     /// Certificate ID.
     pub cert: String,
 
@@ -177,10 +163,10 @@ pub struct LocalCa {
 }
 
 /// Details for issuing a single cert.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct CertIssuanceOptions {
-    /// Common name for the issued certificate. Defaults to the common name specified in CSR if not provided.
-    pub common_name: Option<String>,
+    #[serde(flatten)]
+    pub subject: Option<CertSubject>,
 
     /// Number of days between cert issuance and expiry. Applies to local_ca and self_signed issuance methods.
     /// If not provided, defaults to 30.
@@ -192,11 +178,18 @@ pub struct CertIssuanceOptions {
     pub method: CertIssuanceMethod,
 }
 
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CertSubject {
+    CommonName(String),
+    Subject(BTreeMap<String, String>),
+}
+
 pub fn deserialize_expiry_days<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
-    let result: Option<u32> = serde::Deserialize::deserialize(deserializer)?;
+    let result: Option<u32> = Deserialize::deserialize(deserializer)?;
 
     if result == Some(0) {
         return Err(serde::de::Error::custom(
@@ -208,18 +201,13 @@ where
 }
 
 /// The method used to issue a certificate.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "method", rename_all = "snake_case")]
 pub enum CertIssuanceMethod {
     /// The certificate is to be issued via EST.
-    #[serde(rename = "est")]
     Est {
-        url: Option<url::Url>,
-        #[serde(
-            flatten,
-            deserialize_with = "deserialize_est_auth",
-            serialize_with = "serialize_est_auth"
-        )]
+        url: Option<Url>,
+        #[serde(flatten)]
         auth: Option<EstAuth>,
     },
 
@@ -230,44 +218,14 @@ pub enum CertIssuanceMethod {
     SelfSigned,
 }
 
-fn deserialize_est_auth<'de, D>(deserializer: D) -> Result<Option<EstAuth>, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    let inner: Option<EstAuthInner> = serde::Deserialize::deserialize(deserializer)?;
-
-    if let Some(inner) = inner {
-        let auth = deserialize_auth_inner(&inner).map_err(serde::de::Error::missing_field)?;
-
-        if auth.basic.is_some() || auth.x509.is_some() {
-            return Ok(Some(auth));
-        }
-    }
-
-    Ok(None)
-}
-
-fn serialize_est_auth<S>(auth: &Option<EstAuth>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::ser::Serializer,
-{
-    let mut inner = EstAuthInner::default();
-
-    if let Some(auth) = auth {
-        serialize_auth_inner(&auth, &mut inner);
-    }
-
-    inner.serialize(serializer)
-}
-
 /// The location of a preloaded cert.
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PreloadedCert {
     /// A URI for the location.
     ///
     /// Only `file://` URIs are supported.
-    Uri(url::Url),
+    Uri(Url),
 
     /// A list of IDs of other certs, preloaded or otherwise.
     ///
@@ -276,30 +234,30 @@ pub enum PreloadedCert {
 }
 
 /// Map of service names to endpoint URIs.
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct Endpoints {
     /// The endpoint that the certd service binds to.
-    pub aziot_certd: http_common::Connector,
+    pub aziot_certd: Connector,
 
     /// The endpoint that the keyd service binds to.
-    pub aziot_keyd: http_common::Connector,
+    pub aziot_keyd: Connector,
 }
 
 impl Default for Endpoints {
     fn default() -> Self {
         Endpoints {
-            aziot_certd: http_common::Connector::Unix {
-                socket_path: std::path::Path::new("/run/aziot/certd.sock").into(),
+            aziot_certd: Connector::Unix {
+                socket_path: Path::new("/run/aziot/certd.sock").into(),
             },
-            aziot_keyd: http_common::Connector::Unix {
-                socket_path: std::path::Path::new("/run/aziot/keyd.sock").into(),
+            aziot_keyd: Connector::Unix {
+                socket_path: Path::new("/run/aziot/keyd.sock").into(),
             },
         }
     }
 }
 
 /// Map of a Unix UID to certificate IDs with write access.
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct Principal {
     /// Unix UID.
     pub uid: libc::uid_t,
@@ -308,73 +266,10 @@ pub struct Principal {
     pub certs: Vec<String>,
 }
 
-fn deserialize_auth_inner(auth: &EstAuthInner) -> Result<EstAuth, &'static str> {
-    let auth_basic = match (&auth.username, &auth.password) {
-        (Some(username), Some(password)) => Some(EstAuthBasic {
-            username: username.to_owned(),
-            password: password.to_owned(),
-        }),
-
-        (Some(_), None) => return Err("password"),
-
-        (None, Some(_)) => return Err("username"),
-
-        (None, None) => None,
-    };
-
-    let auth_x509 = match (&auth.identity_cert, &auth.identity_pk) {
-        (Some(identity_cert), Some(identity_pk)) => {
-            let identity = (identity_cert.to_owned(), identity_pk.to_owned());
-
-            let bootstrap_identity =
-                match (&auth.bootstrap_identity_cert, &auth.bootstrap_identity_pk) {
-                    (Some(bootstrap_identity_cert), Some(bootstrap_identity_pk)) => Some((
-                        bootstrap_identity_cert.to_owned(),
-                        bootstrap_identity_pk.to_owned(),
-                    )),
-                    (Some(_), None) => return Err("bootstrap_identity_pk"),
-                    (None, Some(_)) => return Err("bootstrap_identity_cert"),
-                    (None, None) => None,
-                };
-
-            Some(EstAuthX509 {
-                identity,
-                bootstrap_identity,
-            })
-        }
-
-        (Some(_), None) => return Err("identity_pk"),
-
-        (None, Some(_)) => return Err("identity_cert"),
-
-        (None, None) => None,
-    };
-
-    Ok(EstAuth {
-        basic: auth_basic,
-        x509: auth_x509,
-    })
-}
-
-fn serialize_auth_inner(auth: &EstAuth, inner: &mut EstAuthInner) {
-    if let Some(basic) = &auth.basic {
-        inner.username = Some(basic.username.clone());
-        inner.password = Some(basic.password.clone());
-    }
-
-    if let Some(x509) = &auth.x509 {
-        inner.identity_cert = Some(x509.identity.0.clone());
-        inner.identity_pk = Some(x509.identity.1.clone());
-
-        if let Some(bootstrap_identity) = &x509.bootstrap_identity {
-            inner.bootstrap_identity_cert = Some(bootstrap_identity.0.clone());
-            inner.bootstrap_identity_pk = Some(bootstrap_identity.1.clone());
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn parse_config() {
         let actual = r#"
@@ -387,7 +282,6 @@ module-server = { method = "local_ca" }
 
 [cert_issuance.device-id]
 method = "est"
-common_name = "test-device"
 expiry_days = 365
 url = "https://estendpoint.com/.well-known/est/device-id/"
 username = "username"
@@ -396,6 +290,11 @@ identity_cert = "device-id"
 identity_pk = "device-id"
 bootstrap_identity_cert = "bootstrap"
 bootstrap_identity_pk = "bootstrap"
+
+[cert_issuance.device-id.subject]
+L = "AQ"
+ST = "Antarctica"
+CN = "test-device"
 
 [cert_issuance.est]
 identity_cert = "est-id"
@@ -422,25 +321,28 @@ uid = 1000
 certs = ["test"]
 "#;
 
-        let actual: super::Config = toml::from_str(actual).unwrap();
+        let actual: Config = toml::from_str(actual).unwrap();
         assert_eq!(
             actual,
-            super::Config {
+            Config {
                 homedir_path: "/var/lib/aziot/certd".into(),
 
-                cert_issuance: super::CertIssuance {
-                    est: Some(super::Est {
-                        auth: super::EstAuth {
-                            basic: None,
-                            x509: Some(super::EstAuthX509 {
-                                identity: ("est-id".to_owned(), "est-id".to_owned()),
-                                bootstrap_identity: Some((
-                                    "bootstrap".to_owned(),
-                                    "bootstrap".to_owned()
-                                )),
-                            }),
-                        },
+                cert_issuance: CertIssuance {
+                    est: Some(Est {
                         trusted_certs: vec!["est-ca".to_owned(),],
+                        auth: EstAuth {
+                            basic: None,
+                            x509: Some(EstAuthX509 {
+                                identity: CertificateWithPrivateKey {
+                                    cert: "est-id".to_owned(),
+                                    pk: "est-id".to_owned()
+                                },
+                                bootstrap_identity: Some(CertificateWithPrivateKey {
+                                    cert: "bootstrap".to_owned(),
+                                    pk: "bootstrap".to_owned()
+                                }),
+                            })
+                        },
                         urls: vec![
                             (
                                 "default".to_owned(),
@@ -454,7 +356,7 @@ certs = ["test"]
                             ),
                         ]
                         .into_iter()
-                        .collect(),
+                        .collect()
                     }),
 
                     local_ca: None,
@@ -462,58 +364,66 @@ certs = ["test"]
                     certs: [
                         (
                             "device-ca",
-                            super::CertIssuanceOptions {
-                                method: super::CertIssuanceMethod::Est {
+                            CertIssuanceOptions {
+                                method: CertIssuanceMethod::Est {
                                     url: None,
                                     auth: None
                                 },
-                                common_name: Some("custom-name".to_owned()),
+                                subject: Some(CertSubject::CommonName("custom-name".to_owned())),
                                 expiry_days: None,
                             }
                         ),
                         (
                             "device-id",
-                            super::CertIssuanceOptions {
-                                method: super::CertIssuanceMethod::Est {
+                            CertIssuanceOptions {
+                                method: CertIssuanceMethod::Est {
                                     url: Some(
                                         "https://estendpoint.com/.well-known/est/device-id/"
                                             .parse()
                                             .unwrap()
                                     ),
-                                    auth: Some(super::EstAuth {
-                                        basic: Some(super::EstAuthBasic {
+                                    auth: Some(EstAuth {
+                                        basic: Some(EstAuthBasic {
                                             username: "username".to_owned(),
                                             password: "password".to_owned(),
                                         }),
-                                        x509: Some(super::EstAuthX509 {
-                                            identity: (
-                                                "device-id".to_owned(),
-                                                "device-id".to_owned()
-                                            ),
-                                            bootstrap_identity: Some((
-                                                "bootstrap".to_owned(),
-                                                "bootstrap".to_owned()
-                                            )),
+                                        x509: Some(EstAuthX509 {
+                                            identity: CertificateWithPrivateKey {
+                                                cert: "device-id".to_owned(),
+                                                pk: "device-id".to_owned()
+                                            },
+                                            bootstrap_identity: Some(CertificateWithPrivateKey {
+                                                cert: "bootstrap".to_owned(),
+                                                pk: "bootstrap".to_owned()
+                                            }),
                                         })
                                     })
                                 },
-                                common_name: Some("test-device".to_owned()),
+                                subject: Some(CertSubject::Subject(
+                                    vec![
+                                        ("L".to_owned(), "AQ".to_owned()),
+                                        ("ST".to_owned(), "Antarctica".to_owned()),
+                                        ("CN".to_owned(), "test-device".to_owned())
+                                    ]
+                                    .into_iter()
+                                    .collect()
+                                )),
                                 expiry_days: Some(365)
                             }
                         ),
                         (
                             "module-id",
-                            super::CertIssuanceOptions {
-                                method: super::CertIssuanceMethod::SelfSigned,
-                                common_name: Some("custom-name".to_owned()),
+                            CertIssuanceOptions {
+                                method: CertIssuanceMethod::SelfSigned,
+                                subject: Some(CertSubject::CommonName("custom-name".to_owned())),
                                 expiry_days: Some(90),
                             }
                         ),
                         (
                             "module-server",
-                            super::CertIssuanceOptions {
-                                method: super::CertIssuanceMethod::LocalCa,
-                                common_name: None,
+                            CertIssuanceOptions {
+                                method: CertIssuanceMethod::LocalCa,
+                                subject: None,
                                 expiry_days: None,
                             }
                         ),
@@ -526,34 +436,30 @@ certs = ["test"]
                 preloaded_certs: vec![
                     (
                         "bootstrap".to_owned(),
-                        super::PreloadedCert::Uri(
-                            "file:///var/secrets/bootstrap.cer".parse().unwrap()
-                        )
+                        PreloadedCert::Uri("file:///var/secrets/bootstrap.cer".parse().unwrap())
                     ),
                     (
                         "est-ca".to_owned(),
-                        super::PreloadedCert::Uri(
-                            "file:///var/secrets/est-ca.cer".parse().unwrap()
-                        )
+                        PreloadedCert::Uri("file:///var/secrets/est-ca.cer".parse().unwrap())
                     ),
                     (
                         "trust-bundle".to_owned(),
-                        super::PreloadedCert::Ids(vec!["est-ca".to_owned()])
+                        PreloadedCert::Ids(vec!["est-ca".to_owned()])
                     ),
                 ]
                 .into_iter()
                 .collect(),
 
-                endpoints: super::Endpoints {
-                    aziot_certd: http_common::Connector::Unix {
-                        socket_path: std::path::Path::new("/run/aziot/certd.sock").into()
+                endpoints: Endpoints {
+                    aziot_certd: Connector::Unix {
+                        socket_path: Path::new("/run/aziot/certd.sock").into()
                     },
-                    aziot_keyd: http_common::Connector::Unix {
-                        socket_path: std::path::Path::new("/run/aziot/keyd.sock").into()
+                    aziot_keyd: Connector::Unix {
+                        socket_path: Path::new("/run/aziot/keyd.sock").into()
                     },
                 },
 
-                principal: vec![super::Principal {
+                principal: vec![Principal {
                     uid: 1000,
                     certs: vec!["test".to_string()]
                 }],
@@ -572,27 +478,168 @@ aziot_keyd = "unix:///run/aziot/keyd.sock"
 aziot_certd = "unix:///run/aziot/certd.sock"
 "#;
 
-        let actual: super::Config = toml::from_str(actual).unwrap();
+        let actual: Config = toml::from_str(actual).unwrap();
         assert_eq!(
             actual,
-            super::Config {
+            Config {
                 homedir_path: "/var/lib/aziot/certd".into(),
 
                 cert_issuance: Default::default(),
 
                 preloaded_certs: Default::default(),
 
-                endpoints: super::Endpoints {
-                    aziot_certd: http_common::Connector::Unix {
-                        socket_path: std::path::Path::new("/run/aziot/certd.sock").into()
+                endpoints: Endpoints {
+                    aziot_certd: Connector::Unix {
+                        socket_path: Path::new("/run/aziot/certd.sock").into()
                     },
-                    aziot_keyd: http_common::Connector::Unix {
-                        socket_path: std::path::Path::new("/run/aziot/keyd.sock").into()
+                    aziot_keyd: Connector::Unix {
+                        socket_path: Path::new("/run/aziot/keyd.sock").into()
                     },
                 },
 
                 principal: Default::default(),
             }
         );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn serialize_config() {
+        let configuration = Config {
+            homedir_path: "/var/lib/aziot/certd".into(),
+
+            cert_issuance: CertIssuance {
+                est: Some(Est {
+                    trusted_certs: vec!["est-ca".to_owned()],
+                    auth: EstAuth {
+                        basic: None,
+                        x509: Some(EstAuthX509 {
+                            identity: CertificateWithPrivateKey {
+                                cert: "est-id".to_owned(),
+                                pk: "est-id".to_owned(),
+                            },
+                            bootstrap_identity: Some(CertificateWithPrivateKey {
+                                cert: "bootstrap".to_owned(),
+                                pk: "bootstrap".to_owned(),
+                            }),
+                        }),
+                    },
+                    urls: vec![
+                        (
+                            "default".to_owned(),
+                            "https://estendpoint.com/.well-known/est/".parse().unwrap(),
+                        ),
+                        (
+                            "device-ca".to_owned(),
+                            "https://estendpoint.com/.well-known/est/device-ca/"
+                                .parse()
+                                .unwrap(),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                }),
+
+                local_ca: None,
+
+                certs: [
+                    (
+                        "device-ca",
+                        CertIssuanceOptions {
+                            method: CertIssuanceMethod::Est {
+                                url: None,
+                                auth: None,
+                            },
+                            subject: Some(CertSubject::CommonName("custom-name".to_owned())),
+                            expiry_days: None,
+                        },
+                    ),
+                    (
+                        "device-id",
+                        CertIssuanceOptions {
+                            method: CertIssuanceMethod::Est {
+                                url: Some(
+                                    "https://estendpoint.com/.well-known/est/device-id/"
+                                        .parse()
+                                        .unwrap(),
+                                ),
+                                auth: Some(EstAuth {
+                                    basic: Some(EstAuthBasic {
+                                        username: "username".to_owned(),
+                                        password: "password".to_owned(),
+                                    }),
+                                    x509: Some(EstAuthX509 {
+                                        identity: CertificateWithPrivateKey {
+                                            cert: "device-id".to_owned(),
+                                            pk: "device-id".to_owned(),
+                                        },
+                                        bootstrap_identity: Some(CertificateWithPrivateKey {
+                                            cert: "bootstrap".to_owned(),
+                                            pk: "bootstrap".to_owned(),
+                                        }),
+                                    }),
+                                }),
+                            },
+                            subject: Some(CertSubject::CommonName("test-device".to_owned())),
+                            expiry_days: Some(365),
+                        },
+                    ),
+                    (
+                        "module-id",
+                        CertIssuanceOptions {
+                            method: CertIssuanceMethod::SelfSigned,
+                            subject: Some(CertSubject::CommonName("custom-name".to_owned())),
+                            expiry_days: Some(90),
+                        },
+                    ),
+                    (
+                        "module-server",
+                        CertIssuanceOptions {
+                            method: CertIssuanceMethod::LocalCa,
+                            subject: None,
+                            expiry_days: None,
+                        },
+                    ),
+                ]
+                .iter()
+                .map(|(id, options)| ((*id).to_owned(), options.clone()))
+                .collect(),
+            },
+
+            preloaded_certs: vec![
+                (
+                    "bootstrap".to_owned(),
+                    PreloadedCert::Uri("file:///var/secrets/bootstrap.cer".parse().unwrap()),
+                ),
+                (
+                    "est-ca".to_owned(),
+                    PreloadedCert::Uri("file:///var/secrets/est-ca.cer".parse().unwrap()),
+                ),
+                (
+                    "trust-bundle".to_owned(),
+                    PreloadedCert::Ids(vec!["est-ca".to_owned()]),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+
+            endpoints: Endpoints {
+                aziot_certd: Connector::Unix {
+                    socket_path: Path::new("/run/aziot/certd.sock").into(),
+                },
+                aziot_keyd: Connector::Unix {
+                    socket_path: Path::new("/run/aziot/keyd.sock").into(),
+                },
+            },
+
+            principal: vec![Principal {
+                uid: 1000,
+                certs: vec!["test".to_string()],
+            }],
+        };
+
+        let serialized = toml::to_string(&configuration).unwrap();
+
+        assert_eq!(configuration, toml::from_str(&serialized).unwrap());
     }
 }

--- a/cert/aziot-certd/Cargo.toml
+++ b/cert/aziot-certd/Cargo.toml
@@ -7,6 +7,7 @@ build = "build/main.rs"
 
 
 [dependencies]
+async-recursion = "0.3"
 async-trait = "0.1"
 base64 = "0.13"
 foreign-types-shared = "0.1"
@@ -35,7 +36,7 @@ aziot-key-common = { path = "../../key/aziot-key-common" }
 aziot-key-common-http = { path = "../../key/aziot-key-common-http" }
 aziot-key-openssl-engine = { path = "../../key/aziot-key-openssl-engine" }
 config-common = { path = "../../config-common", features = ["watcher"] }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }
 openssl2 = { path = "../../openssl2" }
 
 

--- a/cert/aziot-certd/src/error.rs
+++ b/cert/aziot-certd/src/error.rs
@@ -51,6 +51,7 @@ pub enum InternalError {
     InvalidProxyUri(Box<dyn std::error::Error + Send + Sync>),
     LoadKeyOpensslEngine(openssl2::Error),
     ReadFile(std::io::Error),
+    WriteFile(std::io::Error),
 }
 
 impl std::fmt::Display for InternalError {
@@ -66,6 +67,7 @@ impl std::fmt::Display for InternalError {
                 f.write_str("could not load aziot-key-openssl-engine")
             }
             InternalError::ReadFile(_) => f.write_str("could not read cert file"),
+            InternalError::WriteFile(_) => f.write_str("could not write cert file"),
         }
     }
 }
@@ -80,6 +82,7 @@ impl std::error::Error for InternalError {
             InternalError::InvalidProxyUri(err) => Some(&**err),
             InternalError::LoadKeyOpensslEngine(err) => Some(err),
             InternalError::ReadFile(err) => Some(err),
+            InternalError::WriteFile(err) => Some(err),
         }
     }
 }

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -11,27 +11,44 @@
     clippy::too_many_lines
 )]
 
-use async_trait::async_trait;
-
 mod error;
-use error::{Error, InternalError};
-
 mod est;
-
 mod http;
 
-use aziot_certd_config::{
-    CertIssuance, CertIssuanceMethod, CertIssuanceOptions, Config, Endpoints, EstAuthBasic,
-    EstAuthX509, LocalCa, PreloadedCert, Principal,
-};
+use std::collections::BTreeMap;
+use std::error::Error as StdError;
+use std::ffi::{CStr, CString};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use async_recursion::async_recursion;
+use async_trait::async_trait;
+use futures_util::lock::Mutex;
+use openssl::asn1::Asn1Time;
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKeyRef, Public};
+use openssl::stack::Stack;
+use openssl::x509::{extension, X509Name, X509Req, X509ReqRef, X509};
+use openssl2::FunctionalEngine;
+
+use aziot_certd_config::{
+    CertIssuance, CertIssuanceMethod, CertSubject, CertificateWithPrivateKey, Config, Endpoints,
+    EstAuthX509, PreloadedCert, Principal,
+};
 use config_common::watcher::UpdateConfig;
+use http_common::Connector;
+
+use error::{Error, InternalError};
+
+pub(crate) type BoxedError = Box<dyn StdError + Send + Sync>;
 
 pub async fn main(
     config: Config,
-    config_path: std::path::PathBuf,
-    config_directory_path: std::path::PathBuf,
-) -> Result<(http_common::Connector, http::Service), Box<dyn std::error::Error>> {
+    config_path: PathBuf,
+    config_directory_path: PathBuf,
+) -> Result<(Connector, http::Service), Box<dyn StdError>> {
     let Config {
         homedir_path,
         cert_issuance,
@@ -50,7 +67,7 @@ pub async fn main(
                 aziot_key_common_http::ApiVersion::V2020_09_01,
                 key_connector,
             );
-            let key_client = std::sync::Arc::new(key_client);
+            let key_client = Arc::new(key_client);
             key_client
         };
 
@@ -71,7 +88,7 @@ pub async fn main(
             proxy_uri,
         }
     };
-    let api = std::sync::Arc::new(futures_util::lock::Mutex::new(api));
+    let api = Arc::new(Mutex::new(api));
 
     config_common::watcher::start_watcher(config_path, config_directory_path, api.clone());
 
@@ -81,19 +98,19 @@ pub async fn main(
 }
 
 struct Api {
-    homedir_path: std::path::PathBuf,
+    homedir_path: PathBuf,
     cert_issuance: CertIssuance,
-    preloaded_certs: std::collections::BTreeMap<String, PreloadedCert>,
-    principals: std::collections::BTreeMap<libc::uid_t, Vec<wildmatch::WildMatch>>,
+    preloaded_certs: BTreeMap<String, PreloadedCert>,
+    principals: BTreeMap<libc::uid_t, Vec<wildmatch::WildMatch>>,
 
-    key_client: std::sync::Arc<aziot_key_client::Client>,
-    key_engine: openssl2::FunctionalEngine,
+    key_client: Arc<aziot_key_client::Client>,
+    key_engine: FunctionalEngine,
     proxy_uri: Option<hyper::Uri>,
 }
 
 impl Api {
     pub async fn create_cert(
-        this: std::sync::Arc<futures_util::lock::Mutex<Self>>,
+        this: Arc<Mutex<Self>>,
         id: String,
         csr: Vec<u8>,
         issuer: Option<(String, aziot_key_common::KeyHandle)>,
@@ -105,15 +122,49 @@ impl Api {
             return Err(Error::Unauthorized(user, id));
         }
 
-        let x509 = create_cert(
+        let req = X509Req::from_pem(&csr).map_err(|err| Error::invalid_parameter("csr", err))?;
+        let pubkey = req
+            .public_key()
+            .map_err(|err| Error::invalid_parameter("csr", err))?;
+
+        if !req
+            .verify(&pubkey)
+            .map_err(|err| Error::invalid_parameter("csr", err))?
+        {
+            return Err(Error::invalid_parameter(
+                "csr",
+                "CSR failed to be verified with its public key".to_owned(),
+            ));
+        }
+
+        let issuer = issuer
+            .map(|(id, handle)| -> Result<_, Error> {
+                let pem = get_cert_inner(&this.homedir_path, &this.preloaded_certs, &id)
+                    .map_err(|err| Error::Internal(InternalError::CreateCert(err.into())))?
+                    .ok_or_else(|| Error::invalid_parameter("issuer.certId", "not found"))?;
+                let stack = X509::stack_from_pem(&pem)
+                    .map_err(|err| Error::Internal(InternalError::CreateCert(err.into())))?;
+                if stack.is_empty() {
+                    return Err(Error::invalid_parameter("issuer.certId", "invalid issuer"));
+                }
+
+                let handle = CString::new(handle.0)
+                    .map_err(|err| Error::invalid_parameter("issuer.privateKeyHandle", err))?;
+
+                Ok((stack, handle))
+            })
+            .transpose()?;
+
+        let x509 = create_cert_inner(
             &mut *this,
             &id,
-            &csr,
-            issuer
-                .as_ref()
-                .map(|(issuer_cert, issuer_private_key)| (&**issuer_cert, issuer_private_key)),
+            (&req, &pubkey),
+            issuer.as_ref().map(|(x509, pk)| (&**x509, &**pk)),
         )
-        .await?;
+        .await
+        .map_err(|err| Error::Internal(InternalError::CreateCert(err)))?;
+
+        write_cert(&this.homedir_path, &this.preloaded_certs, &id, &x509)?;
 
         Ok(x509)
     }
@@ -123,12 +174,7 @@ impl Api {
             return Err(Error::Unauthorized(user, id.to_string()));
         }
 
-        let path =
-            aziot_certd_config::util::get_path(&self.homedir_path, &self.preloaded_certs, id, true)
-                .map_err(|err| Error::Internal(InternalError::GetPath(err)))?;
-        std::fs::write(path, pem)
-            .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-        Ok(())
+        write_cert(&self.homedir_path, &self.preloaded_certs, id, pem)
     }
 
     pub fn get_cert(&mut self, id: &str) -> Result<Vec<u8>, Error> {
@@ -145,9 +191,9 @@ impl Api {
         let path =
             aziot_certd_config::util::get_path(&self.homedir_path, &self.preloaded_certs, id, true)
                 .map_err(|err| Error::Internal(InternalError::GetPath(err)))?;
-        match std::fs::remove_file(path) {
+        match fs::remove_file(path) {
             Ok(()) => Ok(()),
-            Err(ref err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(ref err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(err) => Err(Error::Internal(InternalError::DeleteFile(err))),
         }
     }
@@ -178,11 +224,11 @@ impl UpdateConfig for Api {
         // Don't allow changes to homedir path or endpoints while daemon is running.
         // Only update other fields.
         let Config {
-            homedir_path: _,
             cert_issuance,
             preloaded_certs,
-            endpoints: _,
             principal,
+            homedir_path: _,
+            endpoints: _,
         } = new_config;
         self.cert_issuance = cert_issuance;
         self.preloaded_certs = preloaded_certs;
@@ -193,643 +239,333 @@ impl UpdateConfig for Api {
     }
 }
 
-fn load_inner(path: &std::path::Path) -> Result<Option<Vec<u8>>, Error> {
-    match std::fs::read(path) {
-        Ok(cert_bytes) => Ok(Some(cert_bytes)),
-        Err(ref err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(Error::Internal(InternalError::ReadFile(err))),
-    }
-}
-
-fn create_cert<'a>(
-    api: &'a mut Api,
-    id: &'a str,
-    csr: &'a [u8],
-    issuer: Option<(&'a str, &'a aziot_key_common::KeyHandle)>,
-) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<u8>, Error>> + Send + 'a>> {
-    // Creating a cert is recursive in some cases. An async fn cannot recurse because its RPIT Future type would end up being infinitely sized,
-    // so it needs to be boxed. So we have a non-async fn returning a boxed future, where the future being boxed is the result of an inner asyn fn,
-    // and the recursive call is for the outer boxed-future-returning fn.
-
-    async fn create_cert_inner(
-        api: &mut Api,
-        id: &str,
-        csr: &[u8],
-        issuer: Option<(&str, &aziot_key_common::KeyHandle)>,
-    ) -> Result<Vec<u8>, Error> {
-        // Look up issuance options for this certificate ID.
-        let cert_options = api.cert_issuance.certs.get(id);
-
-        if let Some((issuer_id, issuer_private_key)) = issuer {
-            // Issuer is explicitly specified, so load it and use it to sign the CSR.
-
-            let x509_req = openssl::x509::X509Req::from_pem(csr)
-                .map_err(|err| Error::invalid_parameter("csr", err))?;
-            let x509_req_public_key = x509_req
-                .public_key()
-                .map_err(|err| Error::invalid_parameter("csr", err))?;
-            if !x509_req
-                .verify(&x509_req_public_key)
-                .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?
-            {
-                return Err(Error::invalid_parameter(
-                    "csr",
-                    "CSR failed to be verified with its public key",
-                ));
-            }
-
-            // If issuance options are not provided for this certificate ID, use defaults.
-            let mut expiry_days = 30;
-            let mut subject_name = x509_req.subject_name();
-            let version = x509_req.version();
-            let common_name;
-
-            if let Some(options) = cert_options {
-                if let Some(d) = options.expiry_days {
-                    expiry_days = d;
-                }
-
-                if let Some(c) = &options.common_name {
-                    let mut name_builder = openssl::x509::X509Name::builder()
-                        .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-                    name_builder
-                        .append_entry_by_text("CN", &c)
-                        .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-                    common_name = name_builder.build();
-                    subject_name = &common_name;
-                }
-            }
-            let not_after = openssl::asn1::Asn1Time::days_from_now(expiry_days)
-                .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-            let mut x509 = openssl::x509::X509::builder()
-                .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-            x509.set_version(version)
-                .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-            x509.set_subject_name(subject_name)
-                .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-            x509.set_pubkey(&x509_req_public_key)
-                .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-            x509.set_not_before(
-                &*openssl::asn1::Asn1Time::days_from_now(0)
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?,
-            )
-            .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-            // Copy extensions from x509_req to the new cert.
-            let req_extensions = x509_req.extensions();
-
-            // x509_req.extensions() returns an Err variant if no extensions are present in the req.
-            // Ignore this Err and only copy extensions if provided in the req.
-            if let Ok(req_extensions) = req_extensions {
-                for extension in req_extensions {
-                    x509.append_extension(extension)
-                        .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-                }
-            }
-
-            let issuer_private_key = std::ffi::CString::new(issuer_private_key.0.clone())
-                .map_err(|err| Error::invalid_parameter("issuer.privateKeyHandle", err))?;
-            let issuer_private_key = api
-                .key_engine
-                .load_private_key(&issuer_private_key)
-                .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-            let x509 = if issuer_id == id {
-                // Issuer is the same as the cert being created, which means the caller wants the cert to be self-signed.
-
-                x509.set_not_after(&not_after)
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-                x509.set_issuer_name(subject_name)
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-                x509.sign(&issuer_private_key, openssl::hash::MessageDigest::sha256())
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-                let x509 = x509.build();
-
-                let x509 = x509
-                    .to_pem()
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-                x509
-            } else {
-                // Load the issuer and use it to sign the CSR.
-
-                let issuer_path = aziot_certd_config::util::get_path(
-                    &api.homedir_path,
-                    &api.preloaded_certs,
-                    issuer_id,
-                    true,
-                )
-                .map_err(|err| Error::Internal(InternalError::GetPath(err)))?;
-                let issuer_x509_pem = load_inner(&issuer_path)
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?
-                    .ok_or_else(|| Error::invalid_parameter("issuer.certId", "not found"))?;
-                let issuer_x509 = openssl::x509::X509::stack_from_pem(&issuer_x509_pem)
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-                let issuer_x509 = issuer_x509
-                    .get(0)
-                    .ok_or_else(|| Error::invalid_parameter("issuer.certId", "invalid issuer"))?;
-
-                x509.set_issuer_name(issuer_x509.subject_name())
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-                // Cap x509.not_after to issuer_x509.not_after
-                let issuer_not_after = issuer_x509.not_after();
-                let not_after = if issuer_not_after < not_after {
-                    issuer_not_after
-                } else {
-                    &not_after
-                };
-                x509.set_not_after(not_after)
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-                x509.sign(&issuer_private_key, openssl::hash::MessageDigest::sha256())
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-                let x509 = x509.build();
-
-                let mut x509 = x509
-                    .to_pem()
-                    .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-                x509.extend_from_slice(&issuer_x509_pem);
-                x509
-            };
-
-            let path = aziot_certd_config::util::get_path(
-                &api.homedir_path,
-                &api.preloaded_certs,
-                id,
-                true,
-            )
-            .map_err(|err| Error::Internal(InternalError::GetPath(err)))?;
-            std::fs::write(path, &x509)
-                .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-            Ok(x509)
-        } else {
-            // Issuer is not explicitly specified, so use the issuance options for this cert from the configuration.
-
-            let cert_options: &CertIssuanceOptions = cert_options.ok_or_else(|| {
-                Error::invalid_parameter("issuer", "issuer is required for locally-issued certs")
-            })?;
-
-            match &cert_options.method {
-                CertIssuanceMethod::Est {
-                    url: cert_url,
-                    auth: cert_auth,
-                } => {
-                    let defaults = api.cert_issuance.est.as_ref();
-
-                    let auth = cert_auth.as_ref().or_else(|| {
-                        defaults.map(|default| &default.auth)
-                    }).ok_or_else(|| {
-                        Error::Internal(InternalError::CreateCert(
-                            format!(
-                                "cert {:?} is configured to be issued by EST, but EST auth is not configured",
-                                id,
-                            )
-                            .into(),
-                        ))
-                    })?;
-
-                    let url = cert_url.as_ref().or_else(|| {
-                        defaults
-                            .map(|default| &default.urls)
-                            .and_then(|urls| urls.get(id).or_else(|| urls.get("default")))
-                    }).ok_or_else(|| {
-                        Error::Internal(InternalError::CreateCert(
-                            format!(
-                                "cert {:?} is configured to be issued by EST, but EST URL is not configured",
-                                id,
-                            )
-                            .into(),
-                        ))
-                    })?;
-
-                    let auth_basic = auth
-                        .basic
-                        .as_ref()
-                        .map(|EstAuthBasic { username, password }| (&**username, &**password));
-
-                    let mut trusted_certs_x509 = vec![];
-
-                    if let Some(default) = defaults {
-                        for trusted_cert in &default.trusted_certs {
-                            let pem =
-                                get_cert_inner(&api.homedir_path, &api.preloaded_certs, trusted_cert)?
-                                    .ok_or_else(|| {
-                                        Error::Internal(InternalError::CreateCert(
-                                            format!(
-                                        "cert_issuance.est.trusted_certs contains unreadable cert {:?}",
-                                        trusted_cert,
-                                    )
-                                            .into(),
-                                        ))
-                                    })?;
-                            let x509 =
-                                openssl::x509::X509::stack_from_pem(&pem).map_err(|err| {
-                                    Error::Internal(InternalError::CreateCert(Box::new(err)))
-                                })?;
-                            trusted_certs_x509.extend(x509);
-                        }
-                    }
-
-                    if let Some(EstAuthX509 {
-                        identity: (identity_cert, identity_private_key),
-                        bootstrap_identity,
-                    }) = &auth.x509
-                    {
-                        // We need to use TLS client cert auth with the EST server.
-                        //
-                        // Try to load the EST identity cert.
-
-                        let identity = match get_cert_inner(
-                            &api.homedir_path,
-                            &api.preloaded_certs,
-                            identity_cert,
-                        ) {
-                            Ok(Some(identity_cert)) => {
-                                match api.key_client.load_key_pair(identity_private_key) {
-                                    Ok(identity_private_key) => {
-                                        Ok((identity_cert, identity_private_key))
-                                    }
-                                    Err(err) => Err(format!(
-                                        "could not get EST identity cert private key: {}",
-                                        err
-                                    )),
-                                }
-                            }
-                            Ok(None) => Err(format!(
-                                "could not get EST identity cert: {}",
-                                std::io::Error::from(std::io::ErrorKind::NotFound)
-                            )),
-                            Err(err) => Err(format!("could not get EST identity cert: {}", err)),
-                        };
-
-                        match identity {
-                            Ok((identity_cert, identity_private_key)) => {
-                                let identity_private_key =
-                                    std::ffi::CString::new(identity_private_key.0.clone())
-                                        .map_err(|err| {
-                                            Error::Internal(InternalError::CreateCert(Box::new(
-                                                err,
-                                            )))
-                                        })?;
-                                let identity_private_key = api
-                                    .key_engine
-                                    .load_private_key(&identity_private_key)
-                                    .map_err(|err| {
-                                        Error::Internal(InternalError::CreateCert(Box::new(err)))
-                                    })?;
-
-                                let x509 = est::create_cert(
-                                    csr,
-                                    url,
-                                    auth_basic,
-                                    Some((&identity_cert, &identity_private_key)),
-                                    trusted_certs_x509,
-                                    api.proxy_uri.clone(),
-                                )
-                                .await?;
-
-                                let path = aziot_certd_config::util::get_path(
-                                    &api.homedir_path,
-                                    &api.preloaded_certs,
-                                    id,
-                                    true,
-                                )
-                                .map_err(|err| Error::Internal(InternalError::GetPath(err)))?;
-                                std::fs::write(path, &x509).map_err(|err| {
-                                    Error::Internal(InternalError::CreateCert(Box::new(err)))
-                                })?;
-
-                                Ok(x509)
-                            }
-
-                            Err(identity_err) => {
-                                // EST identity cert could not be loaded. We need to issue a new one using the EST bootstrap identity cert.
-                                let bootstrap_identity = if let Some((
-                                    bootstrap_identity_cert,
-                                    bootstrap_identity_private_key,
-                                )) = bootstrap_identity
-                                {
-                                    match get_cert_inner(&api.homedir_path, &api.preloaded_certs, bootstrap_identity_cert) {
-                                        Ok(Some(bootstrap_identity_cert)) => match api.key_client.load_key_pair(bootstrap_identity_private_key) {
-                                            Ok(bootstrap_identity_private_key) => Ok((bootstrap_identity_cert, bootstrap_identity_private_key)),
-                                            Err(err) => Err(format!("could not get EST bootstrap identity cert private key: {}", err)),
-                                        },
-
-                                        Ok(None) => Err(format!(
-                                            "could not get EST bootstrap identity cert: {}",
-                                            std::io::Error::from(std::io::ErrorKind::NotFound),
-                                        )),
-
-                                        Err(err) => Err(format!("could not get EST bootstrap identity cert: {}", err)),
-                                    }
-                                } else {
-                                    Err(format!(
-                                        "cert {:?} is configured to be issued by EST, \
-                                        but EST identity could not be obtained \
-                                        and EST bootstrap identity is not configured; {}",
-                                        id, identity_err,
-                                    ))
-                                };
-
-                                match bootstrap_identity {
-                                    Ok((
-                                        bootstrap_identity_cert,
-                                        bootstrap_identity_private_key,
-                                    )) => {
-                                        // Create a CSR for the new EST identity cert.
-
-                                        let identity_key_pair_handle = api
-                                            .key_client
-                                            .create_key_pair_if_not_exists(
-                                                identity_private_key,
-                                                Some("ec-p256:rsa-4096:*"),
-                                            )
-                                            .map_err(|err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            })?;
-
-                                        let (identity_public_key, identity_private_key) = {
-                                            let identity_key_pair_handle = std::ffi::CString::new(
-                                                identity_key_pair_handle.0.clone(),
-                                            )
-                                            .map_err(|err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            })?;
-                                            let identity_public_key = api
-                                                .key_engine
-                                                .load_public_key(&identity_key_pair_handle)
-                                                .map_err(|err| {
-                                                    Error::Internal(InternalError::CreateCert(
-                                                        Box::new(err),
-                                                    ))
-                                                })?;
-                                            let identity_private_key = api
-                                                .key_engine
-                                                .load_private_key(&identity_key_pair_handle)
-                                                .map_err(|err| {
-                                                    Error::Internal(InternalError::CreateCert(
-                                                        Box::new(err),
-                                                    ))
-                                                })?;
-                                            (identity_public_key, identity_private_key)
-                                        };
-
-                                        let mut identity_csr = openssl::x509::X509Req::builder()
-                                            .map_err(|err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            })?;
-
-                                        identity_csr.set_version(0).map_err(|err| {
-                                            Error::Internal(InternalError::CreateCert(Box::new(
-                                                err,
-                                            )))
-                                        })?;
-
-                                        let mut subject_name = openssl::x509::X509Name::builder()
-                                            .map_err(|err| {
-                                            Error::Internal(InternalError::CreateCert(Box::new(
-                                                err,
-                                            )))
-                                        })?;
-
-                                        let common_name =
-                                            cert_options.common_name.as_deref().unwrap_or("est-id");
-                                        subject_name
-                                            .append_entry_by_text("CN", common_name)
-                                            .map_err(|err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            })?;
-                                        let subject_name = subject_name.build();
-                                        identity_csr.set_subject_name(&subject_name).map_err(
-                                            |err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            },
-                                        )?;
-
-                                        let mut extensions =
-                                            openssl::stack::Stack::new().map_err(|err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            })?;
-                                        let client_extension =
-                                            openssl::x509::extension::ExtendedKeyUsage::new()
-                                                .client_auth()
-                                                .build()
-                                                .map_err(|err| {
-                                                    Error::Internal(InternalError::CreateCert(
-                                                        Box::new(err),
-                                                    ))
-                                                })?;
-                                        extensions.push(client_extension).map_err(|err| {
-                                            Error::Internal(InternalError::CreateCert(Box::new(
-                                                err,
-                                            )))
-                                        })?;
-                                        identity_csr.add_extensions(&extensions).map_err(
-                                            |err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            },
-                                        )?;
-
-                                        identity_csr.set_pubkey(&identity_public_key).map_err(
-                                            |err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            },
-                                        )?;
-
-                                        identity_csr
-                                            .sign(
-                                                &identity_private_key,
-                                                openssl::hash::MessageDigest::sha256(),
-                                            )
-                                            .map_err(|err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            })?;
-
-                                        let identity_csr = identity_csr.build();
-                                        let identity_csr =
-                                            identity_csr.to_pem().map_err(|err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            })?;
-
-                                        // Request the new EST identity cert using the EST bootstrap identity cert.
-
-                                        let bootstrap_identity_private_key =
-                                            std::ffi::CString::new(
-                                                bootstrap_identity_private_key.0.clone(),
-                                            )
-                                            .map_err(
-                                                |err| {
-                                                    Error::Internal(InternalError::CreateCert(
-                                                        Box::new(err),
-                                                    ))
-                                                },
-                                            )?;
-                                        let bootstrap_identity_private_key = api
-                                            .key_engine
-                                            .load_private_key(&bootstrap_identity_private_key)
-                                            .map_err(|err| {
-                                                Error::Internal(InternalError::CreateCert(
-                                                    Box::new(err),
-                                                ))
-                                            })?;
-
-                                        let x509 = est::create_cert(
-                                            &identity_csr,
-                                            url,
-                                            auth_basic,
-                                            Some((
-                                                &bootstrap_identity_cert,
-                                                &bootstrap_identity_private_key,
-                                            )),
-                                            trusted_certs_x509,
-                                            api.proxy_uri.clone(),
-                                        )
-                                        .await?;
-
-                                        let path = aziot_certd_config::util::get_path(
-                                            &api.homedir_path,
-                                            &api.preloaded_certs,
-                                            identity_cert,
-                                            true,
-                                        )
-                                        .map_err(|err| {
-                                            Error::Internal(InternalError::GetPath(err))
-                                        })?;
-                                        std::fs::write(path, &x509).map_err(|err| {
-                                            Error::Internal(InternalError::CreateCert(Box::new(
-                                                err,
-                                            )))
-                                        })?;
-
-                                        // EST identity cert was obtained and persisted successfully. Now recurse to retry the original cert request.
-
-                                        let x509 = create_cert(api, id, csr, issuer).await?;
-                                        Ok(x509)
-                                    }
-
-                                    Err(bootstrap_identity_err) => {
-                                        // Neither EST identity cert nor EST bootstrap identity cert could be obtained.
-                                        Err(Error::Internal(InternalError::CreateCert(format!(
-                                            "cert {:?} is configured to be issued by EST, but neither EST identity nor EST bootstrap identity could be obtained; \
-                                            {} {}",
-                                            id,
-                                            identity_err,
-                                            bootstrap_identity_err,
-                                        ).into())))
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        // We need to only use basic auth with the EST server.
-
-                        let x509 = est::create_cert(
-                            csr,
-                            url,
-                            auth_basic,
-                            None,
-                            trusted_certs_x509,
-                            api.proxy_uri.clone(),
-                        )
-                        .await?;
-
-                        let path = aziot_certd_config::util::get_path(
-                            &api.homedir_path,
-                            &api.preloaded_certs,
-                            id,
-                            true,
-                        )
-                        .map_err(|err| Error::Internal(InternalError::GetPath(err)))?;
-                        std::fs::write(path, &x509).map_err(|err| {
-                            Error::Internal(InternalError::CreateCert(Box::new(err)))
-                        })?;
-
-                        Ok(x509)
-                    }
-                }
-
-                CertIssuanceMethod::LocalCa => {
-                    // Indirect reference to the local CA. Look it up.
-
-                    let (issuer_cert, issuer_private_key) = match &api.cert_issuance.local_ca {
-                        Some(LocalCa { cert, pk }) => {
-                            let private_key =
-                                api.key_client.load_key_pair(pk).map_err(|err| {
-                                    Error::Internal(InternalError::CreateCert(Box::new(err)))
-                                })?;
-                            (cert.clone(), private_key)
-                        }
-
-                        None => {
-                            return Err(Error::Internal(InternalError::CreateCert(
-                                format!(
-                                    "cert {:?} is configured to be issued by local CA, but local CA is not configured",
-                                    id,
-                                )
-                                .into(),
-                            )))
-                        }
-                    };
-
-                    // Recurse with the local CA set explicitly as the issuer parameter.
-
-                    let x509 = create_cert(api, id, csr, Some((&issuer_cert, &issuer_private_key)))
-                        .await?;
-                    Ok(x509)
-                }
-
-                CertIssuanceMethod::SelfSigned => {
-                    // Since the client did not give us their private key handle, we assume that the key is named the same as the cert.
-                    //
-                    // TODO: Is there a way to not have to assume this?
-                    let key_pair_handle = api
-                        .key_client
-                        .load_key_pair(id)
-                        .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
-
-                    // Recurse with explicit issuer.
-                    let x509 = create_cert(api, id, csr, Some((id, &key_pair_handle))).await?;
-                    Ok(x509)
-                }
+fn build_name(subj: &CertSubject) -> Result<X509Name, BoxedError> {
+    let mut builder = X509Name::builder()
+        .map_err(|err| Error::Internal(InternalError::CreateCert(Box::new(err))))?;
+
+    match subj {
+        CertSubject::CommonName(cn) => builder.append_entry_by_text("CN", cn)?,
+        CertSubject::Subject(fields) => {
+            for (name, value) in fields {
+                builder.append_entry_by_text(name, value)?;
             }
         }
     }
 
-    Box::pin(create_cert_inner(api, id, csr, issuer))
+    Ok(builder.build())
+}
+
+#[async_recursion]
+async fn create_cert_inner<'a>(
+    api: &'a mut Api,
+    id: &'a str,
+    (req, pubkey): (&'a X509ReqRef, &'a PKeyRef<Public>),
+    issuer: Option<(&'a [X509], &'a CStr)>,
+) -> Result<Vec<u8>, BoxedError> {
+    let cert_options = api.cert_issuance.certs.get(id);
+
+    if let Some((stack, issuer_handle)) = issuer {
+        let expiry = &*Asn1Time::days_from_now(
+            cert_options.and_then(|opts| opts.expiry_days).unwrap_or(30),
+        )?;
+        let name_override = cert_options
+            .and_then(|opts| opts.subject.as_ref())
+            .map(build_name)
+            .transpose()?;
+
+        let subject_name = name_override
+            .as_deref()
+            .unwrap_or_else(|| req.subject_name());
+
+        let issuer_pk = api.key_engine.load_private_key(issuer_handle)?;
+
+        let mut builder = X509::builder()?;
+        builder.set_version(2)?;
+        builder.set_subject_name(subject_name)?;
+        builder.set_pubkey(pubkey)?;
+        builder.set_not_before(&*Asn1Time::days_from_now(0)?)?;
+
+        // x509_req.extensions() returns an Err variant if no extensions are
+        // present in the req. Ignore this Err and only copy extensions if
+        // provided in the req.
+        if let Ok(exts) = req.extensions() {
+            for ext in exts {
+                builder.append_extension(ext)?;
+            }
+        }
+
+        let (subject_name, expiry) = stack.get(0).map_or((subject_name, expiry), |x509| {
+            let issuer_expiry = x509.not_after();
+
+            (
+                x509.subject_name(),
+                if expiry < issuer_expiry {
+                    expiry
+                } else {
+                    issuer_expiry
+                },
+            )
+        });
+
+        builder.set_not_after(expiry)?;
+        builder.set_issuer_name(subject_name)?;
+        builder.sign(&issuer_pk, MessageDigest::sha256())?;
+
+        let mut pem = builder.build().to_pem()?;
+
+        for x509 in stack {
+            pem.extend_from_slice(&x509.to_pem()?);
+        }
+
+        Ok(pem)
+    } else {
+        let cert_options = cert_options.ok_or_else(|| {
+            Error::invalid_parameter("issuer", "issuer is required for locally-issued certs")
+        })?;
+
+        match &cert_options.method {
+            CertIssuanceMethod::SelfSigned => {
+                let pk = api.key_client.load_key_pair(id)?;
+
+                create_cert_inner(api, id, (req, pubkey), Some((&[], &CString::new(pk.0)?))).await
+            }
+            CertIssuanceMethod::LocalCa => {
+                let CertificateWithPrivateKey { cert, pk } = api.cert_issuance.local_ca.as_ref()
+                    .ok_or_else(||
+                        format!(
+                            "cert {:?} is configured to be issued by local CA, but local CA is not configured",
+                            id
+                        )
+                    )?;
+
+                let pem = get_cert_inner(&api.homedir_path, &api.preloaded_certs, cert)?
+                    .ok_or_else(|| format!("cert for issuer id {:?} not found", id))?;
+                let stack = X509::stack_from_pem(&pem)?;
+
+                let pk = api.key_client.load_key_pair(pk)?;
+
+                create_cert_inner(api, id, (req, pubkey), Some((&stack, &CString::new(pk.0)?)))
+                    .await
+            }
+            CertIssuanceMethod::Est { url, auth } => {
+                let default = api.cert_issuance.est.as_ref();
+
+                let auth = auth.as_ref()
+                    .or_else(|| default.map(|default| &default.auth))
+                    .ok_or_else(||
+                        format!(
+                            "cert {:?} is configured to be issued by EST, but EST auth is not configured",
+                            id
+                        )
+                    )?;
+
+                let url = url.as_ref()
+                    .or_else(||
+                        default
+                            .map(|default| &default.urls)
+                            .and_then(|urls|
+                                urls.get(id)
+                                    .or_else(|| urls.get("default"))
+                            )
+                    )
+                    .ok_or_else(||
+                        format!(
+                            "cert {:?} is configured to be issued by EST, but EST URL is not configured",
+                            id
+                        )
+                    )?;
+
+                let mut trusted_certs = vec![];
+
+                if let Some(certs) = default.map(|default| &default.trusted_certs) {
+                    for cert in certs {
+                        let pem = get_cert_inner(&api.homedir_path, &api.preloaded_certs, cert)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "cert_issuance.est.trusted_certs contains unreadable cert {:?}",
+                                    cert
+                                )
+                            })?;
+
+                        trusted_certs.extend(X509::stack_from_pem(&pem)?);
+                    }
+                }
+
+                let id_opt = auth
+                    .x509
+                    .as_ref()
+                    .map({
+                        let homedir_path = &api.homedir_path;
+                        let preloaded_certs = &api.preloaded_certs;
+                        let key_client = &api.key_client;
+                        let key_engine = &mut api.key_engine;
+
+                        move |EstAuthX509 {
+                                  identity: CertificateWithPrivateKey { cert, pk },
+                                  ..
+                              }|
+                              -> Result<_, BoxedError> {
+                            let cert = get_cert_inner(homedir_path, preloaded_certs, cert)?
+                                .ok_or_else(|| {
+                                    format!(
+                                        "could not get EST identity cert: {}",
+                                        io::Error::from(io::ErrorKind::NotFound)
+                                    )
+                                })?;
+                            let pk = key_client
+                                .load_key_pair(pk)
+                                .map_err(BoxedError::from)
+                                .and_then(|handle| Ok(CString::new(handle.0)?))
+                                .and_then(|cstr| Ok(key_engine.load_private_key(&cstr)?))
+                                .map_err(|err| {
+                                    format!("could not get EST identity cert private key: {}", err)
+                                })?;
+
+                            Ok((cert, pk))
+                        }
+                    })
+                    .transpose();
+
+                match id_opt {
+                    Ok(id_opt) => {
+                        est::create_cert(
+                            base64::encode(req.to_der()?).into_bytes(),
+                            url,
+                            auth.basic.as_ref(),
+                            id_opt.as_ref().map(|(cert, pk)| (&**cert, &**pk)),
+                            &trusted_certs,
+                            api.proxy_uri.clone(),
+                        )
+                        .await
+                    }
+                    Err(err) => {
+                        let auth_x509 = auth.x509.as_ref()
+                            .ok_or_else(||
+                                format!(
+                                    "cert {:?} is configured to be issued by EST, \
+                                    but EST identity could not be obtained \
+                                    and EST X509 authentication with bootstrapping is not in use: {}",
+                                    id, err
+                                )
+                            )?;
+
+                        let CertificateWithPrivateKey {
+                            cert: bid_cert,
+                            pk: bid_pk,
+                        } = auth_x509.bootstrap_identity.as_ref().ok_or_else(|| {
+                            format!(
+                                "cert {:?} is configured to be issued by EST, \
+                                    but EST identity could not be obtained \
+                                    and EST bootstrap identity is not configured: {}",
+                                id, err
+                            )
+                        })?;
+
+                        let bid_cert =
+                            get_cert_inner(&api.homedir_path, &api.preloaded_certs, bid_cert)?
+                                .ok_or_else(|| {
+                                    format!(
+                                        "could not get EST bootstrap identity cert: {}",
+                                        io::Error::from(io::ErrorKind::NotFound)
+                                    )
+                                })?;
+
+                        let bid_pk = api
+                            .key_client
+                            .load_key_pair(bid_pk)
+                            .map_err(BoxedError::from)
+                            .and_then(|handle| Ok(CString::new(handle.0)?))
+                            .and_then({
+                                let key_engine = &mut api.key_engine;
+
+                                move |cstr| Ok(key_engine.load_private_key(&cstr)?)
+                            })
+                            .map_err(|err| {
+                                format!(
+                                    "could not get EST bootstrap identity cert private key: {}",
+                                    err
+                                )
+                            })?;
+
+                        if let Ok(ref handle) = api.key_client.load_key_pair(&auth_x509.identity.pk)
+                        {
+                            api.key_client.delete_key_pair(handle)?;
+                        }
+
+                        let handle = api.key_client.create_key_pair_if_not_exists(
+                            &auth_x509.identity.pk,
+                            Some("ec-p256:rsa-4096:*"),
+                        )?;
+                        let cstr = CString::new(handle.0)?;
+
+                        let id_pubkey = api.key_engine.load_public_key(&cstr)?;
+                        let id_pk = api.key_engine.load_private_key(&cstr)?;
+
+                        let subject_name = if let Some(ref subject) = cert_options.subject {
+                            build_name(subject)?
+                        } else {
+                            build_name(&CertSubject::CommonName("est-id".to_owned()))?
+                        };
+
+                        // Request the new EST identity cert using the EST
+                        // bootstrap identity cert.
+                        let mut builder = X509Req::builder()?;
+                        builder.set_version(0)?;
+                        builder.set_subject_name(&subject_name)?;
+
+                        let mut exts = Stack::new()?;
+                        exts.push(extension::ExtendedKeyUsage::new().client_auth().build()?)?;
+
+                        builder.add_extensions(&exts)?;
+                        builder.set_pubkey(&id_pubkey)?;
+                        builder.sign(&id_pk, MessageDigest::sha256())?;
+
+                        let id_init = est::create_cert(
+                            base64::encode(builder.build().to_der()?).into_bytes(),
+                            url,
+                            auth.basic.as_ref(),
+                            Some((&bid_cert, &bid_pk)),
+                            &trusted_certs,
+                            api.proxy_uri.clone(),
+                        )
+                        .await
+                        .map_err(|bid_err| {
+                            format!(
+                                "cert {:?} is configured to be issued by EST, \
+                                    but neither EST identity nor EST bootstrap \
+                                    identity could be obtained: {} {}",
+                                id, err, bid_err
+                            )
+                        })?;
+                        write_cert(
+                            &api.homedir_path,
+                            &api.preloaded_certs,
+                            &auth_x509.identity.cert,
+                            &id_init,
+                        )?;
+
+                        // EST identity cert was obtained and persisted
+                        // successfully. Now recurse to retry the original cert
+                        // request.
+                        create_cert_inner(api, id, (req, pubkey), issuer).await
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn load_inner(path: &Path) -> Result<Option<Vec<u8>>, Error> {
+    match fs::read(path) {
+        Ok(cert_bytes) => Ok(Some(cert_bytes)),
+        Err(ref err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(Error::Internal(InternalError::ReadFile(err))),
+    }
 }
 
 fn get_cert_inner(
-    homedir_path: &std::path::Path,
-    preloaded_certs: &std::collections::BTreeMap<String, PreloadedCert>,
+    homedir_path: &Path,
+    preloaded_certs: &BTreeMap<String, PreloadedCert>,
     id: &str,
 ) -> Result<Option<Vec<u8>>, Error> {
     match preloaded_certs.get(id) {
@@ -857,10 +593,22 @@ fn get_cert_inner(
     }
 }
 
-fn principal_to_map(
-    principal: Vec<Principal>,
-) -> std::collections::BTreeMap<libc::uid_t, Vec<wildmatch::WildMatch>> {
-    let mut result: std::collections::BTreeMap<_, Vec<_>> = Default::default();
+fn write_cert(
+    homedir_path: &Path,
+    preloaded_certs: &BTreeMap<String, PreloadedCert>,
+    id: &str,
+    x509: &[u8],
+) -> Result<(), Error> {
+    let path = aziot_certd_config::util::get_path(homedir_path, preloaded_certs, id, true)
+        .map_err(|err| Error::Internal(InternalError::GetPath(err)))?;
+
+    fs::write(&path, x509).map_err(|err| Error::Internal(InternalError::WriteFile(err)))?;
+
+    Ok(())
+}
+
+fn principal_to_map(principal: Vec<Principal>) -> BTreeMap<libc::uid_t, Vec<wildmatch::WildMatch>> {
+    let mut result: BTreeMap<_, Vec<_>> = Default::default();
 
     for Principal { uid, certs } in principal {
         result.entry(uid).or_default().extend(

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -487,11 +487,6 @@ async fn create_cert_inner<'a>(
                                 )
                             })?;
 
-                        if let Ok(ref handle) = api.key_client.load_key_pair(&auth_x509.identity.pk)
-                        {
-                            api.key_client.delete_key_pair(handle)?;
-                        }
-
                         let handle = api.key_client.create_key_pair_if_not_exists(
                             &auth_x509.identity.pk,
                             Some("ec-p256:rsa-4096:*"),

--- a/docs/using-est-with-certd.md
+++ b/docs/using-est-with-certd.md
@@ -1,0 +1,198 @@
+# Issuing Certificates over EST with Certificates Service
+
+This document addresses the more advanced scenario of configuring the Certificates Service to issue arbitrary certificates over EST. Refer to [this document](https://github.com/Azure/iotedge/blob/master/edgelet/doc/est.md) that covers the common scenario of issuing the device ID and Edge CA certs.
+
+## Prerequisites
+
+- Certificates Service and Keys Service configured and running
+- A working EST server that processes enrollment requests
+
+## Configuration Files
+
+EST certificate issuance is configured in Certificates Service's config.toml, which by default is `/etc/aziot/certd/config.toml` or a file in `/etc/aziot/certd/config.d/`. We recommend creating a separate file in `config.d` for each certificate issuance. For example, to issue a certificate called `test-est-cert`, create the file `/etc/aziot/certd/config.d/test-est-cert.toml`.
+
+Depending on the EST certificate issuance, Certificates Service might need to access certain keys in Keys Service. This can be configured in `/etc/aziot/keyd/config.toml` or a file in `/etc/aziot/keyd/config.d/`. Again, we recommend creating a separate file in `config.d` for each certificate issuance. For example, to authorize keys for `test-est-cert`, create the file `/etc/aziot/keyd/config.d/test-est-cert.toml`.
+
+## Configuration Options
+
+The options in this section apply to the Certificates Service configuration file.
+
+The global `[cert_issuance.est]` section controls options that apply to all certificates issued over EST.
+
+Each certificate has a `[cert_issuance]` entry. By specifying `method = "est"`, the corresponding certificate will be issued over EST.
+
+```toml
+# Global options that affect all EST-issued certificates.
+[cert_issuance.est]
+
+# Trusted root certificates to validate the EST server's TLS certificate;
+# optional depending on how the EST server is configured.
+# It is not required for servers with a publicly-rooted TLS certificate.
+trusted_certs = ["cert-id"]
+
+# Provides a default URL if the EST URL is not provided for a certificate.
+# Optional if each certificate issuance specifies a URL.
+[cert_issuance.est.urls]
+default = "https://est.example.com/.well-known/est"
+
+# Below are options for authenticating with the EST server. The required options will depend on the EST
+# server's configuration. These global settings apply to all certificates that don't configure auth separately.
+[cert_issuance.est.auth]
+
+# Authentication with TLS client certificate. Provide the cert ID of the client cert and its corresponding
+# private key. Note that the aziotcs user must be authorized to access `identity_pk` in Keys Service.
+identity_cert = "identity-cert-id"
+identity_pk = "identity-cert-pk-id"
+
+# Authentication with a TLS client certificate which will be used once to create the initial certificate.
+# After the first certificate issuance, an identity_cert and identity_pk will be automatically created and
+# used. Provide the cert ID of the bootstrap client cert and its corresponding private key. Note that the
+# aziotcs user must be authorized to access `bootstrap_identity_pk` in Keys Service.
+bootstrap_identity_cert = "bootstrap-identity-cert-id"
+bootstrap_identity_pk = "bootstrap-identity-pk-id"
+
+# Authentication with username and password.
+username = "username"
+password = "password"
+
+# Sample configuration of a single EST-issued certificate.
+# Replace `name` with the desired certificate name.
+[cert_issuance.name]
+
+# Identifies this certificate as being issued over EST.
+method = "est"
+
+# Optionally, the Distinguished Name (DN) for this certificate can be overridden through the use of the
+# `common_name` string or the `subject` table. `common_name` sets the DN of the issued certificate to
+# `/CN=${common_name}`. If `subject` is used instead, the DN is set to `/${key}=${value}/..`, where `key`
+# and `value` are entries from the keys and values of `subject`. For example, if `subject` is set to >
+# subject = { "L" = "AQ", "ST" = "Antarctica", "CN" = "name" } the issued certificate will have DN
+# `/L=AQ/ST=Antarctica/CN=name`. Setting either option will result in certd ignoring the CSR DN for the
+# configured certificate. Be advised that if both `common_name` and `subject` are specified in this
+# section, the one that appears first will be used to set the DN.
+common_name = "name"
+subject = { "L" = "AQ", "ST" = "Antarctica", "CN" = "name" }
+
+# Optional EST URL to issue this certificate. Defaults to the `default` URL in `[cert_issuance.est.urls]`
+# if not provided. The URL must be provided either here or in default, i.e. certd will fail if no URL is
+# provided here and no default exists.
+url = "https://est.example.com/.well-known/est"
+
+# It is also possible to configure auth separately for each certificate. The options are the
+# same as in the global EST configuration and override the global configuration for their corresponding
+# certificate.
+identity_cert = "identity-cert-id"
+identity_pk = "identity-cert-pk-id"
+
+bootstrap_identity_cert = "bootstrap-identity-cert-id"
+bootstrap_identity_pk = "bootstrap-identity-pk-id"
+
+username = "username"
+password = "password"
+```
+
+## Sample Configuration
+
+Below are sample configuration files that can be used as starting points to test EST certificate issuance.
+
+The certd configuration file configures EST certificate issuance.
+
+`/etc/aziot/certd/config.d/test-est-cert.toml`
+
+```toml
+# Configure the trusted root CA certificate in the global EST options. This section is optional
+# if the EST server's TLS certificate is already trusted by the system's CA certificates.
+[cert_issuance.est]
+trusted_certs = ["est-server-ca"]
+
+[cert_issuance.est.urls]
+
+[preloaded_certs]
+est-server-ca = "file:///path/to/file.pem"
+
+# Configure the issuance of the EST test certificate.
+[cert_issuance.test-est-cert]
+method = "est"
+
+# Example with the EST path segment `test-est-cert` in the URL.
+# The path will depend on server configuration.
+url = "https://est.example.com/.well-known/est/test-est-cert"
+
+# This example will use the EST bootstrap certificate and key to authenticate,
+# but a cert and key ID for the identity certificate must still be provided.
+# These credentials will automatically be created, so it is sufficient to provide
+# a set of unique IDs that will not be used for any other credentials.
+identity_cert = "test-est-cert-identity-id"
+identity_pk = "test-est-cert-identity-id"
+
+# The credentials to use upon initial authentication with the EST server.
+# After that, certd will automatically create, use, and renew identity_cert and identity_pk.
+bootstrap_identity_cert = "test-est-bootstrap-cert-id"
+bootstrap_identity_pk = "test-est-bootstrap-key-id"
+
+# Load the bootstrap certificate from a file into certd.
+# This file must be readable by aziotcs.
+[preloaded_certs]
+test-est-bootstrap-cert-id = "file:///path/to/file.pem"
+
+# Allow the specified user to create this certificate.
+# Replace `1000` with the relevant user ID. Note that the root user has access to all certificates.
+[[principal]]
+uid = 1000
+certs = ["test-est-cert"]
+```
+
+The keyd configuration file authorizes aziotcs to access the required keys. It is required because the sample EST certificate issuance is using X.509-based authentication, which requires access to the corresponding private keys. This file would not be required for EST servers that authenticate only based on username and password.
+
+`/etc/aziot/keyd/config.d/test-est-cert.toml`
+
+```toml
+# Load the bootstrap certificate key from a file into key.
+# This file must be readable by aziotks.
+[preloaded_keys]
+test-est-bootstrap-key-id = "file:///path/to/file.pem"
+
+# Authorize aziotcs to access the necessary keys.
+[[principal]]
+# Replace with output of `id -u aziotcs`
+uid = 997
+
+# Should contain the key IDs of bootstrap_identity_pk and identity_pk.
+keys = ["test-est-bootstrap-key-id", "test-est-cert-identity-id"]
+```
+
+## Testing EST on the command line
+
+After configuring Certificates Service, you can test certificate issuance over EST from the command line. Generate a CSR and make a request to Certificates Service to create a new certificate.
+
+```sh
+# Generate a key for CSR.
+openssl genrsa -out key.pem
+
+# Generate CSR. Note that the common name must be provided either here in the CSR
+# or in certd's configuration.
+#
+# This command generates a simple CSR that doesn't have attributes or other useful
+# information. For a production certificate, you will likely need to add attributes
+# or configure the EST server to automatically issue certificates with the required
+# attributes.
+openssl req -new -key key.pem -subj "/CN=test-est-cert" -out req.pem
+
+# Make the request to Certificates Service.
+# The user making this request must be root or in the aziotcs group.
+# For a non-root user, the uid must match the uid in certd's authorized principals
+# (1000 in the example above).
+#
+# The request schema is:
+# {
+#     "certId": "<cert name>",
+#     "csr": "<generated CSR with newlines escaped>"
+# }
+curl --unix-socket /run/aziot/certd.sock http://localhost/certificates?api-version=2020-09-01 \
+    -H "content-type: application/json" \
+    --data "$(jq -cn --arg 'certId' 'test-est-cert' --arg 'csr' "$(cat req.pem)" '{"certId": $certId, "csr": $csr}')"
+```
+
+You should receive the newly-issued certificate as the output of the last command.
+
+If you see error messages from either Keys Service or Certificates Service that begin with `user _ is not authorized...`, check the authorized `[[principal]]` list in the keyd and certd configuration files.

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -8,24 +8,23 @@ edition = "2018"
 async-trait = "0.1"
 base64 = "0.13"
 futures-util = "0.3"
-headers = { version = "0.3", optional = true }
+headers = { version = "0.3" }
 http = "0.2"
-hyper = { version = "0.14", features = ["client", "http1", "http2", "server", "tcp"], optional = true }
-hyper-openssl = { version = "0.9", optional = true }
-hyper-proxy = { version = "0.9", features = ["openssl-tls"], default-features = false, optional = true }
+hyper = { version = "0.14", features = ["client", "http1", "http2", "server", "stream", "tcp"] }
+hyper-openssl = { version = "0.9" }
+hyper-proxy = { version = "0.9", features = ["openssl-tls"], default-features = false }
 libc = "0.2"
 log = "0.4"
 nix = "0.18"
-openssl = { version = "0.10", optional = true }
+openssl = { version = "0.10" }
+openssl-sys = { version = "0.9" }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["net", "rt-multi-thread", "sync"], optional = true }
+tokio = { version = "1", features = ["net", "rt-multi-thread", "sync", "time"] }
 tracing = { version = "0.1", features = ["log"] }
 url = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1"
 
-[features]
-tokio1 = ["headers", "hyper", "hyper-openssl", "hyper-proxy", "openssl", "tokio"]

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -8,23 +8,24 @@ edition = "2018"
 async-trait = "0.1"
 base64 = "0.13"
 futures-util = "0.3"
-headers = { version = "0.3" }
+headers = { version = "0.3", optional = true }
 http = "0.2"
-hyper = { version = "0.14", features = ["client", "http1", "http2", "server", "stream", "tcp"] }
-hyper-openssl = { version = "0.9" }
-hyper-proxy = { version = "0.9", features = ["openssl-tls"], default-features = false }
+hyper = { version = "0.14", features = ["client", "http1", "http2", "server", "tcp"], optional = true }
+hyper-openssl = { version = "0.9", optional = true }
+hyper-proxy = { version = "0.9", features = ["openssl-tls"], default-features = false, optional = true }
 libc = "0.2"
 log = "0.4"
 nix = "0.18"
-openssl = { version = "0.10" }
-openssl-sys = { version = "0.9" }
+openssl = { version = "0.10", optional = true }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = ["net", "rt-multi-thread", "sync"], optional = true }
 tracing = { version = "0.1", features = ["log"] }
 url = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1"
 
+[features]
+tokio1 = ["headers", "hyper", "hyper-openssl", "hyper-proxy", "openssl", "tokio"]

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::sync::atomic;
+
+use futures_util::future;
+
+const SD_LISTEN_FDS_START: std::os::unix::io::RawFd = 3;
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum Connector {
     Tcp {
@@ -17,14 +23,12 @@ pub enum Stream {
     Unix(std::os::unix::net::UnixStream),
 }
 
-#[cfg(feature = "tokio1")]
 #[derive(Debug)]
 pub enum AsyncStream {
     Tcp(tokio::net::TcpStream),
     Unix(tokio::net::UnixStream),
 }
 
-#[cfg(feature = "tokio1")]
 #[derive(Debug)]
 pub enum Incoming {
     Tcp {
@@ -36,7 +40,6 @@ pub enum Incoming {
     },
 }
 
-#[cfg(feature = "tokio1")]
 impl Incoming {
     pub async fn serve<H>(&mut self, server: H) -> std::io::Result<()>
     where
@@ -151,9 +154,13 @@ impl Connector {
         }
     }
 
-    #[cfg(feature = "tokio1")]
-    pub async fn incoming(self) -> std::io::Result<Incoming> {
-        let systemd_socket = get_systemd_socket()
+    pub async fn incoming(
+        self,
+        unix_socket_permission: u32,
+        socket_name: Option<String>,
+    ) -> std::io::Result<Incoming> {
+        // Check for systemd sockets.
+        let systemd_socket = get_systemd_socket(socket_name)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
         if let Some(fd) = systemd_socket {
             let sock_addr = nix::sys::socket::getsockname(fd)
@@ -269,7 +276,6 @@ impl std::str::FromStr for Connector {
     }
 }
 
-#[cfg(feature = "tokio1")]
 impl hyper::service::Service<hyper::Uri> for Connector {
     type Response = AsyncStream;
     type Error = std::io::Error;
@@ -382,7 +388,6 @@ impl std::io::Write for Stream {
     }
 }
 
-#[cfg(feature = "tokio1")]
 impl tokio::io::AsyncRead for AsyncStream {
     fn poll_read(
         mut self: std::pin::Pin<&mut Self>,
@@ -396,7 +401,6 @@ impl tokio::io::AsyncRead for AsyncStream {
     }
 }
 
-#[cfg(feature = "tokio1")]
 impl tokio::io::AsyncWrite for AsyncStream {
     fn poll_write(
         mut self: std::pin::Pin<&mut Self>,
@@ -448,7 +452,6 @@ impl tokio::io::AsyncWrite for AsyncStream {
     }
 }
 
-#[cfg(feature = "tokio1")]
 impl hyper::client::connect::Connection for AsyncStream {
     fn connected(&self) -> hyper::client::connect::Connected {
         match self {
@@ -531,7 +534,64 @@ fn get_systemd_socket() -> Result<Option<std::os::unix::io::RawFd>, String> {
                 return Err(format!("could not read LISTEN_FDS env var: {}", err))
             }
         };
-        let listen_fds: std::os::unix::io::RawFd = listen_fds
+
+    // The index in LISTEN_FDNAMES is an offset from SD_LISTEN_FDS_START.
+    let fd = index + SD_LISTEN_FDS_START;
+
+    Ok(fd)
+}
+
+fn fd_to_listener(fd: std::os::unix::io::RawFd) -> std::io::Result<Incoming> {
+    if is_unix_fd(fd)? {
+        let listener: std::os::unix::net::UnixListener =
+            unsafe { std::os::unix::io::FromRawFd::from_raw_fd(fd) };
+        listener.set_nonblocking(true)?;
+        let listener = tokio::net::UnixListener::from_std(listener)?;
+        Ok(Incoming::Unix {
+            listener,
+            user_state: Default::default(),
+        })
+    } else {
+        let listener: std::net::TcpListener =
+            unsafe { std::os::unix::io::FromRawFd::from_raw_fd(fd) };
+        listener.set_nonblocking(true)?;
+        let listener = tokio::net::TcpListener::from_std(listener)?;
+        Ok(Incoming::Tcp { listener })
+    }
+}
+
+/// Return a matching systemd socket. Checks if this process has been socket-activated.
+///
+/// This mimics `sd_listen_fds` from libsystemd, then returns the fd of systemd socket.
+fn get_systemd_socket(
+    socket_name: Option<String>,
+) -> Result<Option<std::os::unix::io::RawFd>, String> {
+    // Ref: <https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html>
+    //
+    // Try to find a systemd socket to match when non "fd" path has been provided.
+    // We consider 4 cases:
+    // 1. When there is only 1 socket. In this case, we can ignore the socket name. It means
+    // the call is made by identity service which uses only one systemd socket. So matching is simple
+    // 2. There are > 1 systemd sockets and a socket name is provided. It means edged is telling us to match an fd with the provided socket name.
+    // 3. There are > 1 systemd sockets and a socket name is provided but no LISTEN_FDNAMES. We can't match.
+    // 4. There are > 1 systemd sockets but no socket name is provided. In this case it means there is no corresponding systemd socket we should match
+    //
+    // >sd_listen_fds parses the number passed in the $LISTEN_FDS environment variable, then sets the FD_CLOEXEC flag
+    // >for the parsed number of file descriptors starting from SD_LISTEN_FDS_START. Finally, it returns the parsed number.
+    //
+    // Note that it's not possible to distinguish between fd numbers if a process requires more than one socket.
+    // That is why in edged's case we use the systemd socket name to know which fd the function should return
+    // CS/IS/KS currently only expect one socket, so this is fine; but it is not the case for iotedged (mgmt and workload sockets)
+    // for example.
+    //
+    // The complication with LISTEN_FDNAMES is that CentOS 7's systemd is too old and doesn't support it, which
+    // would mean CS/IS/KS would have to stop using systemd socket activation on CentOS 7 (just like iotedged). This creates more complications,
+    // because now the sockets either have to be placed in /var/lib/aziot (just like iotedged does) which means host modules need to try
+    // both /run/aziot and /var/lib/aziot to connect to a service, or the services continue to bind sockets under /run/aziot but have to create
+    // /run/aziot themselves on startup with ACLs for all three users and all three groups.
+
+    let listen_fds: std::os::unix::io::RawFd = match get_env("LISTEN_FDS")? {
+        Some(listen_fds) => listen_fds
             .parse()
             .map_err(|err| format!("could not read LISTEN_FDS env var: {}", err))?;
         listen_fds

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -17,13 +17,18 @@ mod dynrange;
 pub use dynrange::DynRangeBounds;
 
 mod connector;
+#[cfg(feature = "tokio1")]
 pub use connector::AsyncStream;
 pub use connector::{Connector, ConnectorError, Stream};
 
+#[cfg(feature = "tokio1")]
 mod proxy;
+#[cfg(feature = "tokio1")]
 pub use proxy::{get_proxy_uri, MaybeProxyConnector};
 
+#[cfg(feature = "tokio1")]
 mod request;
+#[cfg(feature = "tokio1")]
 pub use request::{
     request, request_no_content, request_no_content_with_retry, request_with_headers,
     request_with_headers_no_content, request_with_retry,
@@ -31,6 +36,7 @@ pub use request::{
 
 pub mod server;
 
+#[cfg(feature = "tokio1")]
 mod uid;
 
 /// Ref <https://url.spec.whatwg.org/#path-percent-encode-set>

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -17,18 +17,13 @@ mod dynrange;
 pub use dynrange::DynRangeBounds;
 
 mod connector;
-#[cfg(feature = "tokio1")]
 pub use connector::AsyncStream;
 pub use connector::{Connector, ConnectorError, Stream};
 
-#[cfg(feature = "tokio1")]
 mod proxy;
-#[cfg(feature = "tokio1")]
 pub use proxy::{get_proxy_uri, MaybeProxyConnector};
 
-#[cfg(feature = "tokio1")]
 mod request;
-#[cfg(feature = "tokio1")]
 pub use request::{
     request, request_no_content, request_no_content_with_retry, request_with_headers,
     request_with_headers_no_content, request_with_retry,
@@ -36,7 +31,6 @@ pub use request::{
 
 pub mod server;
 
-#[cfg(feature = "tokio1")]
 mod uid;
 
 /// Ref <https://url.spec.whatwg.org/#path-percent-encode-set>

--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -309,6 +309,7 @@ pub struct Error {
     pub message: std::borrow::Cow<'static, str>,
 }
 
+#[cfg(feature = "tokio1")]
 impl Error {
     pub fn to_http_response(&self) -> hyper::Response<hyper::Body> {
         let body = crate::ErrorBody {
@@ -319,41 +320,17 @@ impl Error {
     }
 }
 
-pub mod response {
-    pub fn no_content() -> hyper::Response<hyper::Body> {
-        let res = hyper::Response::builder()
-            .status(hyper::StatusCode::NO_CONTENT)
-            .body(Default::default())
-            .expect("cannot fail to build hyper response");
-
-        res
-    }
-
-    pub fn chunked<S, O, E>(
-        status_code: hyper::StatusCode,
-        body: S,
-        content_type: &'static str,
-    ) -> hyper::Response<hyper::Body>
-    where
-        S: futures_util::stream::Stream<Item = Result<O, E>> + Send + 'static,
-        O: Into<hyper::body::Bytes> + 'static,
-        E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
-    {
-        let body = hyper::Body::wrap_stream(body);
-
-        let res = hyper::Response::builder()
-            .status(status_code)
-            .header(hyper::header::CONTENT_TYPE, content_type)
-            .body(body);
-
-        let res = res.expect("cannot fail to build hyper response");
-        res
-    }
-
-    pub fn json(
-        status_code: hyper::StatusCode,
-        body: &impl serde::Serialize,
-    ) -> hyper::Response<hyper::Body> {
+#[cfg(feature = "tokio1")]
+pub fn json_response(
+    status_code: hyper::StatusCode,
+    body: Option<&impl serde::Serialize>,
+) -> hyper::Response<hyper::Body> {
+    let res = hyper::Response::builder().status(status_code);
+    // `res` is consumed by both branches, so this cannot be replaced with `Option::map_or_else`
+    //
+    // Ref: https://github.com/rust-lang/rust-clippy/issues/5822
+    #[allow(clippy::option_if_let_else)]
+    let res = if let Some(body) = body {
         let body = serde_json::to_string(body).expect("cannot fail to serialize response to JSON");
         let body = hyper::Body::from(body);
         res.header(hyper::header::CONTENT_TYPE, "application/json")
@@ -367,6 +344,7 @@ pub mod response {
 
 /// This server is never actually used, but is useful to ensure that the macro
 /// works as expected.
+#[cfg(feature = "tokio1")]
 mod test_server {
     use crate as http_common;
 

--- a/identity/aziot-cloud-client-async-common/Cargo.toml
+++ b/identity/aziot-cloud-client-async-common/Cargo.toml
@@ -24,5 +24,5 @@ aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }
 aziot-tpm-client-async = { path = "../../tpm/aziot-tpm-client-async" }
 aziot-key-client-async = { path = "../../key/aziot-key-client-async" }
 aziot-key-common = { path = "../../key/aziot-key-common" }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }
 openssl2 = { path = "../../openssl2" }

--- a/identity/aziot-dps-client-async/Cargo.toml
+++ b/identity/aziot-dps-client-async/Cargo.toml
@@ -27,5 +27,5 @@ aziot-key-client-async = { path = "../../key/aziot-key-client-async" }
 aziot-key-common = { path = "../../key/aziot-key-common" }
 aziot-tpm-client-async = { path = "../../tpm/aziot-tpm-client-async" }
 aziot-tpm-common = { path = "../../tpm/aziot-tpm-common" }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }
 openssl2 = { path = "../../openssl2" }

--- a/identity/aziot-hub-client-async/Cargo.toml
+++ b/identity/aziot-hub-client-async/Cargo.toml
@@ -28,5 +28,5 @@ aziot-key-client-async = { path = "../../key/aziot-key-client-async" }
 aziot-key-common = { path = "../../key/aziot-key-common" }
 aziot-tpm-client-async = { path = "../../tpm/aziot-tpm-client-async" }
 aziot-tpm-common = { path = "../../tpm/aziot-tpm-common" }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }
 openssl2 = { path = "../../openssl2" }

--- a/identity/aziot-identity-client-async/Cargo.toml
+++ b/identity/aziot-identity-client-async/Cargo.toml
@@ -9,4 +9,4 @@ http = "0.2"
 hyper = "0.14"
 
 aziot-identity-common-http = { path = "../aziot-identity-common-http" }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }

--- a/identity/aziot-identityd/Cargo.toml
+++ b/identity/aziot-identityd/Cargo.toml
@@ -43,7 +43,7 @@ aziot-key-openssl-engine = { path = "../../key/aziot-key-openssl-engine" }
 aziot-tpm-client-async = { path = "../../tpm/aziot-tpm-client-async" }
 aziot-tpm-common-http = { path = "../../tpm/aziot-tpm-common-http" }
 config-common = { path = "../../config-common", features = ["watcher"] }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }
 openssl2 = { path = "../../openssl2" }
 
 

--- a/key/aziot-key-client-async/Cargo.toml
+++ b/key/aziot-key-client-async/Cargo.toml
@@ -9,6 +9,6 @@ http = "0.2"
 hyper = "0.14"
 percent-encoding = "2"
 
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }
 aziot-key-common = { path = "../aziot-key-common" }
 aziot-key-common-http = { path = "../aziot-key-common-http" }

--- a/key/aziot-key-client/src/lib.rs
+++ b/key/aziot-key-client/src/lib.rs
@@ -426,7 +426,9 @@ fn try_parse_response(
         }
     }
 
-    if !is_json {
+    if (res_status_code == Some(204) && content_length.unwrap_or_default() != 0)
+        || (res_status_code != Some(204) && !is_json)
+    {
         return Err(std::io::Error::new(
             std::io::ErrorKind::Other,
             "malformed HTTP response",

--- a/key/aziot-keyd/Cargo.toml
+++ b/key/aziot-keyd/Cargo.toml
@@ -28,4 +28,4 @@ aziot-key-common = { path = "../aziot-key-common" }
 aziot-key-common-http = { path = "../aziot-key-common-http" }
 aziot-keyd-config = { path = "../aziot-keyd-config" }
 config-common = { path = "../../config-common", features = ["watcher"] }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }

--- a/tpm/aziot-tpm-client-async/Cargo.toml
+++ b/tpm/aziot-tpm-client-async/Cargo.toml
@@ -10,4 +10,4 @@ hyper = "0.14"
 
 aziot-tpm-common = { path = "../aziot-tpm-common" }
 aziot-tpm-common-http = { path = "../aziot-tpm-common-http" }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }

--- a/tpm/aziot-tpmd/Cargo.toml
+++ b/tpm/aziot-tpmd/Cargo.toml
@@ -19,4 +19,4 @@ aziot-tpm = { path = "../aziot-tpm-rs" }
 aziot-tpm-common = { path = "../aziot-tpm-common" }
 aziot-tpm-common-http = { path = "../aziot-tpm-common-http" }
 aziot-tpmd-config = { path = "../aziot-tpmd-config" }
-http-common = { path = "../../http-common", features = ["tokio1"] }
+http-common = { path = "../../http-common" }


### PR DESCRIPTION
Backport of subject DN configuration to release 1.2. One change had to be made to `certd`[^1] due to the fact that `libaziot-keys` does not have key deletion support in this branch.

Cf. #296, #302.

[^1]: https://github.com/onalante-msft/iot-identity-service/compare/main..subject-dn-backport#diff-ce1948fdb394a64e8a42f87d92e2057992c63a20520bad0c4c7359b64d0854c2L492-L496