### PR TITLE
When running commands as aziotks using sudo, make sure to reset $HOME to aziotks's $HOME

### DIFF
--- a/docs/pkcs11/index.md
+++ b/docs/pkcs11/index.md
@@ -22,7 +22,7 @@ pkcs11_base_slot = "<PKCS#11 URI of a slot where dynamically generated keys will
 
 ## Verifying the PKCS#11 library was installed and configured correctly
 
-After you've configured the PKCS#11 library, you can test it with `pkcs11-tool` or `p11tool`. Since the library has been configured for the Keys Service's `aziotks` Linux user, ensure that you always use that user when using `pkcs11-tool`, `p11tool`, etc. For example, prepend those commands with `sudo -u aziotks`.
+After you've configured the PKCS#11 library, you can test it with `pkcs11-tool` or `p11tool`. Since the library has been configured for the Keys Service's `aziotks` Linux user, ensure that you always use that user when using `pkcs11-tool`, `p11tool`, etc. For example, prepend those commands with `sudo -Hu aziotks`.
 
 (`$PKCS11_LIB_PATH` is the path of the PKCS#11 library that you set as the value of `aziot_keys.pkcs11_lib_path` in the `/etc/aziot/config.toml`)
 

--- a/docs/pkcs11/tpm2-pkcs11.md
+++ b/docs/pkcs11/tpm2-pkcs11.md
@@ -203,8 +203,8 @@ sudo tpm2_clear
 sudo rm -rf /var/lib/aziot/keyd/.tpm2_pkcs11
 (
     cd ~/src/tpm2-pkcs11/tools &&
-    sudo -u aziotks ./tpm2_ptool init --primary-auth '1234' &&
-    sudo -u aziotks ./tpm2_ptool addtoken \
+    sudo -Hu aziotks ./tpm2_ptool init --primary-auth '1234' &&
+    sudo -Hu aziotks ./tpm2_ptool addtoken \
         --sopin "$SO_PIN" --userpin "$PIN" \
         --label "$TOKEN" --pid '1'
 )


### PR DESCRIPTION
This works around distros like Ubuntu that have their sudo inherit $HOME from
the calling environment, which means commands like tpm2_ptool that save
tpm2-pkcs11 information in $HOME ended up doing so in the human user's $HOME
instead of aziotks's.

Fixes #325