### PR TITLE
[main] Upgrade to latest Rust version

### DIFF
--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -881,6 +881,7 @@ mod tests {
             assert_eq!(*expected, deserialized_connector);
         }
 
+        #[allow(clippy::single_element_loop)]
         for input in &[
             // unsupported scheme
             "ftp://127.0.0.1",

--- a/key/aziot-keyd/src/keys.rs
+++ b/key/aziot-keyd/src/keys.rs
@@ -518,8 +518,7 @@ impl Keys {
                             keys_ok(get_key_pair_parameter(
                                 id.as_ptr(),
                                 sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE_ALGORITHM,
-                                (&mut algorithm as *mut sys::AZIOT_KEYS_KEY_PAIR_PARAMETER_TYPE)
-                                    .cast(),
+                                std::ptr::addr_of_mut!(algorithm).cast(),
                                 &mut algorithm_len,
                             ))
                             .map_err(|err| GetKeyPairPublicParameterError::Api { err })?;
@@ -1216,6 +1215,7 @@ pub(crate) mod sys {
         non_camel_case_types,
         non_snake_case,
         unused,
+        clippy::borrow_as_ptr,
         clippy::too_many_lines,
         clippy::unreadable_literal,
         clippy::unseparated_literal_suffix,

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -330,7 +330,7 @@ impl Api {
                 self.keys.sign(
                     &id_cstr,
                     keys::sys::AZIOT_KEYS_SIGN_MECHANISM_DERIVED,
-                    (&parameters as *const keys::sys::AZIOT_KEYS_SIGN_DERIVED_PARAMETERS).cast(),
+                    std::ptr::addr_of!(parameters).cast(),
                     digest,
                 )?
             }
@@ -366,7 +366,7 @@ impl Api {
                 self.keys.encrypt(
                     &id_cstr,
                     keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD,
-                    (&parameters as *const keys::sys::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS).cast(),
+                    std::ptr::addr_of!(parameters).cast(),
                     plaintext,
                 )?
             }
@@ -404,15 +404,13 @@ impl Api {
                     derivation_data: derivation_data.as_ptr(),
                     derivation_data_len: derivation_data.len(),
                     mechanism: keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD,
-                    parameters: (&parameters
-                        as *const keys::sys::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS)
-                        .cast(),
+                    parameters: std::ptr::addr_of!(parameters).cast(),
                 };
 
                 self.keys.encrypt(
                     &id_cstr,
                     keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_DERIVED,
-                    (&parameters as *const keys::sys::AZIOT_KEYS_ENCRYPT_DERIVED_PARAMETERS).cast(),
+                    std::ptr::addr_of!(parameters).cast(),
                     plaintext,
                 )?
             }
@@ -448,7 +446,7 @@ impl Api {
                 self.keys.decrypt(
                     &id_cstr,
                     keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD,
-                    (&parameters as *const keys::sys::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS).cast(),
+                    std::ptr::addr_of!(parameters).cast(),
                     ciphertext,
                 )?
             }
@@ -468,15 +466,13 @@ impl Api {
                     derivation_data: derivation_data.as_ptr(),
                     derivation_data_len: derivation_data.len(),
                     mechanism: keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_AEAD,
-                    parameters: (&parameters
-                        as *const keys::sys::AZIOT_KEYS_ENCRYPT_AEAD_PARAMETERS)
-                        .cast(),
+                    parameters: std::ptr::addr_of!(parameters).cast(),
                 };
 
                 self.keys.decrypt(
                     &id_cstr,
                     keys::sys::AZIOT_KEYS_ENCRYPT_MECHANISM_DERIVED,
-                    (&parameters as *const keys::sys::AZIOT_KEYS_ENCRYPT_DERIVED_PARAMETERS).cast(),
+                    std::ptr::addr_of!(parameters).cast(),
                     ciphertext,
                 )?
             }

--- a/key/aziot-keys/src/implementation.rs
+++ b/key/aziot-keys/src/implementation.rs
@@ -71,18 +71,16 @@ pub(crate) unsafe fn get_function_list(
             crate::function_list::v2_0_0_0::AZIOT_KEYS_VERSION_2_0_0_0 => {
                 let mut function_list_out = std::ptr::NonNull::new(pfunction_list)
                     .ok_or_else(|| err_invalid_parameter("pfunction_list", "expected non-NULL"))?;
-                *function_list_out.as_mut() = (&AZIOT_KEYS_FUNCTION_LIST_2_0_0_0
-                    as *const crate::function_list::v2_0_0_0::AZIOT_KEYS_FUNCTION_LIST_2_0_0_0)
-                    .cast();
+                *function_list_out.as_mut() =
+                    std::ptr::addr_of!(AZIOT_KEYS_FUNCTION_LIST_2_0_0_0).cast();
                 Ok(())
             }
 
             crate::function_list::v2_1_0_0::AZIOT_KEYS_VERSION_2_1_0_0 => {
                 let mut function_list_out = std::ptr::NonNull::new(pfunction_list)
                     .ok_or_else(|| err_invalid_parameter("pfunction_list", "expected non-NULL"))?;
-                *function_list_out.as_mut() = (&AZIOT_KEYS_FUNCTION_LIST_2_1_0_0
-                    as *const crate::function_list::v2_1_0_0::AZIOT_KEYS_FUNCTION_LIST_2_1_0_0)
-                    .cast();
+                *function_list_out.as_mut() =
+                    std::ptr::addr_of!(AZIOT_KEYS_FUNCTION_LIST_2_1_0_0).cast();
                 Ok(())
             }
 

--- a/pkcs11/pkcs11/src/dl.rs
+++ b/pkcs11/pkcs11/src/dl.rs
@@ -60,7 +60,7 @@ impl<F> std::ops::Deref for Symbol<'_, F> {
             // F is expected to be a fn(...) and fn are themselves pointers. So self.inner is that fn.
             // The signature of `Deref::deref` requires this code to return a &fn, not the fn itself.
             // So we want to return the address of self.inner, and not self.inner itself.
-            &*((&self.inner as *const *mut std::ffi::c_void).cast::<F>())
+            &*(std::ptr::addr_of!(self.inner).cast::<F>())
         }
     }
 }

--- a/pkcs11/pkcs11/src/dl.rs
+++ b/pkcs11/pkcs11/src/dl.rs
@@ -60,7 +60,8 @@ impl<F> std::ops::Deref for Symbol<'_, F> {
             // F is expected to be a fn(...) and fn are themselves pointers. So self.inner is that fn.
             // The signature of `Deref::deref` requires this code to return a &fn, not the fn itself.
             // So we want to return the address of self.inner, and not self.inner itself.
-            &*(std::ptr::addr_of!(self.inner).cast::<F>())
+            #[allow(clippy::borrow_as_ptr)]
+            &*((&self.inner as *const *mut std::ffi::c_void).cast::<F>())
         }
     }
 }

--- a/pkcs11/pkcs11/src/object.rs
+++ b/pkcs11/pkcs11/src/object.rs
@@ -86,7 +86,7 @@ impl Object<()> {
             };
             let mechanism = pkcs11_sys::CK_MECHANISM_IN {
                 mechanism: pkcs11_sys::CKM_AES_GCM,
-                pParameter: (&params as *const pkcs11_sys::CK_GCM_PARAMS).cast(),
+                pParameter: std::ptr::addr_of!(params).cast(),
                 ulParameterLen: std::convert::TryInto::try_into(std::mem::size_of_val(&params))
                     .expect("usize -> CK_ULONG"),
             };
@@ -127,7 +127,7 @@ impl Object<()> {
             };
             let mechanism = pkcs11_sys::CK_MECHANISM_IN {
                 mechanism: pkcs11_sys::CKM_AES_GCM,
-                pParameter: (&params as *const pkcs11_sys::CK_GCM_PARAMS).cast(),
+                pParameter: std::ptr::addr_of!(params).cast(),
                 ulParameterLen: std::convert::TryInto::try_into(std::mem::size_of_val(&params))
                     .expect("usize -> CK_ULONG"),
             };

--- a/pkcs11/pkcs11/src/session.rs
+++ b/pkcs11/pkcs11/src/session.rs
@@ -108,7 +108,7 @@ impl Session {
     ) -> Result<pkcs11_sys::CK_OBJECT_HANDLE, GetKeyError> {
         let mut templates = vec![pkcs11_sys::CK_ATTRIBUTE_IN {
             r#type: pkcs11_sys::CKA_CLASS,
-            pValue: (&class as *const pkcs11_sys::CK_OBJECT_CLASS).cast(),
+            pValue: std::ptr::addr_of!(class).cast(),
             ulValueLen: std::convert::TryInto::try_into(std::mem::size_of_val(&class))
                 .expect("usize -> CK_ULONG"),
         }];
@@ -141,7 +141,7 @@ impl Session {
             .expect("usize -> CK_ULONG");
         let mut attribute = pkcs11_sys::CK_ATTRIBUTE {
             r#type: pkcs11_sys::CKA_KEY_TYPE,
-            pValue: (&mut key_type as *mut pkcs11_sys::CK_KEY_TYPE).cast(),
+            pValue: std::ptr::addr_of_mut!(key_type).cast(),
             ulValueLen: key_type_size,
         };
         let result = (self.context.C_GetAttributeValue)(self.handle, key_handle, &mut attribute, 1);
@@ -378,7 +378,7 @@ impl Session {
             let r#true = pkcs11_sys::CK_TRUE;
             let true_size = std::convert::TryInto::try_into(std::mem::size_of_val(&r#true))
                 .expect("usize -> CK_ULONG");
-            let r#true = (&r#true as *const pkcs11_sys::CK_BBOOL).cast();
+            let r#true = std::ptr::addr_of!(r#true).cast();
 
             // Common to all keys
             let mut key_template = vec![
@@ -442,7 +442,7 @@ impl Session {
                     let key_type = pkcs11_sys::CKK_AES;
                     key_template.push(pkcs11_sys::CK_ATTRIBUTE_IN {
                         r#type: pkcs11_sys::CKA_KEY_TYPE,
-                        pValue: (&key_type as *const pkcs11_sys::CK_KEY_TYPE).cast(),
+                        pValue: std::ptr::addr_of!(key_type).cast(),
                         ulValueLen: std::convert::TryInto::try_into(std::mem::size_of_val(
                             &key_type,
                         ))
@@ -459,7 +459,7 @@ impl Session {
 
                     key_template.push(pkcs11_sys::CK_ATTRIBUTE_IN {
                         r#type: pkcs11_sys::CKA_VALUE_LEN,
-                        pValue: (&len as *const pkcs11_sys::CK_ULONG).cast(),
+                        pValue: std::ptr::addr_of!(len).cast(),
                         ulValueLen: len_size,
                     });
 
@@ -484,7 +484,7 @@ impl Session {
                     len = 16;
                     key_template.push(pkcs11_sys::CK_ATTRIBUTE_IN {
                         r#type: pkcs11_sys::CKA_VALUE_LEN,
-                        pValue: (&len as *const pkcs11_sys::CK_ULONG).cast(),
+                        pValue: std::ptr::addr_of!(len).cast(),
                         ulValueLen: len_size,
                     });
 
@@ -529,14 +529,14 @@ impl Session {
                     });
                     key_template.push(pkcs11_sys::CK_ATTRIBUTE_IN {
                         r#type: pkcs11_sys::CKA_VALUE_LEN,
-                        pValue: (&len as *const pkcs11_sys::CK_ULONG).cast(),
+                        pValue: std::ptr::addr_of!(len).cast(),
                         ulValueLen: len_size,
                     });
 
                     let key_type = pkcs11_sys::CKK_GENERIC_SECRET;
                     key_template.push(pkcs11_sys::CK_ATTRIBUTE_IN {
                         r#type: pkcs11_sys::CKA_KEY_TYPE,
-                        pValue: (&key_type as *const pkcs11_sys::CK_KEY_TYPE).cast(),
+                        pValue: std::ptr::addr_of!(len).cast(),
                         ulValueLen: std::convert::TryInto::try_into(std::mem::size_of_val(
                             &key_type,
                         ))
@@ -633,13 +633,13 @@ impl Session {
             let r#true = pkcs11_sys::CK_TRUE;
             let true_size = std::convert::TryInto::try_into(std::mem::size_of_val(&r#true))
                 .expect("usize -> CK_ULONG");
-            let r#true = (&r#true as *const pkcs11_sys::CK_BBOOL).cast();
+            let r#true = std::ptr::addr_of!(r#true).cast();
 
             // Common to all keys
             let mut key_template = vec![
                 pkcs11_sys::CK_ATTRIBUTE_IN {
                     r#type: pkcs11_sys::CKA_CLASS,
-                    pValue: (&class as *const pkcs11_sys::CK_OBJECT_CLASS).cast(),
+                    pValue: std::ptr::addr_of!(class).cast(),
                     ulValueLen: std::convert::TryInto::try_into(std::mem::size_of_val(&class))
                         .expect("usize -> CK_ULONG"),
                 },
@@ -709,7 +709,7 @@ impl Session {
 
             key_template.push(pkcs11_sys::CK_ATTRIBUTE_IN {
                 r#type: pkcs11_sys::CKA_KEY_TYPE,
-                pValue: (&key_type as *const pkcs11_sys::CK_KEY_TYPE).cast(),
+                pValue: std::ptr::addr_of!(key_type).cast(),
                 ulValueLen: std::convert::TryInto::try_into(std::mem::size_of_val(&key_type))
                     .expect("usize -> CK_ULONG"),
             });
@@ -822,7 +822,7 @@ impl Session {
             let public_key_template = vec![
                 pkcs11_sys::CK_ATTRIBUTE_IN {
                     r#type: pkcs11_sys::CKA_MODULUS_BITS,
-                    pValue: (&modulus_bits as *const pkcs11_sys::CK_ULONG).cast(),
+                    pValue: std::ptr::addr_of!(modulus_bits).cast(),
                     ulValueLen: std::convert::TryInto::try_into(std::mem::size_of_val(
                         &modulus_bits,
                     ))
@@ -882,12 +882,12 @@ impl Session {
         let r#true = pkcs11_sys::CK_TRUE;
         let true_size = std::convert::TryInto::try_into(std::mem::size_of_val(&r#true))
             .expect("usize -> CK_ULONG");
-        let r#true = (&r#true as *const pkcs11_sys::CK_BBOOL).cast();
+        let r#true = std::ptr::addr_of!(r#true).cast();
 
         let r#false = pkcs11_sys::CK_FALSE;
         let false_size = std::convert::TryInto::try_into(std::mem::size_of_val(&r#false))
             .expect("usize -> CK_ULONG");
-        let r#false = (&r#false as *const pkcs11_sys::CK_BBOOL).cast();
+        let r#false = std::ptr::addr_of!(r#false).cast();
 
         // The spec's example also passes in CKA_WRAP for the public key and CKA_UNWRAP for the private key,
         // but tpm2-pkcs11's impl of `C_GenerateKeyPair` does not recognize those and fails.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.59"
+channel = "1.60"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- Use `std::ptr::addr_of` and `std::ptr::addr_of_mut` for pointers to places

[^0]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes-11
  Namely, the point on `mem::uninitialized`.