### PR TITLE
Make apt upgrade non-interactive for VM provisioning

### DIFF
--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -615,7 +615,15 @@ case "$OS" in
             set -euxo pipefail
 
             sudo apt-get update -y
-            sudo apt-get upgrade -y
+            sudo DEBIAN_FRONTEND=noninteractive \
+            apt-get \
+            -o Dpkg::Options::=--force-confnew \
+            -o Dpkg::Options::=--force-confdef \
+            -y \
+            --allow-downgrades \
+            --allow-remove-essential \
+            --allow-change-held-packages \
+            upgrade
         '
         ;;
 

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -616,14 +616,14 @@ case "$OS" in
 
             sudo apt-get update -y
             sudo DEBIAN_FRONTEND=noninteractive \
-            apt-get \
-            -o Dpkg::Options::=--force-confnew \
-            -o Dpkg::Options::=--force-confdef \
-            -y \
-            --allow-downgrades \
-            --allow-remove-essential \
-            --allow-change-held-packages \
-            upgrade
+                apt-get \
+                -o 'Dpkg::Options::=--force-confnew' \
+                -o 'Dpkg::Options::=--force-confdef' \
+                -y \
+                --allow-downgrades \
+                --allow-remove-essential \
+                --allow-change-held-packages \
+                upgrade
         '
         ;;
 


### PR DESCRIPTION
This PR fixes persistent failures in ubuntu:18.04 jobs.

Currently, the VM provisioning process is unable to run **apt upgrade**, which in turn is because the upgrade of the openssh-server package is conflicting with files that are pre-installed on the VM image.

This change makes the upgrades non-interactive and automatically chooses the newer file(s) in case of any conflict (which is fine since it's a clean VM).


**Testing Notes:**

- Check-in gates[ passed (on my fork)](https://github.com/gauravIoTEdge/iot-identity-service/actions/runs/1890462264)
- Ran [E2E tests (on my fork)](https://github.com/gauravIoTEdge/iot-identity-service/runs/5313085676?check_suite_focus=true) and a couple of 18.04 jobs passed, unlike before.