### PR TITLE
Add rotate_key setting and update principals for cert renewal

### DIFF
--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -213,6 +213,16 @@ pub fn run(
 
                                 aziotid_keys.keys.push(super::DEVICE_ID_ID.to_owned());
 
+                                // Identity Service needs authorization to manage a temporary key
+                                // during key rotation.
+                                if let Some(auto_renew) = &auto_renew {
+                                    if auto_renew.rotate_key {
+                                        aziotid_keys
+                                            .keys
+                                            .push(format!("{}-temp", super::DEVICE_ID_ID));
+                                    }
+                                }
+
                                 cert_issuance_certs.insert(
                                     super::DEVICE_ID_ID.to_owned(),
                                     into_cert_options(identity_cert, auth),
@@ -341,6 +351,12 @@ pub fn run(
                         .insert(super::EST_BOOTSTRAP_ID.to_owned(), bootstrap_identity_pk);
                     aziotcs_keys.keys.push(super::EST_BOOTSTRAP_ID.to_owned());
                     aziotcs_keys.keys.push(super::EST_ID_ID.to_owned());
+
+                    // Certificates Service needs authorization to manage a temporary key
+                    // during key rotation.
+                    if identity_auto_renew.rotate_key {
+                        aziotcs_keys.keys.push(format!("{}-temp", super::EST_ID_ID));
+                    }
 
                     Some(aziot_certd_config::EstAuthX509 {
                         identity: aziot_certd_config::CertificateWithPrivateKey {
@@ -542,6 +558,10 @@ pub fn set_est_auth(
 
                     preloaded_keys.insert(bootstrap_cert_id.clone(), bootstrap_identity_pk.clone());
                     aziotcs_keys.keys.push(bootstrap_cert_id.clone());
+
+                    // Certificates Service needs authorization to manage a temporary key
+                    // during key rotation.
+                    aziotcs_keys.keys.push(format!("{}-temp", identity_cert_id));
 
                     Some(aziot_certd_config::CertificateWithPrivateKey {
                         cert: bootstrap_cert_id.clone(),

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -213,13 +213,14 @@ pub fn run(
 
                                 aziotid_keys.keys.push(super::DEVICE_ID_ID.to_owned());
 
-                                // Identity Service needs authorization to manage a temporary key
-                                // during key rotation.
+                                // Identity Service needs authorization to manage temporary credentials
+                                // during cert rotation.
                                 if let Some(auto_renew) = &auto_renew {
+                                    let temp = format!("{}-temp", super::DEVICE_ID_ID);
+                                    aziotid_certs.certs.push(temp.clone());
+
                                     if auto_renew.rotate_key {
-                                        aziotid_keys
-                                            .keys
-                                            .push(format!("{}-temp", super::DEVICE_ID_ID));
+                                        aziotid_keys.keys.push(temp);
                                     }
                                 }
 

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -217,6 +217,11 @@ pub fn run(
                                 // during cert rotation.
                                 if let Some(auto_renew) = &auto_renew {
                                     let temp = format!("{}-temp", super::DEVICE_ID_ID);
+
+                                    cert_issuance_certs.insert(
+                                        temp.clone(),
+                                        into_cert_options(identity_cert.clone(), auth.clone()),
+                                    );
                                     aziotid_certs.certs.push(temp.clone());
 
                                     if auto_renew.rotate_key {

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -217,7 +217,7 @@ pub struct Est {
     pub urls: BTreeMap<String, Url>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EstAuth {
     #[serde(flatten)]
     pub basic: Option<aziot_certd_config::EstAuthBasic>,
@@ -226,7 +226,7 @@ pub struct EstAuth {
     pub x509: Option<EstAuthX509>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum EstAuthX509 {
     BootstrapIdentity {
@@ -281,7 +281,7 @@ pub enum X509Identity {
     },
 }
 
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct CertIssuanceOptions {
     #[serde(flatten)]
     pub method: CertIssuanceMethod,
@@ -300,7 +300,7 @@ pub struct CertIssuanceOptions {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(tag = "method", rename_all = "snake_case")]
 pub enum CertIssuanceMethod {
     #[serde(rename = "est")]

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -293,7 +293,7 @@ pub struct CertIssuanceOptions {
     pub expiry_days: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_renew: Option<cert_renewal::RenewalPolicy>,
+    pub auto_renew: Option<cert_renewal::AutoRenewConfig>,
 
     #[serde(flatten)]
     pub subject: Option<aziot_certd_config::CertSubject>,

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -209,10 +209,10 @@ pub struct Est {
     #[serde(default)]
     pub trusted_certs: Vec<Url>,
     #[serde(
-        default = "aziot_certd_config::default_est_renew",
-        skip_serializing_if = "aziot_certd_config::is_default_est_renew"
+        default,
+        skip_serializing_if = "cert_renewal::AutoRenewConfig::is_default"
     )]
-    pub identity_auto_renew: cert_renewal::RenewalPolicy,
+    pub identity_auto_renew: cert_renewal::AutoRenewConfig,
     pub auth: EstAuth,
     pub urls: BTreeMap<String, Url>,
 }

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/certd.toml
@@ -23,4 +23,4 @@ est-server-ca-1 = "file:///var/secrets/est-id-ca.pem"
 
 [[principal]]
 uid = 5556
-certs = ["device-id"]
+certs = ["device-id-temp", "device-id"]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/certd.toml
@@ -17,6 +17,19 @@ CN = "my-device"
 L = "AQ"
 ST = "Antarctica"
 
+[cert_issuance.device-id-temp]
+method = "est"
+url = "https://example.org/.well-known/est"
+identity_cert = "est-id-device-id"
+identity_pk = "est-id-device-id"
+bootstrap_identity_cert = "est-bootstrap-id-device-id"
+bootstrap_identity_pk = "est-bootstrap-id-device-id"
+
+[cert_issuance.device-id-temp.subject]
+CN = "my-device"
+L = "AQ"
+ST = "Antarctica"
+
 [preloaded_certs]
 est-bootstrap-id-device-id = "file:///var/secrets/est-bootstrap-id.pem"
 est-server-ca-1 = "file:///var/secrets/est-id-ca.pem"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/config.toml
@@ -19,6 +19,7 @@ ST = "Antarctica"
 CN = "my-device"
 
 [provisioning.attestation.identity_cert.auto_renew]
+rotate_key = false
 threshold = "50%"
 retry = "10%"
 

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/identityd.toml
@@ -13,5 +13,6 @@ identity_cert = "device-id"
 identity_pk = "device-id"
 
 [provisioning.attestation.identity_auto_renew]
+rotate_key = false
 threshold = "50%"
 retry = "10%"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/keyd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/keyd.toml
@@ -10,4 +10,4 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["est-bootstrap-id-device-id", "est-id-device-id"]
+keys = ["est-bootstrap-id-device-id", "est-id-device-id-temp", "est-id-device-id"]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
@@ -9,6 +9,7 @@ bootstrap_identity_cert = "est-bootstrap-id"
 bootstrap_identity_pk = "est-bootstrap-id"
 
 [cert_issuance.est.identity_auto_renew]
+rotate_key = true
 threshold = "50%"
 retry = "10%"
 

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
@@ -26,4 +26,4 @@ est-server-ca-1 = "file:///var/secrets/est-id-ca.pem"
 
 [[principal]]
 uid = 5556
-certs = ["device-id"]
+certs = ["device-id-temp", "device-id"]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/certd.toml
@@ -20,6 +20,10 @@ default = "https://example.org/.well-known/est"
 method = "est"
 common_name = "my-device"
 
+[cert_issuance.device-id-temp]
+method = "est"
+common_name = "my-device"
+
 [preloaded_certs]
 est-bootstrap-id = "file:///var/secrets/est-bootstrap-id.pem"
 est-server-ca-1 = "file:///var/secrets/est-id-ca.pem"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/config.toml
@@ -6,7 +6,15 @@ id_scope = "0ab1234C5D6"
 [provisioning.attestation]
 method = "x509"
 registration_id = "my-device"
-identity_cert = { method = "est", common_name = "my-device" }
+
+[provisioning.attestation.identity_cert]
+method = "est"
+common_name = "my-device"
+
+[provisioning.attestation.identity_cert.auto_renew]
+rotate_key = true
+threshold = "90%"
+retry = "1%"
 
 [aziot_keys]
 pkcs11_lib_path = "/usr/lib/libmypkcs11.so"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/config.toml
@@ -24,6 +24,7 @@ bootstrap_identity_cert = "file:///var/secrets/est-bootstrap-id.pem"
 bootstrap_identity_pk = "pkcs11:slot-id=0;object=est-bootstrap-id?pin-value=1234"
 
 [cert_issuance.est.identity_auto_renew]
+rotate_key = true
 threshold = "50%"
 retry = "10%"
 

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
@@ -11,3 +11,8 @@ method = "x509"
 registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
+
+[provisioning.attestation.identity_auto_renew]
+rotate_key = true
+threshold = "90%"
+retry = "1%"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/keyd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/keyd.toml
@@ -8,8 +8,8 @@ est-bootstrap-id = "pkcs11:slot-id=0;object=est%2Dbootstrap%2Did?pin-value=1234"
 
 [[principal]]
 uid = 5556
-keys = ["aziot_identityd_master_id", "device-id"]
+keys = ["aziot_identityd_master_id", "device-id", "device-id-temp"]
 
 [[principal]]
 uid = 5555
-keys = ["est-bootstrap-id", "est-id"]
+keys = ["est-bootstrap-id", "est-id", "est-id-temp"]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-custom-bootstrap/keyd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-custom-bootstrap/keyd.toml
@@ -13,4 +13,4 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["est-bootstrap-id-device-id", "est-id-device-id", "est-bootstrap-id", "est-id"]
+keys = ["est-bootstrap-id-device-id", "est-id-device-id-temp", "est-id-device-id", "est-bootstrap-id", "est-id", "est-id-temp"]

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/keyd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/keyd.toml
@@ -13,4 +13,4 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["est-bootstrap-id-device-id", "est-id-device-id", "est-bootstrap-id", "est-id"]
+keys = ["est-bootstrap-id-device-id", "est-id-device-id-temp", "est-id-device-id", "est-bootstrap-id", "est-id", "est-id-temp"]

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -85,12 +85,12 @@ pub struct Est {
     ///
     /// This setting applies to EST identity certs for all EST `cert_issuance` configurations. Default values
     /// to renew at 80% of cert lifetime with retries every 4% of cert lifetime will be used if this setting
-    /// is not provided.
+    /// is not provided. By default, keys will also be rotated.
     #[serde(
-        default = "default_est_renew",
-        skip_serializing_if = "is_default_est_renew"
+        default,
+        skip_serializing_if = "cert_renewal::AutoRenewConfig::is_default"
     )]
-    pub identity_auto_renew: cert_renewal::RenewalPolicy,
+    pub identity_auto_renew: cert_renewal::AutoRenewConfig,
 
     /// Map of certificate IDs to EST endpoint URLs.
     ///
@@ -327,6 +327,7 @@ trusted_certs = [
 ]
 
 [cert_issuance.est.identity_auto_renew]
+rotate_key = true
 threshold = "50%"
 retry = "10%"
 
@@ -355,9 +356,12 @@ certs = ["test"]
                 cert_issuance: CertIssuance {
                     est: Some(Est {
                         trusted_certs: vec!["est-ca".to_owned(),],
-                        identity_auto_renew: cert_renewal::RenewalPolicy {
-                            threshold: cert_renewal::Policy::Percentage(50),
-                            retry: cert_renewal::Policy::Percentage(10)
+                        identity_auto_renew: cert_renewal::AutoRenewConfig {
+                            rotate_key: true,
+                            policy: cert_renewal::RenewalPolicy {
+                                threshold: cert_renewal::Policy::Percentage(50),
+                                retry: cert_renewal::Policy::Percentage(10)
+                            }
                         },
                         auth: EstAuth {
                             basic: None,
@@ -540,7 +544,7 @@ aziot_certd = "unix:///run/aziot/certd.sock"
             cert_issuance: CertIssuance {
                 est: Some(Est {
                     trusted_certs: vec!["est-ca".to_owned()],
-                    identity_auto_renew: super::default_est_renew(),
+                    identity_auto_renew: cert_renewal::AutoRenewConfig::default(),
                     auth: EstAuth {
                         basic: None,
                         x509: Some(EstAuthX509 {

--- a/cert/cert-renewal/src/lib.rs
+++ b/cert/cert-renewal/src/lib.rs
@@ -47,7 +47,7 @@ fn test_cert(not_before: i64, not_after: i64) -> openssl::x509::X509 {
 }
 
 /// Common settings for configuring auto-renewal.
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AutoRenewConfig {
     /// Whether to rotate the key. This requires temporary storage for a second
     /// key during credential rotation. Defaults to `true`.

--- a/cert/cert-renewal/src/lib.rs
+++ b/cert/cert-renewal/src/lib.rs
@@ -45,3 +45,33 @@ fn test_cert(not_before: i64, not_after: i64) -> openssl::x509::X509 {
 
     cert
 }
+
+/// Common settings for configuring auto-renewal.
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct AutoRenewConfig {
+    /// Whether to rotate the key. This requires temporary storage for a second
+    /// key during credential rotation. Defaults to `true`.
+    pub rotate_key: bool,
+
+    /// Renewal policy.
+    #[serde(flatten)]
+    pub policy: RenewalPolicy,
+}
+
+impl Default for AutoRenewConfig {
+    fn default() -> Self {
+        AutoRenewConfig {
+            rotate_key: true,
+            policy: RenewalPolicy {
+                threshold: Policy::Percentage(80),
+                retry: Policy::Percentage(4),
+            },
+        }
+    }
+}
+
+impl AutoRenewConfig {
+    pub fn is_default(&self) -> bool {
+        self == &AutoRenewConfig::default()
+    }
+}

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -128,7 +128,7 @@ pub enum DpsAttestationMethod {
         identity_cert: String,
         identity_pk: String,
         #[serde(skip_serializing_if = "Option::is_none")]
-        identity_auto_renew: Option<cert_renewal::RenewalPolicy>,
+        identity_auto_renew: Option<cert_renewal::AutoRenewConfig>,
     },
     Tpm {
         registration_id: String,


### PR DESCRIPTION
- Adds the `rotate_key` setting for cert renewal. Defaults to `true`.
- Updates authorized principals to allow access to `temp` keys when necessary.