### PR TITLE
Add documentation for socket throttling

### DIFF
--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -38,5 +38,6 @@
         </ul>
 
         <li><a href="/iot-identity-service/using-est-with-certd.html">Issuing Certificates over EST (Advanced)</a></li>
+        <li><a href="/iot-identity-service/socket-throttling.html">Socket Throttling</a></li>
     </ul>
 </div>

--- a/docs/socket-throttling.md
+++ b/docs/socket-throttling.md
@@ -1,3 +1,13 @@
 # Socket Throttling
 
-Each of the services' sockets implement a throttling mechanism to prevent a malicious process from making continuous requests and denying service to other processes.
+Each of the services' sockets implement a throttling mechanism to prevent a malicious process from making continuous requests and denying service to other processes. This throttling mechanism limits each UNIX user to making 10 simultaneous requests per socket.
+
+If requests on a socket exceed this limit, a service will deny all further requests on its socket until the number of in-progress requests falls below 10. When a service denies a request, it closes the socket connection without sending a reply; this will be reported as an OS-level error (not an HTTP API error) to the caller. It is always the caller's responsibility to retry a request that failed due to throttling.
+
+In addition to closing the socket connection, services will also log a message. The exact message may change between versions, but it will always specify which user (UNIX UID) was throttled.
+
+```
+[INFO] Max simultaneous connections reached for user 1000
+```
+
+Note that even the services' users (i.e. `aziotks`, `aziotcs`, `aziotid`) are subject to throttling when they make a request to other services.

--- a/docs/socket-throttling.md
+++ b/docs/socket-throttling.md
@@ -1,0 +1,3 @@
+# Socket Throttling
+
+Each of the services' sockets implement a throttling mechanism to prevent a malicious process from making continuous requests and denying service to other processes.

--- a/docs/socket-throttling.md
+++ b/docs/socket-throttling.md
@@ -1,6 +1,6 @@
 # Socket Throttling
 
-Each of the services' sockets implement a throttling mechanism to prevent a malicious process from making continuous requests and denying service to other processes. This throttling mechanism limits each UNIX user to making 10 simultaneous requests per socket.
+Each of the services' sockets implement a throttling mechanism to prevent a malicious process from making continuous requests and denying service to other processes. This throttling mechanism limits each caller to making 10 simultaneous requests per socket. Each caller is identified by its UID, so two processes sharing the same UNIX user will be throttled together.
 
 If requests on a socket exceed this limit, a service will deny all further requests on its socket until the number of in-progress requests falls below 10. When a service denies a request, it closes the socket connection without sending a reply; this will be reported as an OS-level error (not an HTTP API error) to the caller. It is always the caller's responsibility to retry a request that failed due to throttling.
 


### PR DESCRIPTION
Documents the socket throttling mechanism of the services, which limits all users to 10 simultaneous requests.