### PR TITLE
Fix aziot-tpm-sys's C code to log to stderr instead of stdout.

### DIFF
--- a/tpm/aziot-tpm-sys/azure-iot-hsm-c/src/hsm_log.c
+++ b/tpm/aziot-tpm-sys/azure-iot-hsm-c/src/hsm_log.c
@@ -5,8 +5,6 @@
 
 #include "hsm_log.h"
 
-#define MAX_LOG_SIZE 256
-
 static bool g_is_log_initialized = false;
 
 static int log_level = LVL_INFO;
@@ -25,18 +23,20 @@ void log_init(int level) {
 
 void log_msg(int level, const char* file, const char* function, int line, const char* fmt_str, ...) {
     static char levels[3][5] = {"DBUG", "INFO", "ERR!"};
-    static int  syslog_levels[3] = { 7, 6, 3 };
+    static int syslog_levels[3] = { 7, 6, 3 };
 
     if (level >= log_level) {
         time_t now;
-        char buffer[MAX_LOG_SIZE];
         char time_buf[sizeof("2018-05-24T00:00:00Z")];
         time(&now);
         strftime(time_buf, sizeof(time_buf), "%FT%TZ", gmtime(&now));
+        fprintf(stderr, "<%d>%s [%s] (%s:%s:%d) ", syslog_levels[level], time_buf, levels[level], file, function, line);
+
         va_list args;
         va_start (args, fmt_str);
-        vsnprintf(buffer, MAX_LOG_SIZE, fmt_str, args);
-        printf("<%d>%s [%s] (%s:%s:%d) %s\r\n", syslog_levels[level], time_buf, levels[level], file, function, line, buffer);
+        vfprintf(stderr, fmt_str, args);
         va_end (args);
+
+        fprintf(stderr, "\n");
     }
 }


### PR DESCRIPTION
This means logs are no longer buffered until some arbitrary point in the future
(such as when the process exits). Instead they are immediately printed.

Unfortunately this does not account for logs from the C SDK dependencies,
ie utpm and c-shared, since they use their own logging macro which also writes
using `printf`. So, for example, when running tpmd without a reachable TPM
prints this:

    <6>2021-12-21T00:24:30Z [INFO] (/home/arsing/src/iot-identity-service/tpm/aziot-tpm-sys/azure-iot-hsm-c/src/hsm_log.c:log_init:20) Initialized logging
    Error: Time:Mon Dec 20 16:24:30 2021 File:/home/arsing/src/iot-identity-service/tpm/aziot-tpm-sys/azure-iot-hsm-c/deps/utpm/src/tpm_comm_linux.c Func:tpm_usermode_resmgr_connect Line:268 Failure: No user mode TRM found.
    Error: Time:Mon Dec 20 16:24:30 2021 File:/home/arsing/src/iot-identity-service/tpm/aziot-tpm-sys/azure-iot-hsm-c/deps/utpm/src/tpm_comm_linux.c Func:tpm_comm_create Line:335 Failure: connecting to the TPM device
    Error: Time:Mon Dec 20 16:24:30 2021 File:/home/arsing/src/iot-identity-service/tpm/aziot-tpm-sys/azure-iot-hsm-c/deps/utpm/src/tpm_codec.c Func:Initialize_TPM_Codec Line:256 creating tpm_comm object
    <3>2021-12-21T00:24:30Z [ERR!] (/home/arsing/src/iot-identity-service/tpm/aziot-tpm-sys/azure-iot-hsm-c/src/hsm_client_tpm_device.c:initialize_tpm_device:278) Failure initializeing TPM Codec
    <3>2021-12-21T00:24:30Z [ERR!] (/home/arsing/src/iot-identity-service/tpm/aziot-tpm-sys/azure-iot-hsm-c/src/hsm_client_tpm_device.c:hsm_client_tpm_create:311) Failure initializing tpm device.

... the "ERR!" logs are now printed to stderr, but the "Error:" logs are still
printed to stdout. Unfortunately the latter are still needed for fully
diagnosing issues.

Nevertheless, we'll at least know the aziot-tpm-sys part of the problem
more easily.

Other changes:

- Write the output directly instead of building up a string buffer first.

- Write with Unix newlines instead of Windows newlines.

Ref #233