### PR TITLE
Add missing template section

### DIFF
--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -78,7 +78,7 @@
 # method = "local_ca"                                                # - a local CA
 # common_name = "my-device"                                          # with the given common name, or...
 # subject = { L = "AQ", ST = "Antarctica", CN = "my-device" }        # with the given DN fields
-# 
+#
 ## identity key
 # identity_pk = "file:///var/secrets/device-id.key.pem"              # file URI, or...
 # identity_pk = "pkcs11:slot-id=0;object=device%20id?pin-value=1234" # PKCS#11 URI
@@ -109,10 +109,15 @@
 # method = "x509"
 # registration_id = "my-device"
 #
+## identity certificate
 # identity_cert = "file:///var/secrets/device-id.pem"                # file URI, or...
-# identity_cert = { method = "est", common_name = "my-device" }      # dynamically issued via EST, or...
-# identity_cert = { method = "local_ca", common_name = "my-device" } # dynamically issued by a local CA
+# [provisioning.authentication.identity_cert]                        # dynamically issued via...
+# method = "est"                                                     # - EST
+# method = "local_ca"                                                # - a local CA
+# common_name = "my-device"                                          # with the given common name, or...
+# subject = { L = "AQ", ST = "Antarctica", CN = "my-device" }        # with the given DN fields
 #
+## identity key
 # identity_pk = "file:///var/secrets/device-id.key.pem"              # file URI, or...
 # identity_pk = "pkcs11:slot-id=0;object=device%20id?pin-value=1234" # PKCS#11 URI
 


### PR DESCRIPTION
DPS attestation also has the same DN configuration options as manual attestation. The previous update did not include this.