### PR TITLE
Ensure parent directories are readable by target user when creating directories in `config apply`

### DIFF
--- a/aziotctl/aziotctl-common/src/config/mod.rs
+++ b/aziotctl/aziotctl-common/src/config/mod.rs
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
 use anyhow::Context;
+use nix::sys::stat as nix_stat;
+use nix::unistd::{self, User};
 
 pub mod apply;
 pub mod super_config;
@@ -22,98 +28,130 @@ const EST_ID_ID: &str = "est-id";
 const EST_BOOTSTRAP_ID: &str = "est-bootstrap-id";
 
 pub fn create_dir_all(
-    path: &(impl AsRef<std::path::Path> + ?Sized),
-    user: &nix::unistd::User,
+    path: &(impl AsRef<Path> + ?Sized),
+    user: &User,
     mode: u32,
 ) -> anyhow::Result<()> {
     let path = path.as_ref();
     let path_displayable = path.display();
 
-    let () = std::fs::create_dir_all(path)
+    // Create `path` and all its parent directories.
+    let () = fs::create_dir_all(path)
         .with_context(|| format!("could not create {} directory", path_displayable))?;
 
-    {
-        // Enforce all parent directories of `path` are readable by `user`, by checking that at least one of these is true:
-        //
-        // - The directory is world-readable.
-        // - The directory is group-readable and `user.gid` is the group.
-        // - The directory is owner-readable and `user.uid` is the owner.
-        //
-        // Note that "readable" means r+x, not just r, because we're talking about directories.
-        //
-        // This is basically reimplementing `access(path, R_OK | X_OK)` but for the `user` user
-        // instead of this process's user (which is root). The alternative would to spawn a child process
-        // as `user` that does the `access` call. If we end up needing this pattern for more places
-        // in the codebase, we can consider that option.
-        //
-        // If none of those conditions are true, we don't know which one is semantically correct to enforce,
-        // so we default to enforcing the first one, ie we make the directory world-readable. `path` itself is still
-        // created with the given `mode`, so it can be as open or closed as the caller wants it to be.
-
-        let mut parent = path.parent();
-        while let Some(dir) = parent {
-            parent = dir.parent();
-
-            let nix::sys::stat::FileStat {
-                st_mode,
-                st_uid,
-                st_gid,
-                ..
-            } = nix::sys::stat::stat(dir)
-                .with_context(|| format!("could not stat {} directory", dir.display()))?;
-            if (st_mode & 0o005) != 0o005 {
-                // World-readable
-                continue;
-            }
-            if st_mode & 0o050 != 0o050 && st_gid == user.gid.as_raw() {
-                // Group-readable by `user.gid`
-                continue;
-            }
-            if st_mode & 0o500 != 0o500 && st_uid == user.uid.as_raw() {
-                // Owner-readable by `user.uid`
-                continue;
-            }
-
-            // Make it world-readable
-            let () = std::fs::set_permissions(
-                dir,
-                std::os::unix::fs::PermissionsExt::from_mode(st_mode | 0o005),
-            )
-            .with_context(|| {
-                format!("could not set permissions on {} directory", dir.display(),)
-            })?;
-        }
+    // Enforce all parent directories of `path` are readable by `user`.
+    if let Some(parent) = path.parent() {
+        check_readable(parent, user, true)?;
     }
 
-    let () = nix::unistd::chown(path, Some(user.uid), Some(user.gid))
+    // Set `path` itself to have the given owner and mode.
+    let () = unistd::chown(path, Some(user.uid), Some(user.gid))
         .with_context(|| format!("could not set ownership on {} directory", path_displayable))?;
-
-    let () = std::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(mode))
-        .with_context(|| {
-            format!(
-                "could not set permissions on {} directory",
-                path_displayable
-            )
-        })?;
+    let () = fs::set_permissions(path, fs::Permissions::from_mode(mode)).with_context(|| {
+        format!(
+            "could not set permissions on {} directory",
+            path_displayable
+        )
+    })?;
 
     Ok(())
 }
 
 pub fn write_file(
-    path: &(impl AsRef<std::path::Path> + ?Sized),
+    path: &(impl AsRef<Path> + ?Sized),
     content: &[u8],
-    user: &nix::unistd::User,
+    user: &User,
     mode: u32,
 ) -> anyhow::Result<()> {
     let path = path.as_ref();
     let path_displayable = path.display();
 
-    let () = std::fs::write(path, content)
+    let () = fs::write(path, content)
         .with_context(|| format!("could not create {}", path_displayable))?;
-    let () = nix::unistd::chown(path, Some(user.uid), Some(user.gid))
+    let () = unistd::chown(path, Some(user.uid), Some(user.gid))
         .with_context(|| format!("could not set ownership on {}", path_displayable))?;
-    let () = std::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(mode))
+    let () = fs::set_permissions(path, fs::Permissions::from_mode(mode))
         .with_context(|| format!("could not set permissions on {}", path_displayable))?;
+
+    Ok(())
+}
+
+/// Enforce `path` and its parent directories all the way to the root are readable by `user`,
+/// by checking that at least one of these is true:
+///
+/// - The segment is world-readable.
+/// - The segment is group-readable and `user.gid` is the group.
+/// - The segment is owner-readable and `user.uid` is the owner.
+///
+/// Note that for directories, "readable" means r+x, not just r.
+///
+/// This is basically reimplementing `access(path, R_OK)` and `access(path, R_OK | X_OK)` but for the `user` user
+/// instead of this process's user (which is root). The alternative would to spawn a child process as `user`
+/// that does the `access` call. If we end up needing this pattern for more places in the codebase,
+/// we can consider that option.
+///
+/// If a non-readable segment is found, the behavior of the function depends on the value of `fix`.
+/// If `fix` is `false`, the function returns an error indicating which segment is not readable.
+/// If `fix` is `true`, the function changes the mode of the segment to make it readable.
+/// For files, the function makes the file owner-readable by the user.
+/// For directories, the function makes the directory world-readable.
+pub fn check_readable(mut path: &Path, user: &User, fix: bool) -> anyhow::Result<()> {
+    loop {
+        let nix_stat::FileStat {
+            st_mode,
+            st_uid,
+            st_gid,
+            ..
+        } = nix_stat::stat(path).with_context(|| format!("could not stat {}", path.display()))?;
+
+        let is_directory =
+            st_mode & nix_stat::SFlag::S_IFMT.bits() == nix_stat::SFlag::S_IFDIR.bits();
+        let readable_bits: nix_stat::mode_t = if is_directory { 0o4 | 0o1 } else { 0o4 };
+
+        let is_world_readable = (st_mode & readable_bits) == readable_bits;
+        let is_group_readable =
+            st_mode & (readable_bits << 3) == (readable_bits << 3) && st_gid == user.gid.as_raw();
+        let is_owner_readable =
+            st_mode & (readable_bits << 6) == (readable_bits << 6) && st_uid == user.uid.as_raw();
+
+        if !is_world_readable && !is_group_readable && !is_owner_readable {
+            if fix {
+                if is_directory {
+                    // Make it world-readable
+                    let () = fs::set_permissions(
+                        path,
+                        fs::Permissions::from_mode(st_mode | readable_bits),
+                    )
+                    .with_context(|| format!("could not set permissions on {}", path.display()))?;
+                } else {
+                    // Make it owner-readable by `user.uid`
+                    let () =
+                        unistd::chown(path, Some(user.uid), Some(user.gid)).with_context(|| {
+                            format!("could not set ownership on {}", path.display())
+                        })?;
+                    let () = fs::set_permissions(
+                        path,
+                        fs::Permissions::from_mode(st_mode | (readable_bits << 6)),
+                    )
+                    .with_context(|| format!("could not set permissions on {}", path.display()))?;
+                }
+            } else {
+                return Err(anyhow::anyhow!(
+                    "{} is not readable by user {} (uid {}, gid {})",
+                    path.display(),
+                    user.name,
+                    user.uid,
+                    user.gid
+                ));
+            }
+        }
+
+        if let Some(parent) = path.parent() {
+            path = parent;
+        } else {
+            break;
+        }
+    }
 
     Ok(())
 }

--- a/aziotctl/src/check.rs
+++ b/aziotctl/src/check.rs
@@ -326,7 +326,7 @@ pub async fn check(mut cfg: Options) -> Result<()> {
             };
 
             if let Err(err) = serde_json::to_writer(std::io::stdout(), &check_results) {
-                eprintln!("Could not write JSON output: {}", err,);
+                eprintln!("Could not write JSON output: {}", err);
             }
         }
         OutputFormat::Text => {}

--- a/aziotctl/src/internal/check/checks/cert_expiry.rs
+++ b/aziotctl/src/internal/check/checks/cert_expiry.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 use anyhow::{anyhow, Result};
+use nix::unistd::User;
 use serde::Serialize;
 
 use crate::internal::check::util::CertificateValidityExt;
@@ -46,6 +47,8 @@ impl IdentityCert {
     ) -> Result<CheckResult> {
         use aziot_identityd_config::{DpsAttestationMethod, ManualAuthMethod, ProvisioningType};
 
+        let aziotcs_user = crate::internal::common::get_system_user("aziotcs")?;
+
         let provisioning = &unwrap_or_skip!(&cache.cfg.identityd)
             .provisioning
             .provisioning
@@ -75,8 +78,13 @@ impl IdentityCert {
         if let Some((identity_cert, identity_cert_name)) = cert {
             let certd_config = unwrap_or_skip!(&cache.cfg.certd);
 
-            let (res, cert_info) =
-                validate_cert(certd_config, identity_cert, identity_cert_name).await?;
+            let (res, cert_info) = validate_cert(
+                certd_config,
+                identity_cert,
+                identity_cert_name,
+                &aziotcs_user,
+            )
+            .await?;
             self.certificate_info = cert_info;
             Ok(res)
         } else {
@@ -115,6 +123,8 @@ impl EstIdentityBootstrapCerts {
     ) -> Result<CheckResult> {
         let certd_config = unwrap_or_skip!(&cache.cfg.certd);
 
+        let aziotcs_user = crate::internal::common::get_system_user("aziotcs")?;
+
         let certs = certd_config
             .cert_issuance
             .est
@@ -135,8 +145,13 @@ impl EstIdentityBootstrapCerts {
             Some((identity, bootstrap)) => {
                 let (identity_cert_id, identity_cert_name) = identity;
 
-                let (identity_cert_res, identity_certificate_info) =
-                    validate_cert(certd_config, identity_cert_id, identity_cert_name).await?;
+                let (identity_cert_res, identity_certificate_info) = validate_cert(
+                    certd_config,
+                    identity_cert_id,
+                    identity_cert_name,
+                    &aziotcs_user,
+                )
+                .await?;
                 self.identity_certificate_info = identity_certificate_info;
 
                 // TODO: clean this up if a checks ever get the ability to return multiple results
@@ -145,8 +160,13 @@ impl EstIdentityBootstrapCerts {
                 }
 
                 if let Some((bootstrap_cert_id, bootstrap_cert_name)) = bootstrap {
-                    let (bootstrap_cert_res, bootstrap_certificate_info) =
-                        validate_cert(certd_config, bootstrap_cert_id, bootstrap_cert_name).await?;
+                    let (bootstrap_cert_res, bootstrap_certificate_info) = validate_cert(
+                        certd_config,
+                        bootstrap_cert_id,
+                        bootstrap_cert_name,
+                        &aziotcs_user,
+                    )
+                    .await?;
                     self.bootstrap_certificate_info = bootstrap_certificate_info;
 
                     if !matches!(bootstrap_cert_res, CheckResult::Ok) {
@@ -200,7 +220,10 @@ impl LocalCaCert {
             None => return Ok(CheckResult::Ignored),
         };
 
-        let (res, cert_info) = validate_cert(certd_config, cert_id, "Local CA").await?;
+        let aziotcs_user = crate::internal::common::get_system_user("aziotcs")?;
+
+        let (res, cert_info) =
+            validate_cert(certd_config, cert_id, "Local CA", &aziotcs_user).await?;
         self.certificate_info = cert_info;
         Ok(res)
     }
@@ -215,6 +238,7 @@ async fn validate_cert(
     certd_config: &aziot_certd_config::Config,
     cert_id: &str,
     cert_name: &str,
+    aziotcs_user: &User,
 ) -> anyhow::Result<(CheckResult, Option<CertificateValidity>)> {
     let path = aziot_certd_config::util::get_path(
         &certd_config.homedir_path,
@@ -225,7 +249,7 @@ async fn validate_cert(
     .map_err(|e| anyhow!("{}", e))?;
 
     if path.exists() {
-        let cert_info = CertificateValidity::new(path, cert_name, cert_id).await?;
+        let cert_info = CertificateValidity::new(path, cert_name, cert_id, aziotcs_user).await?;
         cert_info
             .to_check_result()
             .map(|res| (res, Some(cert_info)))

--- a/aziotctl/src/internal/check/checks/certs_preloaded.rs
+++ b/aziotctl/src/internal/check/checks/certs_preloaded.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::{anyhow, Result};
+use nix::unistd::User;
 use serde::Serialize;
 use url::Url;
 
@@ -44,8 +45,10 @@ impl CertsPreloaded {
 
         let mut visited: BTreeMap<_, _> = Default::default();
 
+        let aziotcs_user = crate::internal::common::get_system_user("aziotcs")?;
+
         for id in preloaded_certs.keys() {
-            match walk_preloaded_certs(id, preloaded_certs, &mut visited).await? {
+            match walk_preloaded_certs(id, preloaded_certs, &aziotcs_user, &mut visited).await? {
                 CheckResult::Ok => {}
                 res => return Ok(res),
             }
@@ -59,6 +62,7 @@ impl CertsPreloaded {
 async fn walk_preloaded_certs<'a>(
     id: &'a str,
     preloaded_certs: &'a BTreeMap<String, PreloadedCert>,
+    aziotcs_user: &'a User,
     visited: &mut BTreeMap<&'a str, &'a Url>,
 ) -> Result<CheckResult> {
     match preloaded_certs.get(id) {
@@ -80,7 +84,7 @@ async fn walk_preloaded_certs<'a>(
                     ));
                 }
 
-                match CertificateValidity::new(uri.path(), "", id)
+                match CertificateValidity::new(uri.path(), "", id, aziotcs_user)
                     .await?
                     .to_check_result()?
                 {
@@ -92,7 +96,7 @@ async fn walk_preloaded_certs<'a>(
 
         Some(PreloadedCert::Ids(ids)) => {
             for id in ids {
-                match walk_preloaded_certs(id, preloaded_certs, visited).await? {
+                match walk_preloaded_certs(id, preloaded_certs, aziotcs_user, visited).await? {
                     CheckResult::Ok => {}
                     res => return Ok(res),
                 }

--- a/aziotctl/src/internal/check/checks/read_key_pairs.rs
+++ b/aziotctl/src/internal/check/checks/read_key_pairs.rs
@@ -66,75 +66,73 @@ impl ReadKeyPairs {
         let aziotks_user = crate::internal::common::get_system_user("aziotks")?;
 
         for (id, path) in preloaded_keys {
-            let mut readable = true;
             if let Ok(aziot_keys_common::PreloadedKeyLocation::Filesystem { path }) = path.parse() {
                 if let Err(err) =
                     aziotctl_common::config::check_readable(&path, &aziotks_user, false)
                 {
                     err_aggregated.push(format!("{:?}", err));
-                    readable = false;
+                    // There's no point trying to load the key through the API,
+                    // so just continue to the next key.
+                    continue;
                 }
             }
 
-            if readable {
-                // Load the key through the keyd API and collect any errors.
-                //
-                // We don't know whether `id` is a symmetric or asymmetric key,
-                // and the `load_key_pair` error doesn't tell us whether it failed because it's a symmetric key
-                // or because of some other reason.
-                //
-                // We also can't go behind keyd's back and load the keys ourselves, because the point of this check
-                // is to test keyd's ability to load the keys, but also because only keyd is allowed to load PKCS#11 keys
-                // since PKCS#11 implementations are generally not cross-process-safe.
-                //
-                // So as a best effort, ignore errors from loading key pairs entirely.
-                let key_handle = if let Ok(key_handle) = key_client.load_key_pair(id).await {
-                    key_handle
-                } else {
-                    continue;
-                };
+            // Load the key through the keyd API and collect any errors.
+            //
+            // We don't know whether `id` is a symmetric or asymmetric key,
+            // and the `load_key_pair` error doesn't tell us whether it failed because it's a symmetric key
+            // or because of some other reason.
+            //
+            // We also can't go behind keyd's back and load the keys ourselves, because the point of this check
+            // is to test keyd's ability to load the keys, but also because only keyd is allowed to load PKCS#11 keys
+            // since PKCS#11 implementations are generally not cross-process-safe.
+            //
+            // So as a best effort, ignore errors from loading key pairs entirely.
+            let key_handle = if let Ok(key_handle) = key_client.load_key_pair(id).await {
+                key_handle
+            } else {
+                continue;
+            };
 
-                let key = || {
-                    let key_handle = std::ffi::CString::new(key_handle.0)
-                        .context("internal error: key handle is malformed")?;
-                    let key = key_engine.load_private_key(&key_handle).with_context(|| {
-                        format!("could not load preloaded private key with ID {:?}", id)
-                    })?;
-                    Ok::<_, anyhow::Error>(key)
-                };
+            let key = || {
+                let key_handle = std::ffi::CString::new(key_handle.0)
+                    .context("internal error: key handle is malformed")?;
+                let key = key_engine.load_private_key(&key_handle).with_context(|| {
+                    format!("could not load preloaded private key with ID {:?}", id)
+                })?;
+                Ok::<_, anyhow::Error>(key)
+            };
 
-                match key() {
-                    Ok(key) => {
-                        if let Ok(rsa) = key.rsa() {
-                            let key_length = rsa.size() * 8;
+            match key() {
+                Ok(key) => {
+                    if let Ok(rsa) = key.rsa() {
+                        let key_length = rsa.size() * 8;
 
-                            if key_length < RSA_RECOMMENDED_MIN_BITS {
-                                warn_aggregated.push(format!(
-                                    "RSA key {} has length {} (min recommended: {})",
-                                    id, key_length, RSA_RECOMMENDED_MIN_BITS
-                                ));
-                            }
-                        } else if let Ok(ec_key) = key.ec_key() {
-                            if ec_key.group().curve_name()
-                                != Some(openssl::nid::Nid::X9_62_PRIME256V1)
-                            {
-                                warn_aggregated.push(format!(
-                                    "EC key {} not using recommended curve (recommended: P-256)",
-                                    id
-                                ));
-                            }
-                        } else {
+                        if key_length < RSA_RECOMMENDED_MIN_BITS {
                             warn_aggregated.push(format!(
-                                "Key {} not using recommended algorithm (recommended: RSA, EC)",
+                                "RSA key {} has length {} (min recommended: {})",
+                                id, key_length, RSA_RECOMMENDED_MIN_BITS
+                            ));
+                        }
+                    } else if let Ok(ec_key) = key.ec_key() {
+                        if ec_key.group().curve_name() != Some(openssl::nid::Nid::X9_62_PRIME256V1)
+                        {
+                            warn_aggregated.push(format!(
+                                "EC key {} not using recommended curve (recommended: P-256)",
                                 id
                             ));
                         }
+                    } else {
+                        warn_aggregated.push(format!(
+                            "Key {} not using recommended algorithm (recommended: RSA, EC)",
+                            id
+                        ));
+                    }
 
-                        cache.private_keys.insert(id.clone(), key);
-                    }
-                    Err(err) => {
-                        err_aggregated.push(format!("{:?}", err));
-                    }
+                    cache.private_keys.insert(id.clone(), key);
+                }
+                Err(err) => {
+                    err_aggregated.push(format!("{:?}", err));
                 }
             }
         }


### PR DESCRIPTION
When `config apply` creates the /var/secrets/aziot/keyd directory to store
the inline symmetric key, it assumed that parent directories would already
be readable by the target user. But this is not a valid assumption since
it depends on root's umask, and we've had a few cases of devices where
root's umask is such that new directories are 0700 or 0750 by default.

This change adds a step of walking through the parents,
checking if they're readable by the target user, and making them
world-readable if they're not.