### PR TITLE
Add get_provisioning_info API to Identity Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ version = "0.1.0"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
+ "aziot-identityd-config",
  "aziot-key-common",
  "http-common",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ aziot-key-openssl-engine-shared-test:
 
 target/openapi-schema-validated: cert/aziot-certd/openapi/*.yaml
 target/openapi-schema-validated: key/aziot-keyd/openapi/*.yaml
+target/openapi-schema-validated: identity/aziot-identityd/openapi/*.yaml
 target/openapi-schema-validated:
 	mkdir -p target
 	$(RM) target/openapi-schema-validated
@@ -122,7 +123,7 @@ target/openapi-schema-validated:
 	# The resolution is to have CI run this target separately after running `make test`.
 	if [ -f /usr/bin/docker ]; then \
 		set -euo pipefail; \
-		for f in cert/aziot-certd/openapi/*.yaml key/aziot-keyd/openapi/*.yaml; do \
+		for f in cert/aziot-certd/openapi/*.yaml key/aziot-keyd/openapi/*.yaml identity/aziot-identityd/openapi/*.yaml; do \
 			validator_output="$$( \
 				docker run --rm -v "$$PWD:/src" --user 1000 \
 					openapitools/openapi-generator-cli:v4.3.1 \

--- a/aziotctl/src/system.rs
+++ b/aziotctl/src/system.rs
@@ -91,7 +91,7 @@ async fn reprovision(uri: &url::Url) -> Result<()> {
     let connector =
         http_common::Connector::new(uri).map_err(|err| anyhow!("Invalid URI {}: {}", uri, err))?;
     let client = aziot_identity_client_async::Client::new(
-        aziot_identity_common_http::ApiVersion::V2020_09_01,
+        aziot_identity_common_http::ApiVersion::V2021_12_01,
         connector,
         0,
     );

--- a/docs/api/identity-service.md
+++ b/docs/api/identity-service.md
@@ -4,7 +4,7 @@
 
 ### Get primary cloud identity for authenticated workload
 
-`GET /identities/identity?api-version=2020-09-01`
+`GET /identities/identity?api-version=2021-12-01`
 
 The shape of the response will depend on the principal used to authenticate with the Identity Service. The association between an authorized principal and the identity type to return is based on the `idtype` in the identity service's [configuration](identity-service.md#module-provisioning--re-provisioning).
 
@@ -127,7 +127,7 @@ The returned `auth.keyHandle` value is meant to be used with the [Keys Service](
 
 ### Get IoT device provisioning result
 
-`POST /identities/device?api-version=2020-09-01`
+`POST /identities/device?api-version=2021-12-01`
 
 #### Request
 ```json
@@ -175,7 +175,7 @@ The returned `auth.keyHandle` value is meant to be used with the [Keys Service](
 ---
 
 ### List IoT Module Identities
-`GET /identities/modules?api-version=2020-09-01&type={type}`
+`GET /identities/modules?api-version=2021-12-01&type={type}`
 
 The `type` query parameter specifies the identity type to return. Accepted values are:
 - `aziot`: Module identity.
@@ -232,7 +232,7 @@ The `type` query parameter specifies the identity type to return. Accepted value
 
 ### Create IoT module identity
 
-`POST /identities/modules?api-version=2020-09-01`
+`POST /identities/modules?api-version=2021-12-01`
 
 #### Request (Module identity)
 ```json
@@ -322,7 +322,7 @@ If `localIdOpts` is not specified, the default `{"type": "x509", "attributes": "
 
 ### Get IoT module identity information
 
-`GET /identities/modules/{module-id}?api-version=2020-09-01&type={type}`
+`GET /identities/modules/{module-id}?api-version=2021-12-01&type={type}`
 
 The `type` query parameter specifies the identity type to return. Accepted values are:
 - `aziot`: Module identity.
@@ -389,7 +389,7 @@ The `type` query parameter specifies the identity type to return. Accepted value
 
 ### Update IoT module identity
 
-`PUT /identities/modules/{module-id}?api-version=2020-09-01`
+`PUT /identities/modules/{module-id}?api-version=2021-12-01`
 
 #### Request
 ```json
@@ -443,7 +443,7 @@ The `type` query parameter specifies the identity type to return. Accepted value
 
 ### Delete IoT module identity
 
-`DELETE /identities/modules/{module-id}?api-version=2020-09-01&type={type}`
+`DELETE /identities/modules/{module-id}?api-version=2021-12-01&type={type}`
 
 The `type` query parameter specifies the identity type to return. Accepted values are:
 - `aziot`: Module identity.
@@ -458,7 +458,7 @@ The `type` query parameter specifies the identity type to return. Accepted value
 
 ### Trigger IoT device reprovisioning flow
 
-`POST /identities/device/reprovision?api-version=2020-09-01`
+`POST /identities/device/reprovision?api-version=2021-12-01`
 
 #### Request
 

--- a/docs/api/identity-service.md
+++ b/docs/api/identity-service.md
@@ -110,7 +110,7 @@ The returned `auth.keyHandle` value is meant to be used with the [Keys Service](
 }
 ```
 
-`auth` will be either `symmetric_key` or `x509`.
+`auth` will be either `symmetric_key`, `x509`, or `tpm`.
 
 #### Response (Manual provisioning)
 

--- a/docs/api/identity-service.md
+++ b/docs/api/identity-service.md
@@ -94,6 +94,37 @@ The returned `auth.keyHandle` value is meant to be used with the [Keys Service](
 
 ---
 
+### Get device provisioning information
+
+`GET /identities/provisioning?api-version=2021-12-01`
+
+#### Response (DPS provisioning)
+
+```json
+{
+  "source": "dps",
+  "auth": "string",
+  "endpoint": "string",
+  "scope_id": "string",
+  "registration_id": "string"
+}
+```
+
+`auth` will be either `symmetric_key` or `x509`.
+
+#### Response (Manual provisioning)
+
+```json
+{
+  "source": "manual",
+  "auth": "string"
+}
+```
+
+`auth` will be either `sas` or `x509`.
+
+---
+
 ### Get IoT device provisioning result
 
 `POST /identities/device?api-version=2020-09-01`

--- a/identity/aziot-identity-client-async/src/lib.rs
+++ b/identity/aziot-identity-client-async/src/lib.rs
@@ -105,6 +105,21 @@ impl Client {
         Ok(())
     }
 
+    pub async fn get_provisioning_info(
+        &self,
+    ) -> Result<get_provisioning_info::Response, std::io::Error> {
+        let res: get_provisioning_info::Response = http_common::request_with_retry::<(), _>(
+            &self.inner,
+            http::Method::GET,
+            make_uri!("/identities/provisioning", self.api_version),
+            None,
+            self.max_retries,
+        )
+        .await?;
+
+        Ok(res)
+    }
+
     pub async fn create_module_identity(
         &self,
         module_name: &str,

--- a/identity/aziot-identity-common-http/Cargo.toml
+++ b/identity/aziot-identity-common-http/Cargo.toml
@@ -12,5 +12,6 @@ serde_json = "1"
 
 aziot-cert-common-http = { path = "../../cert/aziot-cert-common-http" }
 aziot-identity-common = { path = "../aziot-identity-common" }
+aziot-identityd-config = { path = "../aziot-identityd-config" }
 aziot-key-common = { path = "../../key/aziot-key-common" }
 http-common = { path = "../../http-common" }

--- a/identity/aziot-identity-common-http/src/lib.rs
+++ b/identity/aziot-identity-common-http/src/lib.rs
@@ -6,12 +6,14 @@
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ApiVersion {
     V2020_09_01,
+    V2021_12_01,
 }
 
 impl std::fmt::Display for ApiVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
             ApiVersion::V2020_09_01 => "2020-09-01",
+            ApiVersion::V2021_12_01 => "2021-12-01",
         })
     }
 }
@@ -22,6 +24,7 @@ impl std::str::FromStr for ApiVersion {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "2020-09-01" => Ok(ApiVersion::V2020_09_01),
+            "2021-12-01" => Ok(ApiVersion::V2021_12_01),
             _ => Err(()),
         }
     }
@@ -116,5 +119,77 @@ pub mod reprovision_device {
     pub struct Request {
         #[serde(rename = "type")]
         pub id_type: String,
+    }
+}
+
+pub mod get_provisioning_info {
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+    #[serde(tag = "source", rename_all = "lowercase")]
+    pub enum Response {
+        Dps {
+            auth: String,
+            endpoint: String,
+            scope_id: String,
+            registration_id: Option<String>,
+        },
+        Manual {
+            auth: String,
+        },
+        None,
+    }
+
+    impl std::convert::From<aziot_identityd_config::ProvisioningType> for Response {
+        fn from(config: aziot_identityd_config::ProvisioningType) -> Self {
+            match config {
+                aziot_identityd_config::ProvisioningType::Dps {
+                    global_endpoint,
+                    scope_id,
+                    attestation,
+                } => {
+                    let (auth, registration_id) = match attestation {
+                        aziot_identityd_config::DpsAttestationMethod::SymmetricKey {
+                            registration_id,
+                            symmetric_key: _,
+                        } => ("symmetric_key".to_string(), Some(registration_id)),
+
+                        aziot_identityd_config::DpsAttestationMethod::X509 {
+                            registration_id,
+                            identity_pk: _,
+                            identity_cert: _,
+                        } => ("x509".to_string(), registration_id),
+
+                        aziot_identityd_config::DpsAttestationMethod::Tpm { registration_id } => {
+                            ("tpm".to_string(), Some(registration_id))
+                        }
+                    };
+
+                    let endpoint = global_endpoint.to_string();
+
+                    Response::Dps {
+                        auth,
+                        endpoint,
+                        scope_id,
+                        registration_id,
+                    }
+                }
+
+                aziot_identityd_config::ProvisioningType::Manual {
+                    iothub_hostname: _,
+                    device_id: _,
+                    authentication,
+                } => {
+                    let auth = match authentication {
+                        aziot_identityd_config::ManualAuthMethod::SharedPrivateKey { .. } => {
+                            "sas".to_string()
+                        }
+                        aziot_identityd_config::ManualAuthMethod::X509 { .. } => "x509".to_string(),
+                    };
+
+                    Response::Manual { auth }
+                }
+
+                aziot_identityd_config::ProvisioningType::None => Response::None,
+            }
+        }
     }
 }

--- a/identity/aziot-identityd/openapi/2021-12-01.yaml
+++ b/identity/aziot-identityd/openapi/2021-12-01.yaml
@@ -1,0 +1,638 @@
+# Ref: https://spec.openapis.org/oas/v3.0.3
+
+openapi: 3.0.1
+
+info:
+  title: Identity Service API
+
+  version: '2021-12-01'
+
+  description: |
+    This is the specification of the HTTP API of the aziot-identityd service.
+
+  license:
+    name: 'MIT'
+
+servers:
+- url: 'http://identityd.sock/'
+  description: |
+    The server listens on a unix socket `/run/aziot/identityd.sock`
+
+
+paths:
+  /identities/identity?api-version=2021-12-01:
+    get:
+      tags:
+      - Identity operations
+      summary: Get primary cloud identity for authenticated workload (caller)
+      operationId: getIdentity
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AziotIdentityResponse'
+              examples:
+                'Response for principals associated to device identities (SAS case)':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      auth:
+                        type: 'sas'
+                        keyHandle: 'string'
+                'Response for principals associated to device identities (X.509 case)':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      auth:
+                        type: 'x509'
+                        keyHandle: 'string'
+                        certId: 'string'
+                'Response for principals associated to module identities (SAS case)':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      moduleId: 'module01'
+                      genId: '12345'
+                      auth:
+                        type: 'sas'
+                        keyHandle: 'string'
+                'Response for principals associated to module identities (X.509 case)':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      moduleId: 'module01'
+                      genId: '12345'
+                      auth:
+                        type: 'x509'
+                        keyHandle: 'string'
+                        certId: 'string'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /identities/device?api-version=2021-12-01:
+    post:
+      tags:
+      - Identity operations
+      summary: Get the IoT device provisioning result
+      operationId: getDeviceIdentity
+      x-codegen-request-body-name: GetDeviceIdentityRequest
+      requestBody:
+        description: The type of provisioned identity
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisioningResultRequest'
+            example:
+              value:
+                type: 'aziot'
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                required: ['spec', 'type']
+                type: object
+                properties:
+                  'type':
+                    $ref: '#/components/schemas/AziotIdentityType'
+                  'spec':
+                    $ref: '#/components/schemas/AziotIdentitySpec'
+              examples:
+                'SAS case':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      auth:
+                        type: 'sas'
+                        keyHandle: 'string'
+                'X.509 case':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      auth:
+                        type: 'x509'
+                        keyHandle: 'string'
+                        certId: 'string'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /identities/provisioning?api-version=2021-12-01:
+      get:
+        tags:
+        - Identity operations
+        summary: Get device provisioning settings
+        operationId: getProvisioningInfo
+        responses:
+          200:
+            description: Ok
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ProvisioningInfo'
+                examples:
+                  'DPS provisioning':
+                    value:
+                      source: 'dps'
+                      auth: 'string'
+                      endpoint: 'string'
+                      scope_id: 'string'
+                      registration_id: 'string'
+                  'Manual provisioning':
+                      value:
+                        source: 'manual'
+                        auth: 'string'
+
+  /identities/modules?api-version=2021-12-01&type={type}:
+    parameters:
+    - $ref: '#/components/parameters/AziotIdentityTypeParameter'
+    get:
+      tags:
+      - Identity operations
+      summary: List IoT module identities
+      operationId: getModuleIdentities
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AziotModuleIdentitiesResponse'
+              examples:
+                'SAS case':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      moduleId: 'module01'
+                      genId: '12345'
+                      auth:
+                        type: 'sas'
+                        keyHandle: 'string'
+                'X.509 case':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      moduleId: 'module01'
+                      genId: '12345'
+                      auth:
+                        type: 'x509'
+                        keyHandle: 'string'
+                        certId: 'string'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /identities/modules?api-version=2021-12-01:
+    post:
+      tags:
+      - Identity operations
+      summary: Create IoT module identity
+      operationId: createModuleIdentity
+      x-codegen-request-body-name: CreateModuleIdentityRequest
+      requestBody:
+        description: The type of module identity to create
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateModuleRequest'
+            examples:
+              'Module identity':
+                value:
+                  type: 'aziot'
+                  moduleId: 'module01'
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModuleIdentityResponse'
+              examples:
+                'SAS case':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      moduleId: 'module01'
+                      genId: '12345'
+                      auth:
+                        type: 'sas'
+                        keyHandle: 'string'
+                'X.509 case':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      moduleId: 'module01'
+                      genId: '12345'
+                      auth:
+                        type: 'x509'
+                        keyHandle: 'string'
+                        certId: 'string'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /identities/modules/{id}?api-version=2021-12-01&type={type}:
+    parameters:
+      - $ref: '#/components/parameters/IdentityName'
+      - $ref: '#/components/parameters/ModuleIdentityKind'
+    get:
+      tags:
+      - Identity operations
+      summary: Get IoT module identity information
+      operationId: getModuleIdentityById
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModuleIdentityResponse'
+              examples:
+                'SAS case':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      moduleId: 'module01'
+                      genId: '12345'
+                      auth:
+                        type: 'sas'
+                        keyHandle: 'string'
+                'X.509 case':
+                  value:
+                    type: 'aziot'
+                    spec:
+                      hubName: 'myhub.net'
+                      gatewayHost: 'parentdevice'
+                      deviceId: 'device01'
+                      moduleId: 'module01'
+                      genId: '12345'
+                      auth:
+                        type: 'x509'
+                        keyHandle: 'string'
+                        certId: 'string'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      tags:
+      - Identity operations
+      summary: Delete the IoT module identity
+      operationId: deleteModuleIdentity
+      responses:
+        204:
+          description: No Content
+          content: {}
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /identities/device/reprovision?api-version=2021-12-01:
+    post:
+      tags:
+      - Identity operations
+      summary: Trigger an IoT device reprovisioning flow
+      operationId: reprovision
+      x-codegen-request-body-name: ReprovisionRequest
+      requestBody:
+        description: Type of identity to reprovision
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReprovisionRequest'
+      responses:
+        200:
+          description: Ok
+          content: {}
+        204:
+          description: No Content
+          content: {}
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+
+components:
+  schemas:
+    AuthenticationCredentials:
+      required:
+      - type
+      type: object
+      properties:
+        'type':
+          type: string
+          description: Indicates the type of authentication credential used.
+          enum:
+          - sas
+          - x509
+      discriminator:
+        propertyName: type
+        mapping:
+          sas: '#/components/schemas/SASAuthenticationCredentials'
+          x509: '#/components/schemas/X509AuthenticationCredentials'
+
+    AziotIdentityResponse:
+      required:
+      - spec
+      - type
+      type: object
+      properties:
+        'type':
+          $ref: '#/components/schemas/AziotIdentityType'
+        'spec':
+          $ref: '#/components/schemas/AziotIdentitySpec'
+
+    AziotModuleIdentitiesResponse:
+      type: object
+      properties:
+        'identities':
+          type: array
+          description: A collection of 'aziot' module identities
+          items:
+            $ref: '#/components/schemas/AziotModuleIdentityResponse'
+
+    AziotIdentitySpec:
+      required:
+      - deviceId
+      - gatewayHost
+      - hubName
+      type: object
+      properties:
+        'hubName':
+          type: string
+          description: The name of the IoT hub where the device is provisioned.
+          example: myhub.net
+        'gatewayHost':
+          type: string
+          description: The hostname of the parent Edge gateway that intermediates
+            all requests for the current device when in a nested configuration. In
+            a single-node deployment (i.e. non-nested) it will match the 'hubName'.
+          example: parentdevice
+        'deviceId':
+          type: string
+          description: The identity name of the provisioned device in the assigned
+            IoT Hub.
+          example: device01
+        'moduleId':
+          type: string
+          description: The identity name of the device workload in the provisioned
+            device in the assigned IoT Hub.
+          example: module01
+        'genId':
+          type: string
+          description: The generation ID of the device workload assigned by IoT Hub.
+          example: "12345"
+        'auth':
+          $ref: '#/components/schemas/AuthenticationCredentials'
+      description: The device identity specification.
+
+    AziotIdentityType:
+      type: string
+      enum:
+      - aziot
+      example:
+        aziot:
+          value: aziot
+          summary: 'Module identity.'
+
+    AziotModuleIdentityResponse:
+      required:
+      - spec
+      - type
+      type: object
+      properties:
+        'type':
+          $ref: '#/components/schemas/AziotIdentityType'
+        'spec':
+          $ref: '#/components/schemas/AziotModuleIdentitySpec'
+
+    AziotModuleIdentitySpec:
+      allOf:
+      - $ref: '#/components/schemas/AziotIdentitySpec'
+      required:
+      - moduleId
+      - genId
+      type: object
+      properties:
+        'moduleId':
+          type: string
+          description: The identity name of the device workload in the provisioned
+            device in the assigned IoT Hub.
+          example: module01
+        'genId':
+          type: string
+          description: The generation ID of the device workload assigned by IoT Hub.
+          example: "12345"
+      description: The module identity specification.
+
+    CreateIdentityRequest:
+      required:
+      - moduleId
+      - type
+      type: object
+      properties:
+        'type':
+          $ref: '#/components/schemas/IdentityKind'
+        'moduleId':
+          type: string
+          description: Name of the module to add to the identity registry.
+          example: module01
+
+    CreateModuleRequest:
+      oneOf:
+      - $ref: '#/components/schemas/CreateIdentityRequest'
+      discriminator:
+        propertyName: type
+        mapping:
+          aziot: '#/components/schemas/CreateIdentityRequest'
+
+    ErrorResponse:
+      required:
+      - message
+      type: object
+      properties:
+        'message':
+          type: string
+
+    IdentityKind:
+      type: string
+      description: The identity type.
+      enum:
+      - aziot
+      example:
+        aziot:
+          value: aziot
+          summary: 'Azure IoT Hub identity.'
+
+    ModuleIdentityResponse:
+      oneOf:
+      - $ref: '#/components/schemas/AziotModuleIdentityResponse'
+      discriminator:
+        propertyName: 'type'
+        mapping:
+          'aziot': '#/components/schemas/AziotModuleIdentityResponse'
+
+    ProvisioningInfo:
+      required:
+        - auth
+        - endpoint
+        - registration_id
+        - scope_id
+        - source
+      type: object
+      properties:
+        'auth':
+          type: string
+          description: Type of authentication used with IoT Hub or DPS.
+          enum:
+            - sas
+            - symmetric_key
+            - tpm
+            - x509
+        'endpoint':
+          type: string
+          description: Endpoint for DPS registration.
+        'registration_id':
+          type: string
+          description: DPS registration ID.
+        'scope_id':
+          type: string
+          description: DPS scope ID.
+        'source':
+          type: string
+          description: Source of information for a provisioned device.
+          enum:
+            - dps
+            - manual
+
+    ProvisioningResultRequest:
+      required:
+      - type
+      type: object
+      properties:
+        'type':
+          $ref: '#/components/schemas/AziotIdentityType'
+
+    ReprovisionRequest:
+      required:
+      - type
+      type: object
+      properties:
+        'type':
+          type: string
+          enum:
+          - aziot
+
+    SASAuthenticationCredentials:
+      allOf:
+      - $ref: '#/components/schemas/AuthenticationCredentials'
+      required:
+      - keyHandle
+      type: object
+      properties:
+        'keyHandle':
+          type: string
+          description: Key handle used for Key Service requests.
+
+    X509AuthenticationCredentials:
+      allOf:
+      - $ref: '#/components/schemas/AuthenticationCredentials'
+      required:
+      - certId
+      - keyHandle
+      type: object
+      properties:
+        'keyHandle':
+          type: string
+          description: Key handle used for Key Service requests.
+        'certId':
+          type: string
+          description: Certificate ID of the identity X.509 certificate.
+
+
+  parameters:
+    AziotIdentityTypeParameter:
+      name: type
+      in: path
+      description: Aziot identity type
+      required: true
+      schema:
+        $ref: '#/components/schemas/AziotIdentityType'
+
+    IdentityName:
+      name: id
+      in: path
+      description: ID
+      example: module01
+      required: true
+      schema:
+        type: string
+
+    ModuleIdentityKind:
+      name: type
+      in: path
+      description: Supported identity types
+      required: true
+      schema:
+        $ref: '#/components/schemas/IdentityKind'

--- a/identity/aziot-identityd/src/http/get_provisioning_info.rs
+++ b/identity/aziot-identityd/src/http/get_provisioning_info.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+pub(super) struct Route {
+    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+}
+
+#[async_trait::async_trait]
+impl http_common::server::Route for Route {
+    type ApiVersion = aziot_identity_common_http::ApiVersion;
+    fn api_version() -> &'static dyn http_common::DynRangeBounds<Self::ApiVersion> {
+        &((aziot_identity_common_http::ApiVersion::V2021_12_01)..)
+    }
+
+    type Service = super::Service;
+    fn from_uri(
+        service: &Self::Service,
+        path: &str,
+        _query: &[(std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>)],
+        _extensions: &http::Extensions,
+    ) -> Option<Self> {
+        if path != "/identities/provisioning" {
+            return None;
+        }
+
+        Some(Route {
+            api: service.api.clone(),
+        })
+    }
+
+    async fn get(self) -> http_common::server::RouteResponse {
+        let provisioning = {
+            let api = self.api.lock().await;
+
+            api.settings.provisioning.provisioning.clone()
+        };
+
+        let res: aziot_identity_common_http::get_provisioning_info::Response = provisioning.into();
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
+        Ok(res)
+    }
+
+    type DeleteBody = serde::de::IgnoredAny;
+    type PostBody = serde::de::IgnoredAny;
+    type PutBody = serde::de::IgnoredAny;
+}

--- a/identity/aziot-identityd/src/http/mod.rs
+++ b/identity/aziot-identityd/src/http/mod.rs
@@ -3,6 +3,7 @@
 mod create_or_list_module_identity;
 mod get_caller_identity;
 mod get_device_identity;
+mod get_provisioning_info;
 mod get_trust_bundle;
 mod get_update_or_delete_module_identity;
 mod reprovision_device;
@@ -19,6 +20,7 @@ http_common::make_service! {
         create_or_list_module_identity::Route,
         get_caller_identity::Route,
         get_device_identity::Route,
+        get_provisioning_info::Route,
         get_trust_bundle::Route,
         get_update_or_delete_module_identity::Route,
         reprovision_device::Route,


### PR DESCRIPTION
- Adds an API to export provisioning information from Identity Service. This API is callable by anyone (no auth required).
- Adds a new API version `2021-12-01`, which applies only to the new get_provisioning_info API.
- Adds the get_provisioning_info API to the Identity client
- Adds documentation for get_provisioning_info