### PR TITLE
Increase timeout for e2e-tests/test-run.sh for the sake of AlmaLinux.

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -68,7 +68,7 @@ jobs:
 
     - name: 'Run'
       run: |
-        timeout 15m ./ci/e2e-tests/test-run.sh '${{ matrix.test_name }}' &&
+        timeout 30m ./ci/e2e-tests/test-run.sh '${{ matrix.test_name }}' &&
         timeout 5m ./ci/e2e-tests/test-cleanup.sh '${{ matrix.test_name }}'
       env:
         BRANCH: "${{ github.event.inputs.branch }}"

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -84,7 +84,7 @@ jobs:
 
     - name: 'Run'
       run: |
-        timeout 15m ./ci/e2e-tests/test-run.sh '${{ matrix.test_name }}' &&
+        timeout 30m ./ci/e2e-tests/test-run.sh '${{ matrix.test_name }}' &&
         timeout 5m ./ci/e2e-tests/test-cleanup.sh '${{ matrix.test_name }}'
       env:
         BRANCH: "${{ matrix.branch }}"


### PR DESCRIPTION
AlmaLinux seems to take 15 minutes just to install updates.