### PR TITLE
Always provide DPS registration ID in get_provisioning_info

### DIFF
--- a/identity/aziot-identity-common-http/src/lib.rs
+++ b/identity/aziot-identity-common-http/src/lib.rs
@@ -130,66 +130,11 @@ pub mod get_provisioning_info {
             auth: String,
             endpoint: String,
             scope_id: String,
-            registration_id: Option<String>,
+            registration_id: String,
         },
         Manual {
             auth: String,
         },
         None,
-    }
-
-    impl std::convert::From<aziot_identityd_config::ProvisioningType> for Response {
-        fn from(config: aziot_identityd_config::ProvisioningType) -> Self {
-            match config {
-                aziot_identityd_config::ProvisioningType::Dps {
-                    global_endpoint,
-                    scope_id,
-                    attestation,
-                } => {
-                    let (auth, registration_id) = match attestation {
-                        aziot_identityd_config::DpsAttestationMethod::SymmetricKey {
-                            registration_id,
-                            symmetric_key: _,
-                        } => ("symmetric_key".to_string(), Some(registration_id)),
-
-                        aziot_identityd_config::DpsAttestationMethod::X509 {
-                            registration_id,
-                            identity_pk: _,
-                            identity_cert: _,
-                        } => ("x509".to_string(), registration_id),
-
-                        aziot_identityd_config::DpsAttestationMethod::Tpm { registration_id } => {
-                            ("tpm".to_string(), Some(registration_id))
-                        }
-                    };
-
-                    let endpoint = global_endpoint.to_string();
-
-                    Response::Dps {
-                        auth,
-                        endpoint,
-                        scope_id,
-                        registration_id,
-                    }
-                }
-
-                aziot_identityd_config::ProvisioningType::Manual {
-                    iothub_hostname: _,
-                    device_id: _,
-                    authentication,
-                } => {
-                    let auth = match authentication {
-                        aziot_identityd_config::ManualAuthMethod::SharedPrivateKey { .. } => {
-                            "sas".to_string()
-                        }
-                        aziot_identityd_config::ManualAuthMethod::X509 { .. } => "x509".to_string(),
-                    };
-
-                    Response::Manual { auth }
-                }
-
-                aziot_identityd_config::ProvisioningType::None => Response::None,
-            }
-        }
     }
 }

--- a/identity/aziot-identityd/src/http/get_provisioning_info.rs
+++ b/identity/aziot-identityd/src/http/get_provisioning_info.rs
@@ -28,14 +28,13 @@ impl http_common::server::Route for Route {
     }
 
     async fn get(self) -> http_common::server::RouteResponse {
-        let provisioning = {
-            let api = self.api.lock().await;
+        let api = self.api.lock().await;
+        let provisioning = api
+            .get_provisioning_info()
+            .await
+            .map_err(|err| super::to_http_error(&err))?;
 
-            api.settings.provisioning.provisioning.clone()
-        };
-
-        let res: aziot_identity_common_http::get_provisioning_info::Response = provisioning.into();
-        let res = http_common::server::response::json(hyper::StatusCode::OK, &res);
+        let res = http_common::server::response::json(hyper::StatusCode::OK, &provisioning);
         Ok(res)
     }
 

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -221,9 +221,9 @@ impl Api {
                         ("tpm".to_string(), registration_id.to_string())
                     }
                     config::DpsAttestationMethod::X509 { identity_cert, .. } => {
-                        // The identity certificate's common name is used as registration ID and always
-                        // overrides any registration ID set in the config. Therefore, the registration
-                        // ID must always be retrieved from the identity certificate.
+                        // This API call is only available after a successful provision, which means
+                        // that the device ID certificate was used. The registration ID is taken from
+                        // the CN of the device ID certificate.
                         let identity_cert = self
                             .cert_client
                             .get_cert(identity_cert)

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -241,9 +241,11 @@ impl Api {
                             .subject_name()
                             .entries_by_nid(openssl::nid::Nid::COMMONNAME)
                             .next()
-                            .ok_or(Error::Internal(InternalError::CreateCertificate(
-                                "identity certificate missing common name".into(),
-                            )))?;
+                            .ok_or_else(|| {
+                                Error::Internal(InternalError::CreateCertificate(
+                                    "identity certificate missing common name".into(),
+                                ))
+                            })?;
 
                         let registration_id =
                             String::from_utf8(cert_subject.data().as_slice().to_vec()).map_err(

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -204,6 +204,81 @@ impl Api {
         Err(Error::Authorization)
     }
 
+    pub async fn get_provisioning_info(
+        &self,
+    ) -> Result<aziot_identity_common_http::get_provisioning_info::Response, Error> {
+        match &self.settings.provisioning.provisioning {
+            config::ProvisioningType::Dps {
+                global_endpoint,
+                scope_id,
+                attestation,
+            } => {
+                let (auth, registration_id) = match attestation {
+                    config::DpsAttestationMethod::SymmetricKey {
+                        registration_id, ..
+                    } => ("symmetric_key".to_string(), registration_id.to_string()),
+                    config::DpsAttestationMethod::Tpm { registration_id } => {
+                        ("tpm".to_string(), registration_id.to_string())
+                    }
+                    config::DpsAttestationMethod::X509 { identity_cert, .. } => {
+                        // The identity certificate's common name is used as registration ID and always
+                        // overrides any registration ID set in the config. Therefore, the registration
+                        // ID must always be retrieved from the identity certificate.
+                        let identity_cert = self
+                            .cert_client
+                            .get_cert(identity_cert)
+                            .await
+                            .map_err(|err| {
+                                Error::Internal(InternalError::CreateCertificate(err.into()))
+                            })?;
+
+                        let identity_cert =
+                            openssl::x509::X509::from_pem(&identity_cert).map_err(|err| {
+                                Error::Internal(InternalError::CreateCertificate(err.into()))
+                            })?;
+
+                        let cert_subject = identity_cert
+                            .subject_name()
+                            .entries_by_nid(openssl::nid::Nid::COMMONNAME)
+                            .next()
+                            .ok_or(Error::Internal(InternalError::CreateCertificate(
+                                "identity certificate missing common name".into(),
+                            )))?;
+
+                        let registration_id =
+                            String::from_utf8(cert_subject.data().as_slice().to_vec()).map_err(
+                                |err| Error::Internal(InternalError::CreateCertificate(err.into())),
+                            )?;
+
+                        ("x509".to_string(), registration_id)
+                    }
+                };
+
+                Ok(
+                    aziot_identity_common_http::get_provisioning_info::Response::Dps {
+                        auth,
+                        endpoint: global_endpoint.to_string(),
+                        scope_id: scope_id.to_string(),
+                        registration_id,
+                    },
+                )
+            }
+            config::ProvisioningType::Manual { authentication, .. } => {
+                let auth = match authentication {
+                    aziot_identityd_config::ManualAuthMethod::SharedPrivateKey { .. } => {
+                        "sas".to_string()
+                    }
+                    aziot_identityd_config::ManualAuthMethod::X509 { .. } => "x509".to_string(),
+                };
+
+                Ok(aziot_identity_common_http::get_provisioning_info::Response::Manual { auth })
+            }
+            aziot_identityd_config::ProvisioningType::None => {
+                Ok(aziot_identity_common_http::get_provisioning_info::Response::None)
+            }
+        }
+    }
+
     pub async fn get_identity(
         &self,
         auth_id: auth::AuthId,


### PR DESCRIPTION
The DPS registration ID is always known to Identity Service and should always be provided in the get_provisioning_info response.