### PR TITLE
Ensure parent directories are readable by target user when creating directories in `config apply`

### DIFF
--- a/aziotctl/aziotctl-common/src/config/mod.rs
+++ b/aziotctl/aziotctl-common/src/config/mod.rs
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
 use anyhow::Context;
+use nix::sys::stat as nix_stat;
+use nix::unistd::{self, User};
 
 pub mod apply;
 pub mod super_config;
@@ -21,44 +27,127 @@ const EST_ID_ID: &str = "est-id";
 /// The ID used for the private key and cert that is used as the client cert to authenticate with the EST server for the initial bootstrap.
 const EST_BOOTSTRAP_ID: &str = "est-bootstrap-id";
 
-pub fn create_dir_all(
-    path: &(impl AsRef<std::path::Path> + ?Sized),
-    user: &nix::unistd::User,
-    mode: u32,
-) -> anyhow::Result<()> {
+pub fn create_dir_all(path: impl AsRef<Path>, user: &User, mode: u32) -> anyhow::Result<()> {
     let path = path.as_ref();
     let path_displayable = path.display();
 
-    let () = std::fs::create_dir_all(path)
+    // Create `path` and all its parent directories.
+    let () = fs::create_dir_all(path)
         .with_context(|| format!("could not create {} directory", path_displayable))?;
-    let () = nix::unistd::chown(path, Some(user.uid), Some(user.gid))
+
+    // Enforce all parent directories of `path` are readable by `user`.
+    if let Some(parent) = path.parent() {
+        check_readable(parent, user, true)?;
+    }
+
+    // Set `path` itself to have the given owner and mode.
+    let () = unistd::chown(path, Some(user.uid), Some(user.gid))
         .with_context(|| format!("could not set ownership on {} directory", path_displayable))?;
-    let () = std::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(mode))
-        .with_context(|| {
-            format!(
-                "could not set permissions on {} directory",
-                path_displayable
-            )
-        })?;
+    let () = fs::set_permissions(path, fs::Permissions::from_mode(mode)).with_context(|| {
+        format!(
+            "could not set permissions on {} directory",
+            path_displayable
+        )
+    })?;
 
     Ok(())
 }
 
 pub fn write_file(
-    path: &(impl AsRef<std::path::Path> + ?Sized),
+    path: impl AsRef<Path>,
     content: &[u8],
-    user: &nix::unistd::User,
+    user: &User,
     mode: u32,
 ) -> anyhow::Result<()> {
     let path = path.as_ref();
     let path_displayable = path.display();
 
-    let () = std::fs::write(path, content)
+    let () = fs::write(path, content)
         .with_context(|| format!("could not create {}", path_displayable))?;
-    let () = nix::unistd::chown(path, Some(user.uid), Some(user.gid))
+    let () = unistd::chown(path, Some(user.uid), Some(user.gid))
         .with_context(|| format!("could not set ownership on {}", path_displayable))?;
-    let () = std::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(mode))
+    let () = fs::set_permissions(path, fs::Permissions::from_mode(mode))
         .with_context(|| format!("could not set permissions on {}", path_displayable))?;
+
+    Ok(())
+}
+
+/// Enforce `path` and its parent directories all the way to the root are readable by `user`,
+/// by checking that at least one of these is true:
+///
+/// - The segment is world-readable.
+/// - The segment is group-readable and `user.gid` is the group.
+/// - The segment is owner-readable and `user.uid` is the owner.
+///
+/// Note that for directories, "readable" means r+x, not just r.
+///
+/// This is basically reimplementing `access(path, R_OK)` and `access(path, R_OK | X_OK)` but for the `user` user
+/// instead of this process's user (which is root). The alternative would to spawn a child process as `user`
+/// that does the `access` call. If we end up needing this pattern for more places in the codebase,
+/// we can consider that option.
+///
+/// If a non-readable segment is found, the behavior of the function depends on the value of `fix`.
+/// If `fix` is `false`, the function returns an error indicating which segment is not readable.
+/// If `fix` is `true`, the function changes the mode of the segment to make it readable.
+/// For files, the function makes the file owner-readable by the user.
+/// For directories, the function makes the directory world-readable.
+pub fn check_readable(mut path: &Path, user: &User, fix: bool) -> anyhow::Result<()> {
+    loop {
+        let nix_stat::FileStat {
+            st_mode,
+            st_uid,
+            st_gid,
+            ..
+        } = nix_stat::stat(path).with_context(|| format!("could not stat {}", path.display()))?;
+
+        let is_directory =
+            st_mode & nix_stat::SFlag::S_IFMT.bits() == nix_stat::SFlag::S_IFDIR.bits();
+        let readable_bits: nix_stat::mode_t = if is_directory { 0o4 | 0o1 } else { 0o4 };
+
+        let is_world_readable = (st_mode & readable_bits) == readable_bits;
+        let is_group_readable =
+            st_mode & (readable_bits << 3) == (readable_bits << 3) && st_gid == user.gid.as_raw();
+        let is_owner_readable =
+            st_mode & (readable_bits << 6) == (readable_bits << 6) && st_uid == user.uid.as_raw();
+
+        if !is_world_readable && !is_group_readable && !is_owner_readable {
+            if fix {
+                if is_directory {
+                    // Make it world-readable
+                    let () = fs::set_permissions(
+                        path,
+                        fs::Permissions::from_mode(st_mode | readable_bits),
+                    )
+                    .with_context(|| format!("could not set permissions on {}", path.display()))?;
+                } else {
+                    // Make it owner-readable by `user.uid`
+                    let () =
+                        unistd::chown(path, Some(user.uid), Some(user.gid)).with_context(|| {
+                            format!("could not set ownership on {}", path.display())
+                        })?;
+                    let () = fs::set_permissions(
+                        path,
+                        fs::Permissions::from_mode(st_mode | (readable_bits << 6)),
+                    )
+                    .with_context(|| format!("could not set permissions on {}", path.display()))?;
+                }
+            } else {
+                return Err(anyhow::anyhow!(
+                    "{} is not readable by user {} (uid {}, gid {})",
+                    path.display(),
+                    user.name,
+                    user.uid,
+                    user.gid
+                ));
+            }
+        }
+
+        if let Some(parent) = path.parent() {
+            path = parent;
+        } else {
+            break;
+        }
+    }
 
     Ok(())
 }

--- a/aziotctl/src/check.rs
+++ b/aziotctl/src/check.rs
@@ -326,7 +326,7 @@ pub async fn check(mut cfg: Options) -> Result<()> {
             };
 
             if let Err(err) = serde_json::to_writer(std::io::stdout(), &check_results) {
-                eprintln!("Could not write JSON output: {}", err,);
+                eprintln!("Could not write JSON output: {}", err);
             }
         }
         OutputFormat::Text => {}

--- a/aziotctl/src/internal/check/checks/cert_expiry.rs
+++ b/aziotctl/src/internal/check/checks/cert_expiry.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 use anyhow::{anyhow, Result};
+use nix::unistd::User;
 use serde::Serialize;
 
 use crate::internal::check::util::CertificateValidityExt;
@@ -46,6 +47,8 @@ impl IdentityCert {
     ) -> Result<CheckResult> {
         use aziot_identityd_config::{DpsAttestationMethod, ManualAuthMethod, ProvisioningType};
 
+        let aziotcs_user = crate::internal::common::get_system_user("aziotcs")?;
+
         let provisioning = &unwrap_or_skip!(&cache.cfg.identityd)
             .provisioning
             .provisioning
@@ -75,8 +78,13 @@ impl IdentityCert {
         if let Some((identity_cert, identity_cert_name)) = cert {
             let certd_config = unwrap_or_skip!(&cache.cfg.certd);
 
-            let (res, cert_info) =
-                validate_cert(certd_config, identity_cert, identity_cert_name).await?;
+            let (res, cert_info) = validate_cert(
+                certd_config,
+                identity_cert,
+                identity_cert_name,
+                &aziotcs_user,
+            )
+            .await?;
             self.certificate_info = cert_info;
             Ok(res)
         } else {
@@ -115,6 +123,8 @@ impl EstIdentityBootstrapCerts {
     ) -> Result<CheckResult> {
         let certd_config = unwrap_or_skip!(&cache.cfg.certd);
 
+        let aziotcs_user = crate::internal::common::get_system_user("aziotcs")?;
+
         let certs = certd_config
             .cert_issuance
             .est
@@ -135,8 +145,13 @@ impl EstIdentityBootstrapCerts {
             Some((identity, bootstrap)) => {
                 let (identity_cert_id, identity_cert_name) = identity;
 
-                let (identity_cert_res, identity_certificate_info) =
-                    validate_cert(certd_config, identity_cert_id, identity_cert_name).await?;
+                let (identity_cert_res, identity_certificate_info) = validate_cert(
+                    certd_config,
+                    identity_cert_id,
+                    identity_cert_name,
+                    &aziotcs_user,
+                )
+                .await?;
                 self.identity_certificate_info = identity_certificate_info;
 
                 // TODO: clean this up if a checks ever get the ability to return multiple results
@@ -145,8 +160,13 @@ impl EstIdentityBootstrapCerts {
                 }
 
                 if let Some((bootstrap_cert_id, bootstrap_cert_name)) = bootstrap {
-                    let (bootstrap_cert_res, bootstrap_certificate_info) =
-                        validate_cert(certd_config, bootstrap_cert_id, bootstrap_cert_name).await?;
+                    let (bootstrap_cert_res, bootstrap_certificate_info) = validate_cert(
+                        certd_config,
+                        bootstrap_cert_id,
+                        bootstrap_cert_name,
+                        &aziotcs_user,
+                    )
+                    .await?;
                     self.bootstrap_certificate_info = bootstrap_certificate_info;
 
                     if !matches!(bootstrap_cert_res, CheckResult::Ok) {
@@ -200,7 +220,10 @@ impl LocalCaCert {
             None => return Ok(CheckResult::Ignored),
         };
 
-        let (res, cert_info) = validate_cert(certd_config, cert_id, "Local CA").await?;
+        let aziotcs_user = crate::internal::common::get_system_user("aziotcs")?;
+
+        let (res, cert_info) =
+            validate_cert(certd_config, cert_id, "Local CA", &aziotcs_user).await?;
         self.certificate_info = cert_info;
         Ok(res)
     }
@@ -215,6 +238,7 @@ async fn validate_cert(
     certd_config: &aziot_certd_config::Config,
     cert_id: &str,
     cert_name: &str,
+    aziotcs_user: &User,
 ) -> anyhow::Result<(CheckResult, Option<CertificateValidity>)> {
     let path = aziot_certd_config::util::get_path(
         &certd_config.homedir_path,
@@ -225,7 +249,7 @@ async fn validate_cert(
     .map_err(|e| anyhow!("{}", e))?;
 
     if path.exists() {
-        let cert_info = CertificateValidity::new(path, cert_name, cert_id).await?;
+        let cert_info = CertificateValidity::new(path, cert_name, cert_id, aziotcs_user).await?;
         cert_info
             .to_check_result()
             .map(|res| (res, Some(cert_info)))

--- a/aziotctl/src/internal/check/checks/read_key_pairs.rs
+++ b/aziotctl/src/internal/check/checks/read_key_pairs.rs
@@ -62,7 +62,23 @@ impl ReadKeyPairs {
         let mut err_aggregated = vec![];
         let mut warn_aggregated = vec![];
 
-        for id in preloaded_keys.keys() {
+        // Check every preloaded key at a file:// URI is readable by the aziotks user and report errors when they aren't.
+        let aziotks_user = crate::internal::common::get_system_user("aziotks")?;
+
+        for (id, path) in preloaded_keys {
+            if let Ok(aziot_keys_common::PreloadedKeyLocation::Filesystem { path }) = path.parse() {
+                if let Err(err) =
+                    aziotctl_common::config::check_readable(&path, &aziotks_user, false)
+                {
+                    err_aggregated.push(format!("{:?}", err));
+                    // There's no point trying to load the key through the API,
+                    // so just continue to the next key.
+                    continue;
+                }
+            }
+
+            // Load the key through the keyd API and collect any errors.
+            //
             // We don't know whether `id` is a symmetric or asymmetric key,
             // and the `load_key_pair` error doesn't tell us whether it failed because it's a symmetric key
             // or because of some other reason.


### PR DESCRIPTION
Cherry-pick from main of 299014df6652a5491fe702a5236b35140119c2c2

When `config apply` creates the /var/secrets/aziot/keyd directory to store
the inline symmetric key, it assumed that parent directories would already
be readable by the target user. But this is not a valid assumption since
it depends on root's umask, and we've had a few cases of devices where
root's umask is such that new directories are 0700 or 0750 by default.

This change adds a step of walking through the parents,
checking if they're readable by the target user, and making them
world-readable if they're not.