### PR TITLE
Upgrade Rust to 1.59

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ dist:
 		./test-common \
 		./tpm \
 		/tmp/aziot-identity-service-$(PACKAGE_VERSION)
-	cp ./Cargo.toml ./Cargo.lock ./CODE_OF_CONDUCT.md ./CONTRIBUTING.md ./LICENSE ./Makefile ./README.md ./rust-toolchain ./SECURITY.md /tmp/aziot-identity-service-$(PACKAGE_VERSION)
+	cp ./Cargo.toml ./Cargo.lock ./CODE_OF_CONDUCT.md ./CONTRIBUTING.md ./LICENSE ./Makefile ./README.md ./rust-toolchain.toml ./SECURITY.md /tmp/aziot-identity-service-$(PACKAGE_VERSION)
 
 	# `cargo vendor` for offline builds
 	cd /tmp/aziot-identity-service-$(PACKAGE_VERSION) && $(CARGO) vendor

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -136,7 +136,7 @@ case "$OS" in
         pushd /tmp
         tar xf "cbindgen-$CBINDGEN_VERSION.tar.gz" --no-same-owner
         pushd "/tmp/cbindgen-$CBINDGEN_VERSION"
-        cp /src/rust-toolchain .
+        cp /src/rust-toolchain.toml .
         cargo vendor vendor
         mkdir -p .cargo
         cat > .cargo/config << EOF
@@ -154,7 +154,7 @@ EOF
         pushd /tmp
         tar xf "rust-bindgen-$BINDGEN_VERSION.tar.gz" --no-same-owner
         pushd "/tmp/rust-bindgen-$BINDGEN_VERSION"
-        cp /src/rust-toolchain .
+        cp /src/rust-toolchain.toml .
         cargo vendor vendor
         mkdir -p .cargo
         cat > .cargo/config << EOF

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -19,6 +19,7 @@ where
     TBody: serde::Serialize,
     TConnector: Clone + Send + Sync + hyper::client::connect::Connect + 'static,
 {
+    #[must_use]
     pub fn delete(connector: TConnector, uri: &str, body: Option<TBody>) -> Self {
         HttpRequest {
             connector,
@@ -31,6 +32,7 @@ where
         }
     }
 
+    #[must_use]
     pub fn get(connector: TConnector, uri: &str) -> Self {
         HttpRequest {
             connector,
@@ -43,6 +45,7 @@ where
         }
     }
 
+    #[must_use]
     pub fn post(connector: TConnector, uri: &str, body: Option<TBody>) -> Self {
         HttpRequest {
             connector,
@@ -55,6 +58,7 @@ where
         }
     }
 
+    #[must_use]
     pub fn put(connector: TConnector, uri: &str, body: TBody) -> Self {
         HttpRequest {
             connector,
@@ -67,12 +71,14 @@ where
         }
     }
 
+    #[must_use]
     pub fn with_retry(mut self, retries: u32) -> Self {
         self.retries = retries;
 
         self
     }
 
+    #[must_use]
     pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.timeout = timeout;
 

--- a/identity/aziot-cloud-client-async/src/dps/mod.rs
+++ b/identity/aziot-cloud-client-async/src/dps/mod.rs
@@ -49,24 +49,28 @@ impl Client {
         }
     }
 
+    #[must_use]
     pub fn with_endpoint(mut self, endpoint: url::Url) -> Self {
         self.endpoint = endpoint;
 
         self
     }
 
+    #[must_use]
     pub fn with_retry(mut self, retries: u32) -> Self {
         self.retries = retries;
 
         self
     }
 
+    #[must_use]
     pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.timeout = timeout;
 
         self
     }
 
+    #[must_use]
     pub fn with_proxy(mut self, proxy: Option<hyper::Uri>) -> Self {
         self.proxy = proxy;
 

--- a/identity/aziot-cloud-client-async/src/hub/mod.rs
+++ b/identity/aziot-cloud-client-async/src/hub/mod.rs
@@ -55,18 +55,21 @@ impl Client {
         }
     }
 
+    #[must_use]
     pub fn with_retry(mut self, retries: u32) -> Self {
         self.retries = retries;
 
         self
     }
 
+    #[must_use]
     pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.timeout = timeout;
 
         self
     }
 
+    #[must_use]
     pub fn with_proxy(mut self, proxy: Option<hyper::Uri>) -> Self {
         self.proxy = proxy;
 

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -445,9 +445,7 @@ impl Api {
         }
 
         //TODO: invoke get trust bundle
-        Ok(aziot_cert_common_http::Pem {
-            0: std::vec::Vec::default(),
-        })
+        Ok(aziot_cert_common_http::Pem(std::vec::Vec::default()))
     }
 
     pub async fn reprovision_device(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.57"
+channel = "1.59"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Counterpart of Azure/iotedge#6206.

This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

Add `#[must_use]` directives on methods returning `Self` to satisfy clippy.

[^0]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes-11
  Namely, the point on `mem::uninitialized`.