### PR TITLE
Move test clients and functions from iotedge

### DIFF
--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -12,3 +12,9 @@ hyper = { version = "0.14", features = ["server"] }
 openssl = "0.10"
 tokio = { version = "1", features = ["net"] }
 tokio-openssl = "0.6"
+
+aziot-key-client = { path = "../key/aziot-key-client" }
+aziot-key-common = { path = "../key/aziot-key-common" }
+aziot-identity-common = { path = "../identity/aziot-identity-common" }
+aziot-identity-common-http = { path = "../identity/aziot-identity-common-http" }
+http-common = { path = "../http-common" }

--- a/test-common/src/client/cert.rs
+++ b/test-common/src/client/cert.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+pub struct CertClient {
+    // Because the signatures of this test client must match the real client, the test client's
+    // functions cannot use `mut self` as a parameter.
+    //
+    // The test client may need to mutate this map of certs, so the workaround is to place it in
+    // a RefCell and use replace_with.
+    pub certs:
+        futures_util::lock::Mutex<std::cell::RefCell<std::collections::BTreeMap<String, Vec<u8>>>>,
+
+    pub issuer: openssl::x509::X509,
+    pub issuer_key: openssl::pkey::PKey<openssl::pkey::Private>,
+}
+
+impl Default for CertClient {
+    fn default() -> Self {
+        let (issuer, issuer_key) = crate::credential::test_certificate("test-device-cert", None);
+
+        CertClient {
+            certs: Default::default(),
+            issuer,
+            issuer_key,
+        }
+    }
+}
+
+impl CertClient {
+    // For the real cert client, the 3rd parameter `data` is always a CSR to send to certd.
+    // This test client repurposes this parameter:
+    // - As cert bytes when no issuer is provided
+    // - As CSR bytes when an issuer is provided
+    pub async fn create_cert(
+        &self,
+        id: &str,
+        data: &[u8],
+        issuer: Option<(&str, &aziot_key_common::KeyHandle)>,
+    ) -> Result<Vec<u8>, std::io::Error> {
+        // The real cert client would connect to certd and create the cert.
+        // This test client just issues certs locally if an issuer is provided.
+        // Otherwise, it just places the provided data into the map of certs.
+        let cert = if issuer.is_none() {
+            data.to_owned()
+        } else {
+            self.issue_cert(data)
+        };
+
+        let certs = self.certs.lock().await;
+        certs.replace_with(|certs| {
+            certs.insert(id.to_string(), cert.clone());
+
+            certs.clone()
+        });
+
+        Ok(cert)
+    }
+
+    pub async fn get_cert(&self, id: &str) -> Result<Vec<u8>, std::io::Error> {
+        let certs = self.certs.lock().await;
+        let certs = certs.replace_with(|certs| certs.clone());
+
+        match certs.get(id) {
+            Some(cert) => Ok(cert.clone()),
+            None => Err(super::client_error()),
+        }
+    }
+
+    fn issue_cert(&self, csr: &[u8]) -> Vec<u8> {
+        let mut issuer_name = openssl::x509::X509Name::builder().unwrap();
+        issuer_name
+            .append_entry_by_text("CN", "test-device-cert")
+            .unwrap();
+        let issuer_name = issuer_name.build();
+
+        let csr = openssl::x509::X509Req::from_pem(csr).unwrap();
+        let csr_pubkey = csr.public_key().unwrap();
+        let csr_extensions = csr.extensions().unwrap();
+        assert!(csr.verify(&csr_pubkey).unwrap());
+
+        let mut cert = openssl::x509::X509::builder().unwrap();
+        cert.set_subject_name(csr.subject_name()).unwrap();
+        cert.set_issuer_name(&issuer_name).unwrap();
+        cert.set_pubkey(&csr_pubkey).unwrap();
+
+        for extension in csr_extensions.iter() {
+            cert.append_extension2(extension).unwrap();
+        }
+
+        let not_before = openssl::asn1::Asn1Time::from_unix(0).unwrap();
+        let not_after = openssl::asn1::Asn1Time::days_from_now(30).unwrap();
+
+        cert.set_not_before(&not_before).unwrap();
+        cert.set_not_after(&not_after).unwrap();
+
+        cert.sign(&self.issuer_key, openssl::hash::MessageDigest::sha256())
+            .unwrap();
+
+        cert.build().to_pem().unwrap()
+    }
+}

--- a/test-common/src/client/identity.rs
+++ b/test-common/src/client/identity.rs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use aziot_identity_common::Identity;
+use aziot_identity_common_http::get_provisioning_info::Response as ProvisioningInfo;
+
+#[allow(clippy::struct_excessive_bools)]
+pub struct IdentityClient {
+    pub get_provisioning_info_ok: bool,
+    pub create_identity_ok: bool,
+    pub get_identities_ok: bool,
+    pub get_identity_ok: bool,
+    pub update_identity_ok: bool,
+    pub delete_identity_ok: bool,
+
+    pub provisioning_info: ProvisioningInfo,
+
+    // Because the signatures of this test client must match the real client, the test client's
+    // functions cannot use `mut self` as a parameter.
+    //
+    // The test client may need to mutate this map of identities, so the workaround is to place it in
+    // a RefCell and use replace_with.
+    pub identities:
+        futures_util::lock::Mutex<std::cell::RefCell<std::collections::BTreeMap<String, Identity>>>,
+}
+
+impl Default for IdentityClient {
+    fn default() -> Self {
+        let mut identities = std::collections::BTreeMap::new();
+        identities.insert("testModule".to_string(), test_identity("testModule"));
+
+        let identities = futures_util::lock::Mutex::new(std::cell::RefCell::new(identities));
+
+        IdentityClient {
+            get_provisioning_info_ok: true,
+            create_identity_ok: true,
+            get_identities_ok: true,
+            get_identity_ok: true,
+            update_identity_ok: true,
+            delete_identity_ok: true,
+
+            provisioning_info: provisioning_info(),
+            identities,
+        }
+    }
+}
+
+impl IdentityClient {
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new(
+        _api_version: aziot_identity_common_http::ApiVersion,
+        _connector: http_common::Connector,
+        _max_retries: u32,
+    ) -> Self {
+        Self::default()
+    }
+
+    pub async fn get_provisioning_info(&self) -> Result<ProvisioningInfo, std::io::Error> {
+        if self.get_provisioning_info_ok {
+            Ok(self.provisioning_info.clone())
+        } else {
+            Err(super::client_error())
+        }
+    }
+
+    pub async fn create_module_identity(
+        &self,
+        module_name: &str,
+    ) -> Result<Identity, std::io::Error> {
+        if self.get_identity_ok {
+            let identity = test_identity(module_name);
+
+            let identities = self.identities.lock().await;
+
+            identities.replace_with(|identities| {
+                identities.insert(module_name.to_string(), identity.clone());
+
+                identities.clone()
+            });
+
+            Ok(identity)
+        } else {
+            Err(super::client_error())
+        }
+    }
+
+    pub async fn get_identities(&self) -> Result<Vec<Identity>, std::io::Error> {
+        if self.get_identities_ok {
+            let identities = {
+                let identities = self.identities.lock().await;
+
+                identities.replace_with(|identities| identities.clone())
+            };
+
+            let mut identities_list = vec![];
+
+            for (_, identity) in identities {
+                identities_list.push(identity.clone());
+            }
+
+            Ok(identities_list)
+        } else {
+            Err(super::client_error())
+        }
+    }
+
+    pub async fn get_identity(&self, module_name: &str) -> Result<Identity, std::io::Error> {
+        if self.get_identity_ok {
+            let identities = {
+                let identities = self.identities.lock().await;
+
+                identities.replace_with(|identities| identities.clone())
+            };
+
+            match identities.get(module_name) {
+                Some(identity) => Ok(identity.clone()),
+                None => Err(super::client_error()),
+            }
+        } else {
+            Err(super::client_error())
+        }
+    }
+
+    pub async fn update_module_identity(
+        &self,
+        module_name: &str,
+    ) -> Result<Identity, std::io::Error> {
+        if self.update_identity_ok {
+            // A real identity client would update the Idenitity in Hub. But this test
+            // client can just return the existing Identity.
+            self.get_identity(module_name).await
+        } else {
+            Err(super::client_error())
+        }
+    }
+
+    pub async fn delete_identity(&self, module_name: &str) -> Result<(), std::io::Error> {
+        if self.delete_identity_ok {
+            let identities = self.identities.lock().await;
+
+            identities.replace_with(|identities| {
+                identities.remove(module_name);
+
+                identities.clone()
+            });
+
+            Ok(())
+        } else {
+            Err(super::client_error())
+        }
+    }
+}
+
+/// Generates an Identity struct for a given module name.
+fn test_identity(module_name: &str) -> Identity {
+    Identity::Aziot(aziot_identity_common::AzureIoTSpec {
+        hub_name: "test-hub.test.net".to_string(),
+        gateway_host: "gateway-host.test.net".to_string(),
+        device_id: aziot_identity_common::DeviceId("test-device".to_string()),
+        module_id: Some(aziot_identity_common::ModuleId(module_name.to_string())),
+        gen_id: Some(aziot_identity_common::GenId("test-gen-id".to_string())),
+        auth: Some(aziot_identity_common::AuthenticationInfo {
+            auth_type: aziot_identity_common::AuthenticationType::X509,
+            key_handle: Some(aziot_key_common::KeyHandle(format!("{}-key", module_name))),
+            cert_id: Some(format!("{}-cert", module_name)),
+        }),
+    })
+}
+
+/// Generate a `ProvisioningInfo` with `CertIssuancePolicy`.
+fn provisioning_info() -> ProvisioningInfo {
+    ProvisioningInfo::Dps {
+        auth: "x509".to_string(),
+        endpoint: "localhost".to_string(),
+        scope_id: "scope".to_string(),
+        registration_id: "registrationId".to_string(),
+        cert_policy: Some(aziot_identity_common::CertPolicy {
+            cert_type: aziot_identity_common::CertType::Server,
+            key_length: 2048,
+            key_curve: None,
+        }),
+    }
+}

--- a/test-common/src/client/key.rs
+++ b/test-common/src/client/key.rs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#[allow(clippy::struct_excessive_bools)]
+pub struct KeyClient {
+    pub create_key_if_not_exists_ok: bool,
+    pub create_key_pair_if_not_exists_ok: bool,
+
+    pub encrypt_ok: bool,
+    pub decrypt_ok: bool,
+    pub sign_ok: bool,
+}
+
+impl Default for KeyClient {
+    fn default() -> Self {
+        KeyClient {
+            create_key_if_not_exists_ok: true,
+            create_key_pair_if_not_exists_ok: true,
+            encrypt_ok: true,
+            decrypt_ok: true,
+            sign_ok: true,
+        }
+    }
+}
+
+impl KeyClient {
+    pub async fn create_key_if_not_exists(
+        &self,
+        _id: &str,
+        _value: aziot_key_common::CreateKeyValue,
+        _usage: &[aziot_key_common::KeyUsage],
+    ) -> std::io::Result<aziot_key_common::KeyHandle> {
+        if self.create_key_if_not_exists_ok {
+            Ok(aziot_key_common::KeyHandle("key-handle".to_string()))
+        } else {
+            Err(super::client_error())
+        }
+    }
+
+    pub async fn create_key_pair_if_not_exists(
+        &self,
+        _id: &str,
+        _preferred_algorithms: Option<&str>,
+    ) -> std::io::Result<aziot_key_common::KeyHandle> {
+        if self.create_key_pair_if_not_exists_ok {
+            Ok(aziot_key_common::KeyHandle("key-pair-handle".to_string()))
+        } else {
+            Err(super::client_error())
+        }
+    }
+
+    pub async fn encrypt(
+        &self,
+        _handle: &aziot_key_common::KeyHandle,
+        _mechanism: aziot_key_common::EncryptMechanism,
+        _plaintext: &[u8],
+    ) -> std::io::Result<Vec<u8>> {
+        if self.encrypt_ok {
+            Ok("ciphertext".as_bytes().to_owned())
+        } else {
+            Err(super::client_error())
+        }
+    }
+
+    pub async fn decrypt(
+        &self,
+        _handle: &aziot_key_common::KeyHandle,
+        _mechanism: aziot_key_common::EncryptMechanism,
+        _ciphertext: &[u8],
+    ) -> std::io::Result<Vec<u8>> {
+        if self.decrypt_ok {
+            Ok("plaintext".as_bytes().to_owned())
+        } else {
+            Err(super::client_error())
+        }
+    }
+
+    pub async fn sign(
+        &self,
+        _handle: &aziot_key_common::KeyHandle,
+        _mechanism: aziot_key_common::SignMechanism,
+        _digest: &[u8],
+    ) -> std::io::Result<Vec<u8>> {
+        if self.sign_ok {
+            Ok("digest".as_bytes().to_owned())
+        } else {
+            Err(super::client_error())
+        }
+    }
+}
+
+pub struct KeyEngine {
+    pub keys: std::collections::BTreeMap<
+        String,
+        (
+            openssl::pkey::PKey<openssl::pkey::Private>,
+            openssl::pkey::PKey<openssl::pkey::Public>,
+        ),
+    >,
+}
+
+impl KeyEngine {
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn load(_client: std::sync::Arc<aziot_key_client::Client>) -> Result<Self, std::io::Error> {
+        Ok(KeyEngine {
+            keys: std::collections::BTreeMap::new(),
+        })
+    }
+
+    pub fn load_private_key(
+        &mut self,
+        key_handle: &std::ffi::CString,
+    ) -> Result<openssl::pkey::PKey<openssl::pkey::Private>, std::io::Error> {
+        let key_handle = key_handle.to_str().unwrap();
+
+        match self.keys.get(key_handle) {
+            Some((private_key, _)) => Ok(private_key.clone()),
+            None => Ok(self.create_keys(key_handle).0),
+        }
+    }
+
+    pub fn load_public_key(
+        &mut self,
+        key_handle: &std::ffi::CString,
+    ) -> Result<openssl::pkey::PKey<openssl::pkey::Public>, std::io::Error> {
+        let key_handle = key_handle.to_str().unwrap();
+
+        match self.keys.get(key_handle) {
+            Some((_, public_key)) => Ok(public_key.clone()),
+            None => Ok(self.create_keys(key_handle).1),
+        }
+    }
+
+    fn create_keys(
+        &mut self,
+        key_handle: &str,
+    ) -> (
+        openssl::pkey::PKey<openssl::pkey::Private>,
+        openssl::pkey::PKey<openssl::pkey::Public>,
+    ) {
+        let keys = crate::credential::new_keys();
+
+        assert!(self
+            .keys
+            .insert(key_handle.to_string(), keys.clone())
+            .is_none());
+
+        keys
+    }
+}

--- a/test-common/src/client/mod.rs
+++ b/test-common/src/client/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+mod cert;
+mod identity;
+mod key;
+
+pub use cert::CertClient;
+pub use identity::IdentityClient;
+pub use key::KeyClient;
+pub use key::KeyEngine;
+
+/// Generic client error. Current tests don't act on the error other
+/// than passing it up the call stack, so it's fine to return any error.
+fn client_error() -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, "test error")
+}

--- a/test-common/src/credential.rs
+++ b/test-common/src/credential.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+/// Generate a new private key and public key.
+pub fn new_keys() -> (
+    openssl::pkey::PKey<openssl::pkey::Private>,
+    openssl::pkey::PKey<openssl::pkey::Public>,
+) {
+    let rsa = openssl::rsa::Rsa::generate(2048).unwrap();
+    let private_key = openssl::pkey::PKey::from_rsa(rsa).unwrap();
+
+    let public_key = private_key.public_key_to_pem().unwrap();
+    let public_key = openssl::pkey::PKey::public_key_from_pem(&public_key).unwrap();
+
+    (private_key, public_key)
+}
+
+/// Generate a CSR for testing.
+///
+/// The `customize` parameter is an optional function that can be used to
+/// override the test defaults before the CSR is signed.
+pub fn test_csr(
+    common_name: &str,
+    customize: Option<fn(&mut openssl::x509::X509ReqBuilder)>,
+) -> (
+    openssl::x509::X509Req,
+    openssl::pkey::PKey<openssl::pkey::Private>,
+) {
+    let name = name(common_name);
+    let (private_key, public_key) = new_keys();
+
+    let mut csr = openssl::x509::X509Req::builder().unwrap();
+
+    csr.set_subject_name(&name).unwrap();
+    csr.set_pubkey(&public_key).unwrap();
+
+    if let Some(customize) = customize {
+        customize(&mut csr);
+    }
+
+    csr.sign(&private_key, openssl::hash::MessageDigest::sha256())
+        .unwrap();
+
+    (csr.build(), private_key)
+}
+
+/// Generate a self-signed cert for testing.
+///
+/// The `customize` parameter is an optional function that can be used to
+/// override the test defaults before the certificate is signed.
+pub fn test_certificate(
+    common_name: &str,
+    customize: Option<fn(&mut openssl::x509::X509Builder)>,
+) -> (
+    openssl::x509::X509,
+    openssl::pkey::PKey<openssl::pkey::Private>,
+) {
+    let name = name(common_name);
+    let (private_key, public_key) = new_keys();
+
+    let mut cert = openssl::x509::X509::builder().unwrap();
+
+    cert.set_subject_name(&name).unwrap();
+    cert.set_issuer_name(&name).unwrap();
+    cert.set_pubkey(&public_key).unwrap();
+
+    let not_before = openssl::asn1::Asn1Time::from_unix(0).unwrap();
+    let not_after = openssl::asn1::Asn1Time::days_from_now(30).unwrap();
+
+    cert.set_not_before(&not_before).unwrap();
+    cert.set_not_after(&not_after).unwrap();
+
+    if let Some(customize) = customize {
+        customize(&mut cert);
+    }
+
+    cert.sign(&private_key, openssl::hash::MessageDigest::sha256())
+        .unwrap();
+
+    (cert.build(), private_key)
+}
+
+fn name(common_name: &str) -> openssl::x509::X509Name {
+    let mut name = openssl::x509::X509Name::builder().unwrap();
+    name.append_entry_by_text("CN", common_name).unwrap();
+
+    name.build()
+}

--- a/test-common/src/lib.rs
+++ b/test-common/src/lib.rs
@@ -6,7 +6,11 @@
     clippy::default_trait_access,
     clippy::let_unit_value,
     clippy::missing_errors_doc,
-    clippy::missing_panics_doc
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate
 )]
 
+pub mod client;
+pub mod credential;
 pub mod tokio_openssl2;


### PR DESCRIPTION
The iotedge repo currently has mocks of the KS, CS, and IS clients; as well as some test functions for generating certificates.

This PR moves those functions to this repo so they can be used for tests here as well.