### PR TITLE
DPS uses "attestation", not "authentication"

### DIFF
--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -71,6 +71,10 @@
 # [provisioning.authentication]
 # method = "x509"
 #
+## identity key
+# identity_pk = "file:///var/secrets/device-id.key.pem"              # file URI, or...
+# identity_pk = "pkcs11:slot-id=0;object=device%20id?pin-value=1234" # PKCS#11 URI
+#
 ## identity certificate
 # identity_cert = "file:///var/secrets/device-id.pem"                # file URI, or...
 # [provisioning.authentication.identity_cert]                        # dynamically issued via...
@@ -78,10 +82,6 @@
 # method = "local_ca"                                                # - a local CA
 # common_name = "my-device"                                          # with the given common name, or...
 # subject = { L = "AQ", ST = "Antarctica", CN = "my-device" }        # with the given DN fields
-#
-## identity key
-# identity_pk = "file:///var/secrets/device-id.key.pem"              # file URI, or...
-# identity_pk = "pkcs11:slot-id=0;object=device%20id?pin-value=1234" # PKCS#11 URI
 
 
 ## DPS provisioning with symmetric key
@@ -109,17 +109,17 @@
 # method = "x509"
 # registration_id = "my-device"
 #
+## identity key
+# identity_pk = "file:///var/secrets/device-id.key.pem"              # file URI, or...
+# identity_pk = "pkcs11:slot-id=0;object=device%20id?pin-value=1234" # PKCS#11 URI
+#
 ## identity certificate
 # identity_cert = "file:///var/secrets/device-id.pem"                # file URI, or...
-# [provisioning.authentication.identity_cert]                        # dynamically issued via...
+# [provisioning.attestation.identity_cert]                           # dynamically issued via...
 # method = "est"                                                     # - EST
 # method = "local_ca"                                                # - a local CA
 # common_name = "my-device"                                          # with the given common name, or...
 # subject = { L = "AQ", ST = "Antarctica", CN = "my-device" }        # with the given DN fields
-#
-## identity key
-# identity_pk = "file:///var/secrets/device-id.key.pem"              # file URI, or...
-# identity_pk = "pkcs11:slot-id=0;object=device%20id?pin-value=1234" # PKCS#11 URI
 
 
 ## DPS provisioning with TPM


### PR DESCRIPTION
Reordered identity certificate and private key fields in template for correctness.