### PR TITLE
Minor fixes for mock-iot-server

### DIFF
--- a/ci/mock-iot-tests/mock-iot-setup.sh
+++ b/ci/mock-iot-tests/mock-iot-setup.sh
@@ -61,9 +61,11 @@ openssl x509 -req \
 >/etc/aziot/keyd/config.toml cat <<-EOF
 [aziot_keys]
 homedir_path = "/var/lib/aziot/keyd"
+
 [preloaded_keys]
 device-id-symkey = "file://$PWD/device_id_symkey"
 device-id-certkey = "file://$PWD/device_id_certkey.pem"
+
 [[principal]]
 uid = $UID
 keys = ["*"]
@@ -71,8 +73,10 @@ EOF
 
 >/etc/aziot/certd/config.toml cat<<-EOF
 homedir_path = "/var/lib/aziot/certd"
+
 [preloaded_certs]
 device-id-cert = "file://$PWD/device_id_cert.pem"
+
 [[principal]]
 uid = $UID
 certs = ["*"]

--- a/identity/mock-iot-server/src/dps.rs
+++ b/identity/mock-iot-server/src/dps.rs
@@ -107,7 +107,7 @@ fn operation_status(operation_id: &str, context: &mut crate::server::Context) ->
 
                 context
                     .devices
-                    .insert(device_id, std::collections::BTreeSet::new());
+                    .insert(device_id, std::collections::HashSet::new());
             }
 
             Response::json(hyper::StatusCode::OK, operation)

--- a/identity/mock-iot-server/src/hub.rs
+++ b/identity/mock-iot-server/src/hub.rs
@@ -3,7 +3,7 @@
 use crate::server::Response;
 
 fn list_modules(
-    modules: &std::collections::BTreeSet<aziot_identity_common::hub::Module>,
+    modules: &std::collections::HashSet<aziot_identity_common::hub::Module>,
 ) -> Response {
     let mut response = vec![];
 
@@ -17,7 +17,7 @@ fn list_modules(
 fn module_action(
     method: &hyper::Method,
     _module_id: &str,
-    _modules: &mut std::collections::BTreeSet<aziot_identity_common::hub::Module>,
+    _modules: &mut std::collections::HashSet<aziot_identity_common::hub::Module>,
 ) -> Response {
     // Current tests do not require these to be implemented, but they may be
     // needed in the future.

--- a/identity/mock-iot-server/src/server.rs
+++ b/identity/mock-iot-server/src/server.rs
@@ -139,7 +139,7 @@ pub(crate) struct ContextInner {
     >,
     pub devices: std::collections::BTreeMap<
         String,
-        std::collections::BTreeSet<aziot_identity_common::hub::Module>,
+        std::collections::HashSet<aziot_identity_common::hub::Module>,
     >,
     pub endpoint: String,
 }


### PR DESCRIPTION
- Fix spacing and permissions on mock-iot-setup.sh
- Change mock-iot-server to use HashSet for Modules, since ordering isn't important.