### PR TITLE
Disable EL8 in E2E tests.

### DIFF
--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -66,7 +66,8 @@ jobs:
         - 'debian:9'
         - 'debian:10'
         - 'debian:11'
-        - 'platform:el8'
+        # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
+        # - 'platform:el8'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         test_name:


### PR DESCRIPTION
412eef3741ec550ba3b164683e16650538cf1685 tried to fix the EL8 failures from it
taking too long to install packages, but EL8 tests still fail because
the Azure VM spontaneously lose ssh access after installing updates for
some reason. Serial console doesn't reveal why.

So this change disables EL8 runs for the sake of getting E2E tests passing,
until we get around to investigating the VM issue.