### PR TITLE
E2E scheduled run fixes involving EL8.

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -68,7 +68,7 @@ jobs:
 
     - name: 'Run'
       run: |
-        timeout 15m ./ci/e2e-tests/test-run.sh '${{ matrix.test_name }}' &&
+        timeout 30m ./ci/e2e-tests/test-run.sh '${{ matrix.test_name }}' &&
         timeout 5m ./ci/e2e-tests/test-cleanup.sh '${{ matrix.test_name }}'
       env:
         BRANCH: "${{ github.event.inputs.branch }}"

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -66,7 +66,8 @@ jobs:
         - 'debian:9'
         - 'debian:10'
         - 'debian:11'
-        - 'platform:el8'
+        # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
+        # - 'platform:el8'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         test_name:
@@ -84,7 +85,7 @@ jobs:
 
     - name: 'Run'
       run: |
-        timeout 15m ./ci/e2e-tests/test-run.sh '${{ matrix.test_name }}' &&
+        timeout 30m ./ci/e2e-tests/test-run.sh '${{ matrix.test_name }}' &&
         timeout 5m ./ci/e2e-tests/test-cleanup.sh '${{ matrix.test_name }}'
       env:
         BRANCH: "${{ matrix.branch }}"


### PR DESCRIPTION
Cherry-pick from main of:

- 412eef3741ec550ba3b164683e16650538cf1685

  Increase timeout for e2e-tests/test-run.sh for the sake of AlmaLinux. (#329)

  AlmaLinux seems to take 15 minutes just to install updates.

- 3f6b402a71757869af81b8abea6ea2362e30add8

  Disable EL8 in E2E tests. (#331)

  412eef3741ec550ba3b164683e16650538cf1685 tried to fix the EL8 failures from it
  taking too long to install packages, but EL8 tests still fail because
  the Azure VM spontaneously lose ssh access after installing updates for
  some reason. Serial console doesn't reveal why.

  So this change disables EL8 runs for the sake of getting E2E tests passing,
  until we get around to investigating the VM issue.