### PR TITLE
Add mock-dps-server and mock-dps-provision test (#315)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
       run: |
         container_os="${{ matrix.container_os }}"
         container_os="$(sed -e 's@[:/]@-@g' <<< "$container_os")"
-        echo "::set-output name=artifact-name::aziot-key-openssl-engine-shared-test_${container_os}_${{ matrix.arch }}"
+        echo "::set-output name=artifact-name::test-artifacts_${container_os}_${{ matrix.arch }}"
 
         case "${{ matrix.arch }}" in
           'amd64') target_dir='x86_64-unknown-linux-gnu' ;;
@@ -58,6 +58,7 @@ jobs:
           target/${{ steps.generate-artifact-properties.outputs.target_dir }}/debug/aziot-key-openssl-engine-shared-test
           target/${{ steps.generate-artifact-properties.outputs.target_dir }}/debug/libaziot_key_openssl_engine_shared.so
           target/${{ steps.generate-artifact-properties.outputs.target_dir }}/debug/libaziot_keys.so
+          target/${{ steps.generate-artifact-properties.outputs.target_dir }}/debug/mock-dps-server
         if-no-files-found: 'error'
 
 
@@ -97,7 +98,7 @@ jobs:
       run: |
         container_os="${{ matrix.container_os }}"
         container_os="$(sed -e 's@[:/]@-@g' <<< "$container_os")"
-        echo "::set-output name=artifact-name::aziot-key-openssl-engine-shared-test_${container_os}_${{ matrix.arch }}"
+        echo "::set-output name=artifact-name::test-artifacts_${container_os}_${{ matrix.arch }}"
 
         case "${{ matrix.arch }}" in
           'amd64') target_dir='x86_64-unknown-linux-gnu' ;;
@@ -110,7 +111,7 @@ jobs:
       uses: 'actions/download-artifact@v2'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
-        path: 'target/${{ steps.generate-artifact-properties.outputs.aziot-key-openssl-engine-shared-test-directory }}/debug'
+        path: 'target/debug'
     - name: 'Run'
       run: |
         docker run --rm \
@@ -125,6 +126,65 @@ jobs:
         KEY_TYPE: "${{ matrix.key_type }}"
         PKCS11_BACKEND: "${{ matrix.pkcs11_backend }}"
 
+  mock-dps-tests:
+    runs-on: 'ubuntu-18.04'
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        container_os:
+        - 'centos:7'
+        - 'debian:10-slim'
+        - 'redhat/ubi8:latest'
+        - 'ubuntu:18.04'
+        arch:
+        - 'amd64'
+
+    needs: 'basic'
+
+    steps:
+    - uses: 'actions/checkout@v1'
+    - name: 'Generate artifact properties'
+      id: 'generate-artifact-properties'
+      run: |
+        container_os="${{ matrix.container_os }}"
+        container_os="$(sed -e 's@[:/]@-@g' <<< "$container_os")"
+        echo "::set-output name=artifact-name::test-artifacts_${container_os}_${{ matrix.arch }}"
+
+        case "${{ matrix.arch }}" in
+          'amd64') target_dir='x86_64-unknown-linux-gnu' ;;
+          'arm32v7') target_dir='armv7-unknown-linux-gnueabihf' ;;
+          'aarch64') target_dir='aarch64-unknown-linux-gnu' ;;
+        esac
+        echo "::set-output name=target_dir::$target_dir"
+    - name: 'Download'
+      id: 'download-artifact'
+      uses: 'actions/download-artifact@v2'
+      with:
+        name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
+        path: 'target/debug'
+    - name: 'Generate certificates'
+      run: |
+        touch ~/.rnd
+        mkdir mock_dps_server_certs
+        cd mock_dps_server_certs
+        ../ci/mock-dps-tests/mock-dps-cert-gen.sh
+    - name: 'Run mock-dps-provision'
+      run: |
+        docker run --rm \
+          -v "$GITHUB_WORKSPACE:/src" \
+          -e "CONTAINER_OS=$CONTAINER_OS" \
+          -e "ROOT_CERT=$ROOT_CERT" \
+          -e "SERVER_CERT_CHAIN=$SERVER_CERT_CHAIN" \
+          -e "SERVER_KEY=$SERVER_KEY" \
+          "${{ matrix.container_os }}" \
+          '/src/ci/mock-dps-tests/mock-dps-provision.sh'
+      env:
+        CONTAINER_OS: "${{ matrix.container_os }}"
+        ROOT_CERT: '/src/mock_dps_server_certs/root_cert.pem'
+        SERVER_CERT_CHAIN: '/src/mock_dps_server_certs/server_cert_chain.pem'
+        SERVER_KEY: '/src/mock_dps_server_certs/server_cert_key.pem'
 
   openapi:
     runs-on: 'ubuntu-18.04'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,6 @@ name = "aziot-key-openssl-engine-shared-test"
 version = "0.1.0"
 dependencies = [
  "backtrace",
- "futures-core",
  "futures-util",
  "http",
  "hyper",
@@ -408,8 +407,8 @@ dependencies = [
  "openssl-sys2",
  "openssl2",
  "structopt",
+ "test-common",
  "tokio",
- "tokio-openssl",
 ]
 
 [[package]]
@@ -1166,7 +1165,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1306,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -1669,6 +1679,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mock-dps-server"
+version = "0.1.0"
+dependencies = [
+ "aziot-dps-client-async",
+ "chrono",
+ "http",
+ "hyper",
+ "lazy_static",
+ "openssl",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "structopt",
+ "test-common",
+ "tokio",
+ "tokio-openssl",
+ "uuid",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,7 +2023,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -2015,7 +2046,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -2300,6 +2331,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-common"
+version = "0.1.0"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "hyper",
+ "openssl",
+ "tokio",
+ "tokio-openssl",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,6 +2560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.3",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,6 +2612,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wildmatch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 	"identity/aziot-identity-common",
 	"identity/aziot-identity-common-http",
 	"identity/aziot-identityd",
+	"identity/mock-dps-server",
 
 	"iotedged",
 
@@ -43,6 +44,8 @@ members = [
 
 	"pkcs11/pkcs11",
 	"pkcs11/pkcs11-sys",
+
+	"test-common",
 
 	"tpm/aziot-tpm-client-async",
 	"tpm/aziot-tpm-common-http",

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 SHELL := /bin/bash
 
 
-.PHONY: aziot-key-openssl-engine-shared-test clean default iotedged test test-release
+.PHONY: aziot-key-openssl-engine-shared-test clean default iotedged mock-dps-server test test-release
 .PHONY: deb dist install-common install-deb install-rpm rpm
 
 
@@ -107,6 +107,8 @@ iotedged:
 aziot-key-openssl-engine-shared-test:
 	$(CARGO) build -p aziot-key-openssl-engine-shared-test $(CARGO_PROFILE) --target $(CARGO_TARGET) $(CARGO_VERBOSE)
 
+mock-dps-server:
+	$(CARGO) build -p mock-dps-server $(CARGO_PROFILE) --target $(CARGO_TARGET) $(CARGO_VERBOSE)
 
 target/openapi-schema-validated: cert/aziot-certd/openapi/2020-09-01.yaml
 target/openapi-schema-validated: key/aziot-keyd/openapi/2020-09-01.yaml
@@ -147,7 +149,7 @@ test-release: test
 		(echo 'There are uncommitted modifications to aziot-keys.h' >&2; exit 1)
 
 
-test: aziot-key-openssl-engine-shared-test default iotedged
+test: aziot-key-openssl-engine-shared-test default iotedged mock-dps-server
 test: target/openapi-schema-validated
 test:
 	set -o pipefail; \
@@ -220,6 +222,7 @@ dist:
 		./cert \
 		./identity \
 		./key \
+		./test-common \
 		./tpm \
 		./iotedged \
 		/tmp/aziot-identity-service-$(PACKAGE_VERSION)

--- a/ci/install-runtime-deps.sh
+++ b/ci/install-runtime-deps.sh
@@ -10,14 +10,14 @@ case "$OS" in
         # openssl 1.0
 
         if [ "$OS" = 'platform:el8' ] && [ "$(. /etc/os-release; echo "$ID")" = 'rhel' ]; then
-            # If using RHEL 8 UBI images without a subscription then they only have access to a 
+            # If using RHEL 8 UBI images without a subscription then they only have access to a
             # subset of packages. Workaround to enable EPEL.
             yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         else
             yum install -y epel-release
         fi
 
-        yum install -y curl jq openssl
+        yum install -y curl jq openssl ca-certificates
 
         case "${PKCS11_BACKEND:-}" in
             'softhsm')
@@ -42,7 +42,7 @@ case "$OS" in
         # openssl 1.1.0 for Debian 9, 1.1.1 for the others
 
         apt-get update -y
-        DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y curl jq openssl
+        DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y curl jq openssl ca-certificates
 
         case "${PKCS11_BACKEND:-}" in
             'softhsm')

--- a/ci/mock-dps-tests/mock-dps-cert-gen.sh
+++ b/ci/mock-dps-tests/mock-dps-cert-gen.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+>mock_dps_certs.conf cat <<-EOF
+[ root_cert ]
+basicConstraints = critical, CA:TRUE
+keyUsage = keyCertSign
+
+[ server_cert ]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+EOF
+
+# Generate test root CA certificate.
+openssl genrsa -out root_cert_key.pem &> /dev/null
+openssl req -new -key root_cert_key.pem -subj "/CN=Mock_DPS_Test_Root" -out root_req.pem
+
+openssl x509 -req \
+    -in root_req.pem \
+    -extfile mock_dps_certs.conf -extensions root_cert \
+    -signkey root_cert_key.pem -sha256 \
+    -out root_cert.pem &> /dev/null
+
+# Generate test server certificate.
+openssl genrsa -out server_cert_key.pem &> /dev/null
+
+# mock-dps-server always uses hostname localhost, so its server certificate must always have CN or SAN localhost.
+openssl req -new -key server_cert_key.pem -subj "/CN=localhost" -out server_req.pem
+
+openssl x509 -req \
+    -in server_req.pem \
+    -extfile mock_dps_certs.conf -extensions server_cert \
+    -CAcreateserial -sha256 \
+    -CA root_cert.pem -CAkey root_cert_key.pem \
+    -out server_cert.pem &> /dev/null
+
+cat server_cert.pem root_cert.pem > server_cert_chain.pem
+
+echo "Generated test root CA certificate:"
+echo " - $(pwd)/root_cert.pem"
+echo ""
+echo "Generated test server certificate:"
+echo " - cert chain: $(pwd)/server_cert_chain.pem"
+echo " - key: $(pwd)/server_cert_key.pem"

--- a/ci/mock-dps-tests/mock-dps-provision.sh
+++ b/ci/mock-dps-tests/mock-dps-provision.sh
@@ -109,31 +109,10 @@ sleep 1
 identityd_pid="$!"
 sleep 5
 
-# Check provisioning info.
-result=$(curl -s \
-    --unix-socket /run/aziot/identityd.sock \
-    "http://localhost/identities/provisioning?api-version=2021-12-01" \
-    --fail \
-    | jq .)
-expected=$(jq . <<< '{"source":"dps","auth":"symmetric_key","endpoint":"https://localhost:8443/","scope_id":"scope123","registration_id":"mock-dps-provision"}')
-
-if [ "$result" != "$expected" ]; then
-    echo ""
-    echo "SYMMETRIC KEY PROVISIONING WITH MOCK DPS: FAIL"
-    echo ""
-    echo "Symmetric key provisioning information does not match."
-    echo ""
-    echo "Expected: $expected"
-    echo ""
-    echo "Got: $result"
-    echo ""
-    exit 1
-fi
-
 # Get device identity.
 device_id_response=$(curl -s \
     --unix-socket /run/aziot/identityd.sock \
-    "http://localhost/identities/device?api-version=2021-12-01" \
+    "http://localhost/identities/device?api-version=2020-09-01" \
     --data '{"type": "aziot"}' \
     -H "content-type: application/json" \
     --fail \
@@ -181,27 +160,10 @@ EOF
 identityd_pid="$!"
 sleep 5
 
-# Check provisioning info.
-result=$(curl -s --unix-socket /run/aziot/identityd.sock "http://localhost/identities/provisioning?api-version=2021-12-01" | jq .)
-expected=$(jq . <<< '{"source":"dps","auth":"x509","endpoint":"https://localhost:8443/","scope_id":"scope123","registration_id":"mock-dps-provision"}')
-
-if [ "$result" != "$expected" ]; then
-    echo ""
-    echo "X.509 PROVISIONING WITH MOCK DPS: FAIL"
-    echo ""
-    echo "X.509 provisioning information does not match."
-    echo ""
-    echo "Expected: $expected"
-    echo ""
-    echo "Got: $result"
-    echo ""
-    exit 1
-fi
-
 # Get device identity. Check that it changed with the reprovision.
 device_id_response=$(curl -s \
     --unix-socket /run/aziot/identityd.sock \
-    "http://localhost/identities/device?api-version=2021-12-01" \
+    "http://localhost/identities/device?api-version=2020-09-01" \
     --data '{"type": "aziot"}' \
     -H "content-type: application/json" \
     --fail \

--- a/ci/mock-dps-tests/mock-dps-provision.sh
+++ b/ci/mock-dps-tests/mock-dps-provision.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+cd /src
+. ./ci/install-runtime-deps.sh
+. ./ci/mock-dps-tests/mock-dps-root-install.sh
+
+set -euo pipefail
+
+# Find the build output directory / the directory where CI extracted the artifact.
+#
+# For a local build, this would be target/x86_64-unknown-linux-gnu/debug.
+# For CI, this would be target/debug.
+cd "$(find target -type f -name mock-dps-server | head -n 1 | xargs dirname)"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:$PWD"
+
+chmod +x ./aziotd
+chmod +x ./mock-dps-server
+
+# Create directories needed for the tests.
+mkdir -p /run/aziot
+mkdir -p /etc/aziot/keyd/
+mkdir -p /var/lib/aziot/keyd
+mkdir -p /etc/aziot/certd
+mkdir -p /var/lib/aziot/certd
+mkdir -p /etc/aziot/identityd
+mkdir -p /var/lib/aziot/identityd
+
+uid=$(id -u)
+
+# Start mock-dps-server and wait for it to come up.
+./mock-dps-server --port 8443 --server-cert-chain "$SERVER_CERT_CHAIN" --server-key "$SERVER_KEY" &
+server_pid="$!"
+sleep 1
+
+# mock-dps-server does not authenticate, so tests can use any arbitrary credentials.
+echo 'mock-dps-provision' | base64 > device_id_symkey
+
+touch ~/.rnd
+>device_id_cert.conf cat <<-EOF
+[ device_id_cert ]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+EOF
+
+openssl genrsa -out device_id_certkey.pem
+openssl req -new -key device_id_certkey.pem -subj "/CN=mock-dps-provision" -out device_id_certreq.pem
+
+openssl x509 -req \
+    -in device_id_certreq.pem \
+    -extfile device_id_cert.conf -extensions device_id_cert \
+    -signkey device_id_certkey.pem -sha256 \
+    -out device_id_cert.pem
+
+>/etc/aziot/keyd/config.toml cat <<-EOF
+[aziot_keys]
+homedir_path = "/var/lib/aziot/keyd"
+
+[preloaded_keys]
+device-id-symkey = "file://$PWD/device_id_symkey"
+device-id-certkey = "file://$PWD/device_id_certkey.pem"
+
+[[principal]]
+uid = $uid
+keys = ["*"]
+EOF
+
+>/etc/aziot/certd/config.toml cat<<-EOF
+homedir_path = "/var/lib/aziot/certd"
+
+[preloaded_certs]
+device-id-cert = "file://$PWD/device_id_cert.pem"
+
+[[principal]]
+uid = $uid
+certs = ["*"]
+EOF
+
+# Set up for DPS provisioning with symmetric key.
+>/etc/aziot/identityd/config.toml cat<<-EOF
+hostname = "$(hostname)"
+homedir = "/var/lib/aziot/identityd"
+
+[provisioning]
+source = "dps"
+global_endpoint = "https://localhost:8443/"
+scope_id = "scope123"
+
+[provisioning.attestation]
+method = "symmetric_key"
+registration_id = "mock-dps-provision"
+symmetric_key = "device-id-symkey"
+
+[[principal]]
+uid = $uid
+name = "aziot-edged"
+EOF
+
+# Start services and wait for them to come up.
+./aziotd aziot-keyd &
+keyd_pid="$!"
+sleep 1
+
+./aziotd aziot-certd &
+certd_pid="$!"
+sleep 1
+
+./aziotd aziot-identityd &
+identityd_pid="$!"
+sleep 5
+
+# Check provisioning info.
+result=$(curl -s \
+    --unix-socket /run/aziot/identityd.sock \
+    "http://localhost/identities/provisioning?api-version=2021-12-01" \
+    --fail \
+    | jq .)
+expected=$(jq . <<< '{"source":"dps","auth":"symmetric_key","endpoint":"https://localhost:8443/","scope_id":"scope123","registration_id":"mock-dps-provision"}')
+
+if [ "$result" != "$expected" ]; then
+    echo ""
+    echo "SYMMETRIC KEY PROVISIONING WITH MOCK DPS: FAIL"
+    echo ""
+    echo "Symmetric key provisioning information does not match."
+    echo ""
+    echo "Expected: $expected"
+    echo ""
+    echo "Got: $result"
+    echo ""
+    exit 1
+fi
+
+# Get device identity.
+device_id_response=$(curl -s \
+    --unix-socket /run/aziot/identityd.sock \
+    "http://localhost/identities/device?api-version=2021-12-01" \
+    --data '{"type": "aziot"}' \
+    -H "content-type: application/json" \
+    --fail \
+    | jq .)
+
+auth_type=$(jq .spec.auth.type <<< "$device_id_response")
+symkey_device_id=$(jq .spec.deviceId <<< "$device_id_response")
+
+if [ "$auth_type" != '"sas"' ]; then
+    echo ""
+    echo "SYMMETRIC KEY PROVISIONING WITH MOCK DPS: FAIL"
+    echo "Auth type is $auth_type, not 'sas'"
+    exit 1
+fi
+
+echo ""
+echo "SYMMETRIC KEY PROVISIONING WITH MOCK DPS: PASS"
+echo ""
+
+# Change to DPS provisioning with X.509 credential.
+kill -TERM "$identityd_pid"
+wait "$identityd_pid" || :
+
+>/etc/aziot/identityd/config.toml cat<<-EOF
+hostname = "$(hostname)"
+homedir = "/var/lib/aziot/identityd"
+
+[provisioning]
+source = "dps"
+global_endpoint = "https://localhost:8443/"
+scope_id = "scope123"
+
+[provisioning.attestation]
+method = "x509"
+registration_id = "mock-dps-provision"
+identity_cert = "device-id-cert"
+identity_pk = "device-id-certkey"
+
+[[principal]]
+uid = $uid
+name = "aziot-edged"
+EOF
+
+./aziotd aziot-identityd &
+identityd_pid="$!"
+sleep 5
+
+# Check provisioning info.
+result=$(curl -s --unix-socket /run/aziot/identityd.sock "http://localhost/identities/provisioning?api-version=2021-12-01" | jq .)
+expected=$(jq . <<< '{"source":"dps","auth":"x509","endpoint":"https://localhost:8443/","scope_id":"scope123","registration_id":"mock-dps-provision"}')
+
+if [ "$result" != "$expected" ]; then
+    echo ""
+    echo "X.509 PROVISIONING WITH MOCK DPS: FAIL"
+    echo ""
+    echo "X.509 provisioning information does not match."
+    echo ""
+    echo "Expected: $expected"
+    echo ""
+    echo "Got: $result"
+    echo ""
+    exit 1
+fi
+
+# Get device identity. Check that it changed with the reprovision.
+device_id_response=$(curl -s \
+    --unix-socket /run/aziot/identityd.sock \
+    "http://localhost/identities/device?api-version=2021-12-01" \
+    --data '{"type": "aziot"}' \
+    -H "content-type: application/json" \
+    --fail \
+    | jq .)
+
+auth_type=$(jq .spec.auth.type <<< "$device_id_response")
+x509_device_id=$(jq .spec.deviceId <<< "$device_id_response")
+
+if [ "$auth_type" != '"x509"' ]; then
+    echo ""
+    echo "X.509 PROVISIONING WITH MOCK DPS: FAIL"
+    echo "Auth type is $auth_type, not 'x509'"
+    exit 1
+fi
+
+if [ "$symkey_device_id" = "$x509_device_id" ]; then
+    echo ""
+    echo "MOCK DPS REPROVISION: FAIL"
+    echo "Device identity did not change."
+    echo ""
+    exit 1
+fi
+
+echo ""
+echo "X.509 PROVISIONING WITH MOCK DPS: PASS"
+echo ""
+
+# Clean up.
+kill -TERM "$identityd_pid"
+wait "$identityd_pid" || :
+
+kill -TERM "$certd_pid"
+wait "$certd_pid" || :
+
+kill -TERM "$keyd_pid"
+wait "$keyd_pid" || :
+
+kill -TERM "$server_pid"
+wait "$server_pid" || :

--- a/ci/mock-dps-tests/mock-dps-root-install.sh
+++ b/ci/mock-dps-tests/mock-dps-root-install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+# Don't modify trusted certificates if not running on a CI container OS.
+case "$CONTAINER_OS" in
+    'ubuntu:18.04' | 'debian:10-slim')
+        mkdir -p /usr/local/share/ca-certificates
+        cp "$ROOT_CERT" /usr/local/share/ca-certificates/dps_root_cert.crt
+        update-ca-certificates
+        ;;
+    'centos:7' | 'redhat/ubi8:latest')
+        mkdir -p /etc/pki/ca-trust/source/anchors
+        cp "$ROOT_CERT" /etc/pki/ca-trust/source/anchors/dps_root_cert.crt
+        update-ca-trust
+    ;;
+esac
+echo "Added mock DPS root certificate to system root store."

--- a/identity/mock-dps-server/Cargo.toml
+++ b/identity/mock-dps-server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mock-dps-server"
+version = "0.1.0"
+authors = ["Azure IoT Edge Devs"]
+edition = "2018"
+
+[dependencies]
+chrono = "0.4"
+http = "0.2"
+hyper = { version = "0.14", features = ["http1", "server"] }
+lazy_static = "1.4"
+openssl = "0.10"
+percent-encoding = "2"
+regex = "1"
+serde = "1"
+serde_json = "1"
+structopt = "0.3"
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+tokio-openssl = "0.6"
+uuid = { version = "0.8", features = ["v4"] }
+
+aziot-dps-client-async = { path = "../aziot-dps-client-async" }
+test-common = { path = "../../test-common" }

--- a/identity/mock-dps-server/README.md
+++ b/identity/mock-dps-server/README.md
@@ -1,0 +1,19 @@
+# mock-dps-server
+
+mock-dps-server provides a subset of DPS server functionality for testing. In its current form, it is *not* a substitute for testing with the real DPS.
+ - Does not verify any client credentials
+ - May return the same hardcoded responses to all clients
+ - May panic on error
+
+## Arguments
+
+Required arguments:
+ - `--port`: Port to listen on. Hostname is always `localhost`.
+ - `--server-cert-chain`: Path to server cert chain, starting with the leaf and ending with the root.
+ - `--server-key`: Server cert key.
+
+## TLS server certificate
+
+Since DPS only accepts requests over TLS, mock-dps-server needs a TLS server certificate. See [mock-dps-cert-gen.sh](../../ci/mock-dps-tests/mock-dps-cert-gen.sh) for an example on how to generate a root CA certificate and TLS server certificate for mock-dps-server.
+
+mock-dps-server's root CA certificate must be installed to the system's root CA certificate store.

--- a/identity/mock-dps-server/src/main.rs
+++ b/identity/mock-dps-server/src/main.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+
+mod request;
+mod server;
+
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Options {
+    #[structopt(long, value_name = "PORT")]
+    port: u16,
+
+    #[structopt(long, value_name = "SERVER_CERT_CHAIN")]
+    server_cert_chain: std::path::PathBuf,
+
+    #[structopt(long, value_name = "SERVER_KEY")]
+    server_key: std::path::PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    let options = Options::from_args();
+
+    println!(
+        "Using server certificate chain {}",
+        options.server_cert_chain.to_str().unwrap()
+    );
+    println!(
+        "Using server private key {}",
+        options.server_key.to_str().unwrap()
+    );
+
+    let server_key = std::fs::read_to_string(options.server_key).unwrap();
+    let server_key = openssl::pkey::PKey::private_key_from_pem(server_key.as_bytes()).unwrap();
+
+    println!("Listening on localhost:{}.", options.port);
+    let incoming = test_common::tokio_openssl2::Incoming::new(
+        "localhost",
+        options.port,
+        &options.server_cert_chain,
+        &server_key,
+        false,
+    )
+    .unwrap();
+
+    let dps_context = crate::server::DpsContextInner::default();
+    let dps_context = std::sync::Mutex::new(dps_context);
+    let dps_context = std::sync::Arc::new(dps_context);
+
+    let server =
+        hyper::Server::builder(incoming).serve(hyper::service::make_service_fn(move |_| {
+            let context = dps_context.clone();
+
+            let service = hyper::service::service_fn(move |req| {
+                crate::server::serve_request(context.clone(), req)
+            });
+
+            async move { Ok::<_, std::convert::Infallible>(service) }
+        }));
+
+    server.await.unwrap();
+}

--- a/identity/mock-dps-server/src/request.rs
+++ b/identity/mock-dps-server/src/request.rs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use crate::server::Response;
+
+fn register(
+    registration_id: String,
+    headers: &std::collections::HashMap<String, String>,
+    body: Option<String>,
+    context: &mut crate::server::DpsContext,
+) -> Response {
+    let body = if let Some(body) = body {
+        let body: aziot_dps_client_async::model::DeviceRegistration =
+            match serde_json::from_str(&body) {
+                Ok(body) => body,
+                Err(_) => return Response::bad_request("failed to parse register body"),
+            };
+
+        if let Some(req_reg_id) = &body.registration_id {
+            if req_reg_id != &registration_id {
+                return Response::bad_request("registration IDs in URI and request mismatch");
+            }
+        }
+
+        body
+    } else {
+        return Response::bad_request("missing required body for register");
+    };
+
+    // Unique value to use for both operation ID and device ID.
+    let uuid = uuid::Uuid::new_v4().to_hyphenated().to_string();
+
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+    let mut registration_state = aziot_dps_client_async::model::DeviceRegistrationResult {
+        tpm: None,
+        x509: None,
+        symmetric_key: None,
+        registration_id: Some(registration_id),
+        created_date_time_utc: Some(now.clone()),
+        // Use localhost as hubname so devices provisioned with mock-dps-server don't try to
+        // communicate with IoT Hub.
+        assigned_hub: Some("localhost".to_string()),
+        device_id: Some(uuid.clone()),
+        status: Some("assigned".to_string()),
+        substatus: Some("initialAssignment".to_string()),
+        error_code: None,
+        error_message: None,
+        last_updated_date_time_utc: Some(now),
+        etag: Some("mock-dps-etag".to_string()),
+    };
+
+    if body.tpm.is_some() {
+        registration_state.tpm = Some(aziot_dps_client_async::model::TpmRegistrationResult {
+            authentication_key: "mock-dps-tpm-key".to_string(),
+        });
+    } else if headers.get("authorization").is_some() {
+        registration_state.symmetric_key = Some(
+            aziot_dps_client_async::model::SymmetricKeyRegistrationResult {
+                enrollment_group_id: Some("mock-dps-enrollment-group".to_string()),
+            },
+        );
+    } else {
+        registration_state.x509 = Some(aziot_dps_client_async::model::X509RegistrationResult {
+            certificate_info: None,
+            enrollment_group_id: Some("mock-dps-enrollment-group".to_string()),
+            signing_certificate_info: None,
+        });
+    };
+
+    let operation_id = {
+        let registration = aziot_dps_client_async::model::RegistrationOperationStatus {
+            operation_id: uuid.clone(),
+            status: "assigned".to_string(),
+            registration_state: Some(registration_state),
+        };
+
+        let mut context = context.lock().unwrap();
+        context
+            .in_progress_operations
+            .insert(uuid.clone(), registration);
+
+        uuid
+    };
+
+    let response = aziot_dps_client_async::model::RegistrationOperationStatus {
+        operation_id,
+        status: "assigning".to_string(),
+        registration_state: None,
+    };
+
+    Response::json(hyper::StatusCode::OK, response)
+}
+
+fn operation_status(operation_id: &str, context: &mut crate::server::DpsContext) -> Response {
+    let mut context = context.lock().unwrap();
+
+    match context.in_progress_operations.remove(operation_id) {
+        Some(operation) => Response::json(hyper::StatusCode::OK, operation),
+        None => Response::not_found(format!("operation {} not found", operation_id)),
+    }
+}
+
+fn get_param(captures: &regex::Captures<'_>, name: &str) -> Result<String, Response> {
+    let value = &captures[name];
+
+    let value = percent_encoding::percent_decode_str(value)
+        .decode_utf8()
+        .map_err(|_| Response::bad_request(format!("bad {}", name)))?
+        .to_string();
+
+    Ok(value)
+}
+
+pub(crate) fn process_dps_request(
+    req: crate::server::ParsedRequest,
+    context: &mut crate::server::DpsContext,
+) -> Response {
+    lazy_static::lazy_static! {
+        static ref DPS_REGEX: regex::Regex = regex::Regex::new(
+            "/(?P<scopeId>[^/]+)/registrations/(?P<registrationId>[^/]+)/(?P<action>.+)\\?api-version=\\d{4}-\\d{2}-\\d{2}$"
+        ).unwrap();
+
+        static ref OPERATION_STATUS_REGEX: regex::Regex = regex::Regex::new(
+            "operations/(?P<operationId>[^/]+)$"
+        ).unwrap();
+    }
+
+    if !DPS_REGEX.is_match(&req.uri) {
+        return Response::not_found(format!("{} not found", req.uri));
+    }
+
+    let captures = DPS_REGEX.captures(&req.uri).unwrap();
+
+    let registration_id = match get_param(&captures, "registrationId") {
+        Ok(registration_id) => registration_id,
+        Err(response) => return response,
+    };
+
+    let action = match get_param(&captures, "action") {
+        Ok(action) => action,
+        Err(response) => return response,
+    };
+
+    if OPERATION_STATUS_REGEX.is_match(&action) {
+        if req.method != hyper::Method::GET {
+            return Response::method_not_allowed(&req.method);
+        }
+
+        let captures = OPERATION_STATUS_REGEX.captures(&action).unwrap();
+        let operation_id = match get_param(&captures, "operationId") {
+            Ok(operation_id) => operation_id,
+            Err(response) => return response,
+        };
+
+        operation_status(&operation_id, context)
+    } else if action == "register" {
+        if req.method != hyper::Method::PUT {
+            return Response::method_not_allowed(&req.method);
+        }
+
+        register(registration_id, &req.headers, req.body, context)
+    } else {
+        Response::not_found(format!("{} not found", req.uri))
+    }
+}

--- a/identity/mock-dps-server/src/server.rs
+++ b/identity/mock-dps-server/src/server.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+pub(crate) struct ParsedRequest {
+    pub method: hyper::Method,
+    pub uri: String,
+    pub headers: std::collections::HashMap<String, String>,
+    pub body: Option<String>,
+}
+
+impl ParsedRequest {
+    async fn from_http(req: hyper::Request<hyper::Body>) -> Result<Self, Response> {
+        println!();
+        println!("----");
+
+        let method = req.method().clone();
+        let uri = req.uri().to_string();
+        println!("> {} {} {:?}", method, uri, req.version());
+
+        let mut headers = std::collections::HashMap::with_capacity(req.headers().len());
+        for (key, value) in req.headers() {
+            let key = key.to_string();
+            let value = value
+                .to_str()
+                .map_err(|_| Response::bad_request("bad header value"))?
+                .to_string();
+
+            println!("> {}: {}", key, value);
+            headers.insert(key, value);
+        }
+
+        let body = hyper::body::to_bytes(req.into_body())
+            .await
+            .map_err(|_| Response::bad_request("unable to get body"))?
+            .to_vec();
+
+        let body = if body.is_empty() {
+            None
+        } else {
+            let body = std::str::from_utf8(&body)
+                .map_err(|_| Response::bad_request("unable to parse body"))?
+                .to_string();
+
+            println!();
+            println!("{}", body);
+
+            Some(body)
+        };
+
+        Ok(ParsedRequest {
+            method,
+            uri,
+            headers,
+            body,
+        })
+    }
+}
+
+pub(crate) enum Response {
+    Error {
+        status: hyper::StatusCode,
+        message: String,
+    },
+
+    Json {
+        status: hyper::StatusCode,
+        body: String,
+    },
+}
+
+impl Response {
+    pub fn bad_request(message: impl std::fmt::Display) -> Self {
+        Response::Error {
+            status: hyper::StatusCode::BAD_REQUEST,
+            message: message.to_string(),
+        }
+    }
+
+    pub fn not_found(message: impl std::fmt::Display) -> Self {
+        Response::Error {
+            status: hyper::StatusCode::NOT_FOUND,
+            message: message.to_string(),
+        }
+    }
+
+    pub fn method_not_allowed(method: &hyper::Method) -> Self {
+        Response::Error {
+            status: hyper::StatusCode::METHOD_NOT_ALLOWED,
+            message: format!("{} not allowed", method),
+        }
+    }
+
+    pub fn json(status: hyper::StatusCode, body: impl serde::Serialize) -> Self {
+        let body = serde_json::to_string(&body).unwrap();
+
+        Response::Json { status, body }
+    }
+
+    #[allow(clippy::wrong_self_convention)] // This function should consume self.
+    pub fn to_http(self) -> hyper::Response<hyper::Body> {
+        let mut response = hyper::Response::builder();
+
+        let (status, body, debug_body) = match self {
+            Response::Error { status, message } => {
+                println!();
+                println!("{}", message);
+
+                (status, hyper::Body::empty(), None)
+            }
+
+            Response::Json { status, body } => {
+                response = response.header(hyper::header::CONTENT_TYPE, "application/json");
+
+                (status, hyper::Body::from(body.clone()), Some(body))
+            }
+        };
+
+        println!();
+        println!("< {}", status);
+
+        let response = response.status(status).body(body).unwrap();
+
+        for (key, value) in response.headers() {
+            println!("< {}: {}", key, value.to_str().unwrap());
+        }
+
+        if let Some(body) = debug_body {
+            println!();
+            println!("{}", body);
+        }
+
+        response
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct DpsContextInner {
+    pub in_progress_operations: std::collections::BTreeMap<
+        String,
+        aziot_dps_client_async::model::RegistrationOperationStatus,
+    >,
+}
+
+pub(crate) type DpsContext = std::sync::Arc<std::sync::Mutex<DpsContextInner>>;
+
+pub(crate) async fn serve_request(
+    mut context: DpsContext,
+    req: hyper::Request<hyper::Body>,
+) -> Result<hyper::Response<hyper::Body>, std::convert::Infallible> {
+    let req = match ParsedRequest::from_http(req).await {
+        Ok(req) => req,
+        Err(response) => return Ok(response.to_http()),
+    };
+
+    Ok(crate::request::process_dps_request(req, &mut context).to_http())
+}

--- a/key/aziot-key-openssl-engine-shared-test/Cargo.toml
+++ b/key/aziot-key-openssl-engine-shared-test/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2018"
 
 [dependencies]
 backtrace = "0.3"
-futures-core = "0.3"
 futures-util = "0.3"
 http = "0.2"
-hyper = { version = "0.14", features = ["client", "http1", "server"] }
+hyper = { version = "0.14", features = ["client", "http1"] }
 hyper-openssl = "0.9"
 openssl = "0.10"
 structopt = "0.3.4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tokio-openssl = "0.6"
 
 openssl2 = { path = "../../openssl2/" }
 openssl-sys2 = { path = "../../openssl-sys2/" }
+
+test-common = { path = "../../test-common" }

--- a/key/aziot-key-openssl-engine-shared-test/src/main.rs
+++ b/key/aziot-key-openssl-engine-shared-test/src/main.rs
@@ -9,8 +9,6 @@
     clippy::use_self
 )]
 
-mod tokio_openssl2;
-
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     openssl::init();
@@ -138,7 +136,8 @@ async fn main() -> Result<(), Error> {
 
             let key = load_private_key(&mut engine, key_handle)?;
 
-            let incoming = tokio_openssl2::Incoming::new("0.0.0.0", port, &cert, &key)?;
+            let incoming =
+                test_common::tokio_openssl2::Incoming::new("0.0.0.0", port, &cert, &key, true)?;
 
             let server =
                 hyper::Server::builder(incoming).serve(hyper::service::make_service_fn(|_| {

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test-common"
+version = "0.1.0"
+license = "MIT"
+authors = ["Azure IoT Edge Devs"]
+edition = "2018"
+
+[dependencies]
+futures-core = "0.3"
+futures-util = "0.3"
+hyper = { version = "0.14", features = ["server"] }
+openssl = "0.10"
+tokio = { version = "1", features = ["net"] }
+tokio-openssl = "0.6"

--- a/test-common/src/lib.rs
+++ b/test-common/src/lib.rs
@@ -5,7 +5,7 @@
 #![allow(
     clippy::default_trait_access,
     clippy::let_unit_value,
-    clippy::missing_errors_doc,
+    clippy::missing_errors_doc
 )]
 
 pub mod tokio_openssl2;

--- a/test-common/src/lib.rs
+++ b/test-common/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#![deny(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::default_trait_access,
+    clippy::let_unit_value,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc
+)]
+
+pub mod tokio_openssl2;

--- a/test-common/src/lib.rs
+++ b/test-common/src/lib.rs
@@ -6,7 +6,6 @@
     clippy::default_trait_access,
     clippy::let_unit_value,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc
 )]
 
 pub mod tokio_openssl2;

--- a/test-common/src/tokio_openssl2.rs
+++ b/test-common/src/tokio_openssl2.rs
@@ -9,18 +9,19 @@ type HandshakeFuture = std::pin::Pin<
 >;
 
 /// A stream of incoming TLS connections, for use with a hyper server.
-pub(crate) struct Incoming {
+pub struct Incoming {
     listener: tokio::net::TcpListener,
     tls_acceptor: openssl::ssl::SslAcceptor,
     connections: futures_util::stream::FuturesUnordered<HandshakeFuture>,
 }
 
 impl Incoming {
-    pub(crate) fn new(
+    pub fn new(
         addr: &str,
         port: u16,
         cert_chain_path: &std::path::Path,
         private_key: &openssl::pkey::PKey<openssl::pkey::Private>,
+        verify_client: bool,
     ) -> std::io::Result<Self> {
         let listener = std::net::TcpListener::bind(&(addr, port))?;
         listener.set_nonblocking(true)?;
@@ -31,41 +32,43 @@ impl Incoming {
         tls_acceptor.set_certificate_chain_file(cert_chain_path)?;
         tls_acceptor.set_private_key(private_key)?;
 
-        // The root of the server cert is the CA, and we expect the client cert to be signed by this same CA.
-        // So add it to the cert store.
-        let ca_cert = {
-            let cert_chain_file = std::fs::read(cert_chain_path)?;
-            let mut cert_chain = openssl::x509::X509::stack_from_pem(&cert_chain_file)?;
-            cert_chain.pop().unwrap()
-        };
-        tls_acceptor.cert_store_mut().add_cert(ca_cert)?;
+        if verify_client {
+            // The root of the server cert is the CA, and we expect the client cert to be signed by this same CA.
+            // So add it to the cert store.
+            let ca_cert = {
+                let cert_chain_file = std::fs::read(cert_chain_path)?;
+                let mut cert_chain = openssl::x509::X509::stack_from_pem(&cert_chain_file)?;
+                cert_chain.pop().unwrap()
+            };
+            tls_acceptor.cert_store_mut().add_cert(ca_cert)?;
 
-        // Log the client cert chain. Does not change the verification result from what openssl already concluded.
-        tls_acceptor.set_verify_callback(
-            openssl::ssl::SslVerifyMode::PEER,
-            |openssl_verification_result, context| {
-                println!("Client cert:");
-                let chain = context.chain().unwrap();
-                for (i, cert) in chain.into_iter().enumerate() {
+            // Log the client cert chain. Does not change the verification result from what openssl already concluded.
+            tls_acceptor.set_verify_callback(
+                openssl::ssl::SslVerifyMode::PEER,
+                |openssl_verification_result, context| {
+                    println!("Client cert:");
+                    let chain = context.chain().unwrap();
+                    for (i, cert) in chain.into_iter().enumerate() {
+                        println!(
+                            "    #{}: {}",
+                            i + 1,
+                            cert.subject_name()
+                                .entries()
+                                .next()
+                                .unwrap()
+                                .data()
+                                .as_utf8()
+                                .unwrap()
+                        );
+                    }
                     println!(
-                        "    #{}: {}",
-                        i + 1,
-                        cert.subject_name()
-                            .entries()
-                            .next()
-                            .unwrap()
-                            .data()
-                            .as_utf8()
-                            .unwrap()
+                        "openssl verification result: {}",
+                        openssl_verification_result
                     );
-                }
-                println!(
-                    "openssl verification result: {}",
                     openssl_verification_result
-                );
-                openssl_verification_result
-            },
-        );
+                },
+            );
+        }
 
         let tls_acceptor = tls_acceptor.build();
 


### PR DESCRIPTION
Adds a test program, `mock-dps-server`, that can mock a subset of DPS functionality. Also adds the `mock-dps-provision` test, which provisions using the mocked DPS server. This new test runs as part of the commit CI.