### PR TITLE
Specify API version for az resource tag in E2E (#316)

### DIFF
--- a/ci/e2e-tests/suite-cleanup.sh
+++ b/ci/e2e-tests/suite-cleanup.sh
@@ -39,7 +39,26 @@ while :; do
         break
     fi
 
-    <<< "$ids" timeout 30s xargs az resource delete --ids >/dev/null
+    # A bug in the latest az CLI causes az resource delete to use an API
+    # version not supported by the cloud for DPS instances. For now, we
+    # will manually specify the API version when deleting DPS instances.
+    #
+    # Ref: https://github.com/Azure/azure-cli/issues/20263
+    readarray -t ids <<< "$ids"
+
+    dps_ids=""
+    other_ids=""
+    for resource in "${ids[@]}"
+    do
+        if [[ "$resource" == *"/Microsoft.Devices/ProvisioningServices/"* ]]; then
+            dps_ids+="$resource"$'\n'
+        else
+            other_ids+="$resource"$'\n'
+        fi
+    done
+
+    <<< "$dps_ids" timeout 30s xargs -r az resource delete --api-version 2020-03-01 --ids >/dev/null
+    <<< "$other_ids" timeout 30s xargs -r az resource delete --ids >/dev/null
 
     sleep 1
     echo 'Retrying...' >&2

--- a/ci/e2e-tests/suite-setup.sh
+++ b/ci/e2e-tests/suite-setup.sh
@@ -80,8 +80,15 @@ az iot dps linked-hub create \
 # `az iot dps linked-hub create` deletes the tags on the DPS that
 # were set by `az iot dps create` for some unknown reason, so we
 # need to tag it again.
+#
+# A bug in the latest az CLI causes az resource tag to use an API
+# version not supported by the cloud. For now, we will manually
+# specify the API version.
+#
+# Ref: https://github.com/Azure/azure-cli/issues/20263
 >/dev/null az resource tag \
     --ids "$dps_resource_id" \
-    --tags "suite_id=$suite_id"
+    --tags "suite_id=$suite_id" \
+    --api-version 2020-03-01
 
 echo 'Created DPS' >&2

--- a/ci/mock-dps-tests/mock-dps-provision.sh
+++ b/ci/mock-dps-tests/mock-dps-provision.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
+set -euo pipefail
+
 cd /src
 . ./ci/install-runtime-deps.sh
 . ./ci/mock-dps-tests/mock-dps-root-install.sh
-
-set -euo pipefail
 
 # Find the build output directory / the directory where CI extracted the artifact.
 #

--- a/ci/mock-dps-tests/mock-dps-root-install.sh
+++ b/ci/mock-dps-tests/mock-dps-root-install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -eu
-
 # Don't modify trusted certificates if not running on a CI container OS.
 case "$CONTAINER_OS" in
     'ubuntu:18.04' | 'debian:10-slim')


### PR DESCRIPTION
A bug in the latest az CLI causes az resource tag to use an API version not supported by the cloud. For now, we fill manually specify the API version.