### PR TITLE
Add generic response and multiple expected statuses to HttpRequest

### DIFF
--- a/cert/aziot-cert-client-async/src/lib.rs
+++ b/cert/aziot-cert-client-async/src/lib.rs
@@ -57,7 +57,7 @@ impl Client {
 
         let response = request.json_response().await?;
         let response: aziot_cert_common_http::create_cert::Response =
-            response.parse::<_, ErrorBody<'_>>(hyper::StatusCode::CREATED)?;
+            response.parse::<_, ErrorBody<'_>>(&[hyper::StatusCode::CREATED])?;
 
         Ok(response.pem.0)
     }
@@ -78,7 +78,7 @@ impl Client {
 
         let response = request.json_response().await?;
         let response: aziot_cert_common_http::import_cert::Response =
-            response.parse::<_, ErrorBody<'_>>(hyper::StatusCode::CREATED)?;
+            response.parse::<_, ErrorBody<'_>>(&[hyper::StatusCode::CREATED])?;
 
         Ok(response.pem.0)
     }

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -92,16 +92,6 @@ where
         Ok(())
     }
 
-    pub async fn no_content_response(self) -> Result<(), Error> {
-        let (response_status, _, _) = self.process_request(false).await?;
-
-        if response_status == hyper::StatusCode::NO_CONTENT {
-            Ok(())
-        } else {
-            Err(Error::new(ErrorKind::Other, "invalid HTTP status code"))
-        }
-    }
-
     pub async fn response(self, has_body: bool) -> Result<HttpResponse, Error> {
         let (status, _, body) = self.process_request(has_body).await?;
 
@@ -112,6 +102,16 @@ where
         };
 
         Ok(HttpResponse { status, body })
+    }
+
+    pub async fn no_content_response(self) -> Result<(), Error> {
+        let (response_status, _, _) = self.process_request(false).await?;
+
+        if response_status == hyper::StatusCode::NO_CONTENT {
+            Ok(())
+        } else {
+            Err(Error::new(ErrorKind::Other, "invalid HTTP status code"))
+        }
     }
 
     pub async fn json_response(self) -> Result<HttpResponse, Error> {
@@ -143,7 +143,7 @@ where
 
     async fn process_request(
         self,
-        has_response: bool,
+        has_response_body: bool,
     ) -> Result<
         (
             hyper::StatusCode,
@@ -224,7 +224,7 @@ where
             response_body,
         ) = response.into_parts();
 
-        let response_body = if has_response {
+        let response_body = if has_response_body {
             let response_body = hyper::body::to_bytes(response_body)
                 .await
                 .map_err(|err| Error::new(ErrorKind::Other, err))?;

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -102,6 +102,15 @@ where
         }
     }
 
+    pub async fn response(self) -> Result<HttpResponse, Error> {
+        let (status, _, body) = self.process_request(true).await?;
+
+        Ok(HttpResponse {
+            status,
+            body: body.expect("process_request did not return body"),
+        })
+    }
+
     pub async fn json_response(self) -> Result<HttpResponse, Error> {
         let (status, headers, body) = self.process_request(true).await?;
 

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -102,13 +102,16 @@ where
         }
     }
 
-    pub async fn response(self) -> Result<HttpResponse, Error> {
-        let (status, _, body) = self.process_request(true).await?;
+    pub async fn response(self, has_body: bool) -> Result<HttpResponse, Error> {
+        let (status, _, body) = self.process_request(has_body).await?;
 
-        Ok(HttpResponse {
-            status,
-            body: body.expect("process_request did not return body"),
-        })
+        let body = if let Some(body) = body {
+            body
+        } else {
+            hyper::body::Bytes::new()
+        };
+
+        Ok(HttpResponse { status, body })
     }
 
     pub async fn json_response(self) -> Result<HttpResponse, Error> {

--- a/identity/aziot-cloud-client-async/src/dps/mod.rs
+++ b/identity/aziot-cloud-client-async/src/dps/mod.rs
@@ -140,9 +140,9 @@ impl Client {
 
         // DPS should respond with 401 Unauthorized and present the encrypted nonce.
         let response = response
-            .parse::<schema::response::TpmAuthKey, schema::response::ServiceError>(
+            .parse::<schema::response::TpmAuthKey, schema::response::ServiceError>(&[
                 hyper::StatusCode::UNAUTHORIZED,
-            )?;
+            ])?;
 
         let auth_key = base64::decode(response.authentication_key)
             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
@@ -203,9 +203,9 @@ impl Client {
         // Determine the registration request's operation ID.
         let operation_id = {
             let response = response
-                .parse::<schema::response::OperationStatus, schema::response::ServiceError>(
+                .parse::<schema::response::OperationStatus, schema::response::ServiceError>(&[
                     hyper::StatusCode::ACCEPTED,
-                )?;
+                ])?;
 
             response.operation_id
         };


### PR DESCRIPTION
- Adds a function to get an HTTP response without requiring the response to be JSON. Edge Daemon uses HTTP requests to get non-JSON responses, such as module logs.
- Allows multiple statuses to be treated as successful when parsing a response. For some calls in Edge Daemon, 304 Not Modified should be treated as success along with 200 Ok.