### PR TITLE
Emit base64-encoded DER in 64-character chunks

### DIFF
--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -436,7 +436,7 @@ async fn create_cert_inner<'a>(
                 match id_opt {
                     Ok(id_opt) => {
                         est::create_cert(
-                            base64::encode(req.to_der()?).into_bytes(),
+                            chunked_base64_encode(&req.to_der()?),
                             url,
                             auth.basic.as_ref(),
                             id_opt.as_ref().map(|(cert, pk)| (&**cert, &**pk)),
@@ -533,7 +533,7 @@ async fn create_cert_inner<'a>(
                         builder.sign(&id_pk, MessageDigest::sha256())?;
 
                         let id_init = est::create_cert(
-                            base64::encode(builder.build().to_der()?).into_bytes(),
+                            chunked_base64_encode(&builder.build().to_der()?),
                             url,
                             auth.basic.as_ref(),
                             Some((&bid_cert, &bid_pk)),
@@ -626,4 +626,15 @@ fn principal_to_map(principal: Vec<Principal>) -> BTreeMap<libc::uid_t, Vec<wild
     }
 
     result
+}
+
+#[inline]
+fn chunked_base64_encode(bytes: &[u8]) -> Vec<u8> {
+    const PEM_LINE_LENGTH: usize = 64;
+
+    base64::encode(bytes)
+        .into_bytes()
+        .chunks(PEM_LINE_LENGTH)
+        .flat_map(|chunk| chunk.iter().chain(b"\n"))
+        .collect()
 }


### PR DESCRIPTION
Cisco's libest implementation[^1] does not accept non-chunked inputs, and pull
296 inadvertently broke support for it by switching to an unchunked base64
encoding[^2].  Though libest is not advertised as an EST server suitable for
production, it is still popular enough to warrant accommodation by our client.
Since it seems that EST servers that accept unchunked input also accept chunked
input, it should be safe (with respect to compatibility with other servers) to
make this change.

[^1]: https://github.com/cisco/libest
[^2]: https://github.com/Azure/iot-identity-service/commit/550dad87a3222858137395343c82c67fc14e6fdd
