### PR TITLE
Specify API version for az resource tag in E2E

### DIFF
--- a/ci/e2e-tests/suite-cleanup.sh
+++ b/ci/e2e-tests/suite-cleanup.sh
@@ -57,8 +57,8 @@ while :; do
         fi
     done
 
-    <<< "$dps_ids" timeout 30s xargs az resource delete --api-version 2020-03-01 --ids >/dev/null
-    <<< "$other_ids" timeout 30s xargs az resource delete --ids >/dev/null
+    <<< "$dps_ids" timeout 30s xargs -r az resource delete --api-version 2020-03-01 --ids >/dev/null
+    <<< "$other_ids" timeout 30s xargs -r az resource delete --ids >/dev/null
 
     sleep 1
     echo 'Retrying...' >&2

--- a/ci/e2e-tests/suite-cleanup.sh
+++ b/ci/e2e-tests/suite-cleanup.sh
@@ -46,14 +46,19 @@ while :; do
     # Ref: https://github.com/Azure/azure-cli/issues/20263
     readarray -t ids <<< "$ids"
 
+    dps_ids=""
+    other_ids=""
     for resource in "${ids[@]}"
     do
         if [[ "$resource" == *"/Microsoft.Devices/ProvisioningServices/"* ]]; then
-            timeout 30s az resource delete --api-version 2020-03-01 --ids "$resource" >/dev/null
+            dps_ids+="$resource"$'\n'
         else
-            timeout 30s az resource delete --ids "$resource" >/dev/null
+            other_ids+="$resource"$'\n'
         fi
     done
+
+    <<< "$dps_ids" timeout 30s xargs az resource delete --api-version 2020-03-01 --ids >/dev/null
+    <<< "$other_ids" timeout 30s xargs az resource delete --ids >/dev/null
 
     sleep 1
     echo 'Retrying...' >&2

--- a/ci/e2e-tests/suite-setup.sh
+++ b/ci/e2e-tests/suite-setup.sh
@@ -80,8 +80,13 @@ az iot dps linked-hub create \
 # `az iot dps linked-hub create` deletes the tags on the DPS that
 # were set by `az iot dps create` for some unknown reason, so we
 # need to tag it again.
+#
+# A bug in the latest az CLI causes az resource tag to use an API
+# version not supported by the cloud. For now, we fill manually
+# specify the API version.
 >/dev/null az resource tag \
     --ids "$dps_resource_id" \
-    --tags "suite_id=$suite_id"
+    --tags "suite_id=$suite_id" \
+    --api-version 2020-03-01
 
 echo 'Created DPS' >&2

--- a/ci/e2e-tests/suite-setup.sh
+++ b/ci/e2e-tests/suite-setup.sh
@@ -82,7 +82,7 @@ az iot dps linked-hub create \
 # need to tag it again.
 #
 # A bug in the latest az CLI causes az resource tag to use an API
-# version not supported by the cloud. For now, we fill manually
+# version not supported by the cloud. For now, we will manually
 # specify the API version.
 #
 # Ref: https://github.com/Azure/azure-cli/issues/20263

--- a/ci/e2e-tests/suite-setup.sh
+++ b/ci/e2e-tests/suite-setup.sh
@@ -84,6 +84,8 @@ az iot dps linked-hub create \
 # A bug in the latest az CLI causes az resource tag to use an API
 # version not supported by the cloud. For now, we fill manually
 # specify the API version.
+#
+# Ref: https://github.com/Azure/azure-cli/issues/20263
 >/dev/null az resource tag \
     --ids "$dps_resource_id" \
     --tags "suite_id=$suite_id" \

--- a/ci/mock-dps-tests/mock-dps-provision.sh
+++ b/ci/mock-dps-tests/mock-dps-provision.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
+set -euo pipefail
+
 cd /src
 . ./ci/install-runtime-deps.sh
 . ./ci/mock-dps-tests/mock-dps-root-install.sh
-
-set -euo pipefail
 
 # Find the build output directory / the directory where CI extracted the artifact.
 #

--- a/ci/mock-dps-tests/mock-dps-root-install.sh
+++ b/ci/mock-dps-tests/mock-dps-root-install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -eu
-
 # Don't modify trusted certificates if not running on a CI container OS.
 case "$CONTAINER_OS" in
     'ubuntu:18.04' | 'debian:10-slim')


### PR DESCRIPTION
A bug in the latest az CLI causes az resource tag to use an API version not supported by the cloud. For now, we fill manually specify the API version.