### PR TITLE
Fix Mariner build to actually build mariner packages.

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -61,6 +61,7 @@ jobs:
           '/src/ci/package.sh'
       env:
         ARCH: "${{ matrix.arch }}"
+        OS: "${{ matrix.os }}"
         # PACKAGE_VERSION should end with '~dev' on the main branch.
         PACKAGE_VERSION: '1.3.0~dev'
         # PACKAGE_RELEASE should always be '1'.


### PR DESCRIPTION
When edb6bab2ed57e2bccb313e725d5eb669532ac8ca cherry-picked Mariner support
to main, it missed this line, with the result that main's mariner package job
was actually building an Ubuntu 18.04 package, not a Mariner package.

---

Marked as draft because I expect this to fail. The Mariner build [uses Rust 1.47](https://github.com/Azure/iot-identity-service/blob/8f53f29c063c03529e508ee4111c7f1b1110c08f/contrib/mariner/aziot-identity-service.spec#L31) while the rest of our code expects 1.57+ due to 368eec1f2f2bd6f661823772cbf4b22c7f74271d . We only didn't notice until now because the Mariner build wasn't actually building a Mariner package. arsing is currently in talks with Mariner folks to figure out what to do here.