### PR TITLE
Make apt upgrade non-interactive for VM provisioning

### DIFF
--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -615,7 +615,15 @@ case "$OS" in
             set -euxo pipefail
 
             sudo apt-get update -y
-            sudo apt-get upgrade -y
+            sudo DEBIAN_FRONTEND=noninteractive \
+                apt-get \
+                -o 'Dpkg::Options::=--force-confnew' \
+                -o 'Dpkg::Options::=--force-confdef' \
+                -y \
+                --allow-downgrades \
+                --allow-remove-essential \
+                --allow-change-held-packages \
+                upgrade
         '
         ;;
 


### PR DESCRIPTION
This PR is a straight cherry-pick of  https://github.com/Azure/iot-identity-service/pull/373