### PR TITLE
Add renewal of device identity certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ version = "0.1.0"
 dependencies = [
  "aziot-key-common",
  "http-common",
+ "openssl",
  "serde",
 ]
 

--- a/cert/cert-renewal/src/engine.rs
+++ b/cert/cert-renewal/src/engine.rs
@@ -135,7 +135,11 @@ where
         )
         .await?;
 
-    log::info!("Certificate {} was renewed.", credential.cert_id);
+    log::info!(
+        "Certificate {} was renewed. Next renewal at {}.",
+        credential.cert_id,
+        credential.next_renewal
+    );
 
     Ok(())
 }

--- a/cert/cert-renewal/src/error.rs
+++ b/cert/cert-renewal/src/error.rs
@@ -26,6 +26,8 @@ impl std::fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 impl std::convert::From<Error> for std::io::Error {
     fn from(err: Error) -> std::io::Error {
         let message = match err {

--- a/identity/aziot-cloud-client-async/src/dps/mod.rs
+++ b/identity/aziot-cloud-client-async/src/dps/mod.rs
@@ -13,8 +13,6 @@ pub struct Client {
     auth: aziot_identity_common::Credentials,
 
     key_client: crate::KeyClient,
-    key_engine: crate::KeyEngine,
-    cert_client: crate::CertClient,
     tpm_client: crate::TpmClient,
 
     timeout: std::time::Duration,
@@ -28,8 +26,6 @@ impl Client {
     pub fn new(
         credentials: aziot_identity_common::Credentials,
         key_client: crate::KeyClient,
-        key_engine: crate::KeyEngine,
-        cert_client: crate::CertClient,
         tpm_client: crate::TpmClient,
     ) -> Self {
         // The default DPS global endpoint.
@@ -40,8 +36,6 @@ impl Client {
             endpoint,
             auth: credentials,
             key_client,
-            key_engine,
-            cert_client,
             tpm_client,
             timeout: std::time::Duration::from_secs(30),
             retries: 0,
@@ -82,14 +76,7 @@ impl Client {
         scope_id: &str,
         registration_id: &str,
     ) -> Result<schema::Device, Error> {
-        let connector = crate::connector::from_auth(
-            &self.auth,
-            self.proxy.clone(),
-            &self.key_client,
-            &self.key_engine,
-            &self.cert_client,
-        )
-        .await?;
+        let connector = crate::connector::from_auth(&self.auth, self.proxy.clone())?;
 
         let register_uri = {
             let register_path = format!("{}/registrations/{}/register", scope_id, registration_id);

--- a/identity/aziot-cloud-client-async/src/dps/mod.rs
+++ b/identity/aziot-cloud-client-async/src/dps/mod.rs
@@ -231,7 +231,10 @@ impl Client {
             log::info!("Checking DPS registration status.");
             let response = status_request.json_response().await?;
 
-            let registration = response.parse_expect_ok::<schema::response::DeviceRegistration, schema::response::ServiceError>()?;
+            let registration = response
+                .parse::<schema::response::DeviceRegistration, schema::response::ServiceError>(
+                    &[hyper::StatusCode::OK, hyper::StatusCode::ACCEPTED],
+                )?;
 
             match registration {
                 schema::response::DeviceRegistration::Assigned { device, tpm } => {

--- a/identity/aziot-cloud-client-async/src/hub/mod.rs
+++ b/identity/aziot-cloud-client-async/src/hub/mod.rs
@@ -24,8 +24,6 @@ pub struct Client {
     device: aziot_identity_common::IoTHubDevice,
 
     key_client: crate::KeyClient,
-    key_engine: crate::KeyEngine,
-    cert_client: crate::CertClient,
     tpm_client: crate::TpmClient,
 
     timeout: std::time::Duration,
@@ -39,15 +37,11 @@ impl Client {
     pub fn new(
         device: &aziot_identity_common::IoTHubDevice,
         key_client: crate::KeyClient,
-        key_engine: crate::KeyEngine,
-        cert_client: crate::CertClient,
         tpm_client: crate::TpmClient,
     ) -> Self {
         Client {
             device: device.clone(),
             key_client,
-            key_engine,
-            cert_client,
             tpm_client,
             timeout: std::time::Duration::from_secs(30),
             retries: 0,
@@ -156,14 +150,7 @@ impl Client {
     where
         TRequest: serde::Serialize,
     {
-        let connector = crate::connector::from_auth(
-            &self.device.credentials,
-            self.proxy.clone(),
-            &self.key_client,
-            &self.key_engine,
-            &self.cert_client,
-        )
-        .await?;
+        let connector = crate::connector::from_auth(&self.device.credentials, self.proxy.clone())?;
 
         let uri = format!("https://{}", &self.device.local_gateway_hostname);
         let mut uri =

--- a/identity/aziot-cloud-client-async/src/lib.rs
+++ b/identity/aziot-cloud-client-async/src/lib.rs
@@ -15,8 +15,6 @@ pub mod hub;
 pub use hub::Client as HubClient;
 
 type KeyClient = std::sync::Arc<aziot_key_client_async::Client>;
-type KeyEngine = std::sync::Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>;
-type CertClient = std::sync::Arc<aziot_cert_client_async::Client>;
 type TpmClient = std::sync::Arc<aziot_tpm_client_async::Client>;
 
 type CloudConnector =

--- a/identity/aziot-identity-common/Cargo.toml
+++ b/identity/aziot-identity-common/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+openssl = "0.10"
 serde = { version = "1", features = ["derive"] }
 
 aziot-key-common = { path = "../../key/aziot-key-common" }

--- a/identity/aziot-identity-common/src/lib.rs
+++ b/identity/aziot-identity-common/src/lib.rs
@@ -161,8 +161,8 @@ pub enum Credentials {
     SharedPrivateKey(String),
 
     X509 {
-        identity_cert: String,
-        identity_pk: String,
+        identity_cert: (String, openssl::x509::X509),
+        identity_pk: (String, openssl::pkey::PKey<openssl::pkey::Private>),
     },
 
     Tpm,
@@ -181,8 +181,8 @@ impl From<Credentials> for AuthenticationInfo {
                 identity_pk,
             } => AuthenticationInfo {
                 auth_type: AuthenticationType::X509,
-                key_handle: Some(aziot_key_common::KeyHandle(identity_pk)),
-                cert_id: Some(identity_cert),
+                key_handle: Some(aziot_key_common::KeyHandle(identity_pk.0)),
+                cert_id: Some(identity_cert.0),
             },
             Credentials::Tpm => AuthenticationInfo {
                 auth_type: AuthenticationType::Tpm,

--- a/identity/aziot-identityd/src/http/reprovision_device.rs
+++ b/identity/aziot-identityd/src/http/reprovision_device.rs
@@ -44,7 +44,7 @@ impl http_common::server::Route for Route {
         };
 
         match api
-            .reprovision_device(auth_id, crate::ReprovisionTrigger::Api)
+            .reprovision_device(auth_id, crate::ReprovisionTrigger::Api, None)
             .await
         {
             Ok(()) => (),

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -23,9 +23,9 @@ pub struct IdentityManager {
     key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
     cert_client: Arc<aziot_cert_client_async::Client>,
     tpm_client: Arc<aziot_tpm_client_async::Client>,
-    iot_hub_device: Option<aziot_identity_common::IoTHubDevice>,
     proxy_uri: Option<hyper::Uri>,
 
+    pub(crate) iot_hub_device: Option<aziot_identity_common::IoTHubDevice>,
     pub(crate) identity_cert_renewal: Option<
         Arc<
             futures_util::lock::Mutex<

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -25,6 +25,14 @@ pub struct IdentityManager {
     tpm_client: Arc<aziot_tpm_client_async::Client>,
     iot_hub_device: Option<aziot_identity_common::IoTHubDevice>,
     proxy_uri: Option<hyper::Uri>,
+
+    pub(crate) identity_cert_renewal: Option<
+        Arc<
+            futures_util::lock::Mutex<
+                cert_renewal::RenewalEngine<crate::renewal::IdentityCertRenewal>,
+            >,
+        >,
+    >,
 }
 
 impl IdentityManager {
@@ -47,6 +55,7 @@ impl IdentityManager {
             tpm_client,
             iot_hub_device,
             proxy_uri,
+            identity_cert_renewal: None,
         }
     }
 
@@ -112,8 +121,6 @@ impl IdentityManager {
                 let client = aziot_cloud_client_async::HubClient::new(
                     device,
                     self.key_client.clone(),
-                    self.key_engine.clone(),
-                    self.cert_client.clone(),
                     self.tpm_client.clone(),
                 )
                 .with_retry(self.req_retries)
@@ -195,8 +202,6 @@ impl IdentityManager {
                 let client = aziot_cloud_client_async::HubClient::new(
                     device,
                     self.key_client.clone(),
-                    self.key_engine.clone(),
-                    self.cert_client.clone(),
                     self.tpm_client.clone(),
                 )
                 .with_retry(self.req_retries)
@@ -295,8 +300,6 @@ impl IdentityManager {
                     let client = aziot_cloud_client_async::HubClient::new(
                         device,
                         self.key_client.clone(),
-                        self.key_engine.clone(),
-                        self.cert_client.clone(),
                         self.tpm_client.clone(),
                     )
                     .with_retry(self.req_retries)
@@ -381,8 +384,6 @@ impl IdentityManager {
                 let client = aziot_cloud_client_async::HubClient::new(
                     device,
                     self.key_client.clone(),
-                    self.key_engine.clone(),
-                    self.cert_client.clone(),
                     self.tpm_client.clone(),
                 )
                 .with_retry(self.req_retries)
@@ -439,8 +440,6 @@ impl IdentityManager {
                 let client = aziot_cloud_client_async::HubClient::new(
                     device,
                     self.key_client.clone(),
-                    self.key_engine.clone(),
-                    self.cert_client.clone(),
                     self.tpm_client.clone(),
                 )
                 .with_retry(self.req_retries)
@@ -489,13 +488,13 @@ impl IdentityManager {
                 } => {
                     let identity_pk_key_handle = self
                         .key_client
-                        .load_key_pair(identity_pk.as_str())
+                        .load_key_pair(identity_pk.0.as_str())
                         .await
                         .map_err(Error::KeyClient)?;
                     Ok(aziot_identity_common::AuthenticationInfo {
                         auth_type: aziot_identity_common::AuthenticationType::X509,
                         key_handle: Some(aziot_key_common::KeyHandle(identity_pk_key_handle.0)),
-                        cert_id: Some(identity_cert.clone()),
+                        cert_id: Some(identity_cert.0.clone()),
                     })
                 }
                 aziot_identity_common::Credentials::Tpm => {
@@ -607,17 +606,11 @@ impl IdentityManager {
                         identity_pk,
                     } => {
                         // IoT Hub doesn't require device ID to match identity certificate CN
-                        let _ = self
-                            .create_identity_cert_if_not_exist_or_expired(
-                                &identity_pk,
-                                &identity_cert,
-                                Some(&device_id),
-                            )
+                        let (_, credentials) = self
+                            .get_identity_cert(&identity_pk, &identity_cert, Some(&device_id))
                             .await?;
-                        aziot_identity_common::Credentials::X509 {
-                            identity_cert,
-                            identity_pk,
-                        }
+
+                        credentials
                     }
                 };
                 let device = aziot_identity_common::IoTHubDevice {
@@ -660,25 +653,15 @@ impl IdentityManager {
                         identity_auto_renew: _,
                     } => {
                         // DPS requires registration ID to match identity certificate CN
-                        let cert_subject_name = self
-                            .create_identity_cert_if_not_exist_or_expired(
+                        let (cert_subject, credentials) = self
+                            .get_identity_cert(
                                 &identity_pk,
                                 &identity_cert,
                                 registration_id.as_ref(),
                             )
                             .await?;
 
-                        let registration_id = match registration_id {
-                            Some(registration_id) => registration_id,
-                            None => cert_subject_name.map_err(|err| {
-                                Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                            })?,
-                        };
-
-                        let credentials = aziot_identity_common::Credentials::X509 {
-                            identity_cert: identity_cert.clone(),
-                            identity_pk: identity_pk.clone(),
-                        };
+                        let registration_id = registration_id.unwrap_or(cert_subject);
 
                         (registration_id, credentials)
                     }
@@ -735,8 +718,6 @@ impl IdentityManager {
         let dps_request = aziot_cloud_client_async::DpsClient::new(
             credentials.clone(),
             self.key_client.clone(),
-            self.key_engine.clone(),
-            self.cert_client.clone(),
             self.tpm_client.clone(),
         )
         .with_endpoint(global_endpoint)
@@ -796,102 +777,95 @@ impl IdentityManager {
         }
     }
 
-    async fn create_identity_cert_if_not_exist_or_expired(
+    async fn get_identity_cert(
         &self,
         identity_pk: &str,
         identity_cert: &str,
         subject: Option<&String>,
-    ) -> Result<Result<String, Error>, Error> {
-        // Retrieve existing cert and check it for expiry.
-        let (device_id_cert, old_cert_subject_name) = match self
-            .cert_client
-            .get_cert(identity_cert)
-            .await
-        {
-            Ok(pem) => {
-                let cert = openssl::x509::X509::from_pem(&pem).map_err(|err| {
-                    Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                })?;
-                let cert_expiration = cert.as_ref().not_after();
-                let cert_subject = cert.as_ref().subject_name();
-                let cert_subject = cert_subject.entries_by_nid(openssl::nid::Nid::COMMONNAME).next()
-                  .map_or(Err(Error::Internal(InternalError::CreateCertificate("old device identity certificate does not contain common name field required for registration".to_string().into()))), |common_name_entry| {
-                    String::from_utf8(common_name_entry.data().as_slice().into()).map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))
-                });
-                let current_time = openssl::asn1::Asn1Time::days_from_now(0).map_err(|err| {
-                    Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                })?;
-                let expiration_time = current_time.diff(cert_expiration).map_err(|err| {
-                    Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                })?;
+    ) -> Result<(String, aziot_identity_common::Credentials), Error> {
+        let (cert, private_key) = if let Some(engine) = &self.identity_cert_renewal {
+            cert_renewal::engine::get_credential(engine, identity_cert, identity_pk)
+                .await
+                .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?
+        } else {
+            let key_handle = self.key_client.load_key_pair(identity_pk).await;
 
-                if expiration_time.days < 1 {
-                    log::info!("{} has expired. Renewing certificate", identity_cert);
+            if let Ok(cert) = self.cert_client.get_cert(identity_cert).await {
+                let cert = openssl::x509::X509::from_pem(&cert)
+                    .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
 
-                    (None, cert_subject)
+                let key_handle = key_handle
+                    .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
+
+                let (private_key, _) = crate::get_keys(key_handle, &self.key_engine)
+                    .await
+                    .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
+
+                (cert, private_key)
+            } else {
+                let subject = if let Some(subject) = subject {
+                    subject
                 } else {
-                    (Some(pem), cert_subject)
+                    return Err(Error::Internal(InternalError::CreateCertificate(
+                        "identity cert does not exist; cannot create new cert as registration ID is unknown".into()
+                    )));
+                };
+
+                if let Ok(key_handle) = key_handle {
+                    self.key_client
+                        .delete_key_pair(&key_handle)
+                        .await
+                        .map_err(|err| {
+                            Error::Internal(InternalError::CreateCertificate(err.into()))
+                        })?;
                 }
-            }
-            Err(_) => {
-                (None, Err(Error::Internal(InternalError::CreateCertificate("old device identity certificate, which should contain the common name field required for registration, could not be retrieved".to_string().into()))))
+
+                let key_handle = self
+                    .key_client
+                    .create_key_pair_if_not_exists(identity_pk, Some("rsa-2048:*"))
+                    .await
+                    .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
+
+                let (private_key, public_key) = crate::get_keys(key_handle, &self.key_engine)
+                    .await
+                    .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
+
+                let csr = create_csr(subject, &public_key, &private_key, None)
+                    .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
+
+                let cert = self
+                    .cert_client
+                    .create_cert(identity_cert, &csr, None)
+                    .await
+                    .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
+
+                let cert = openssl::x509::X509::from_pem(&cert)
+                    .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
+
+                (cert, private_key)
             }
         };
 
-        // Create new certificate if needed.
-        if device_id_cert.is_none() {
-            if let Ok(key_handle) = self.key_client.load_key_pair(identity_pk).await {
-                self.key_client
-                    .delete_key_pair(&key_handle)
-                    .await
-                    .map_err(|err| {
-                        Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                    })?;
-            }
-            let new_cert_subject = match subject {
-                Some(subject) => subject.to_string(),
-                None => old_cert_subject_name.map_err(|err| {
-                    Error::Internal(InternalError::CreateCertificate(Box::new(err)))
-                })?,
-            };
-
-            let key_handle = self
-                .key_client
-                .create_key_pair_if_not_exists(identity_pk, Some("rsa-2048:*"))
-                .await
-                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
-            let key_handle = std::ffi::CString::new(key_handle.0)
-                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
-
-            let mut key_engine = self.key_engine.lock().await;
-            let private_key = key_engine
-                .load_private_key(&key_handle)
-                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
-            let public_key = key_engine
-                .load_public_key(&key_handle)
-                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
-
-            let csr = create_csr(new_cert_subject.as_str(), &public_key, &private_key, None)
-                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
-
-            let new_cert_pem = self
-                .cert_client
-                .create_cert(identity_cert, &csr, None)
-                .await
-                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
-
-            let cert = openssl::x509::X509::from_pem(&new_cert_pem)
-                .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
-            let cert_subject = cert.as_ref().subject_name();
-            let cert_subject = cert_subject.entries_by_nid(openssl::nid::Nid::COMMONNAME).next()
-                .map_or(Err(Error::Internal(InternalError::CreateCertificate("new device identity certificate does not contain common name field required for registration".to_string().into()))), |common_name_entry| {
-                    String::from_utf8(common_name_entry.data().as_slice().into()).map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))
-            });
-
-            Ok(cert_subject)
+        let cert_subject = if let Some(common_name) = cert
+            .subject_name()
+            .entries_by_nid(openssl::nid::Nid::COMMONNAME)
+            .next()
+        {
+            String::from_utf8(common_name.data().as_slice().into()).map_err(|_| {
+                Error::Internal(InternalError::CreateCertificate("bad cert subject".into()))
+            })?
         } else {
-            Ok(old_cert_subject_name)
-        }
+            return Err(Error::Internal(InternalError::CreateCertificate(
+                "cannot determine cert subject".into(),
+            )));
+        };
+
+        let credentials = aziot_identity_common::Credentials::X509 {
+            identity_cert: (identity_cert.to_string(), cert),
+            identity_pk: (identity_pk.to_string(), private_key),
+        };
+
+        Ok((cert_subject, credentials))
     }
 
     pub async fn reconcile_hub_identities(&self, settings: config::Settings) -> Result<(), Error> {

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -738,7 +738,7 @@ impl UpdateConfig for Api {
 
 pub(crate) async fn get_keys(
     key_handle: aziot_key_common::KeyHandle,
-    key_engine: &Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
+    key_engine: &futures_util::lock::Mutex<openssl2::FunctionalEngine>,
 ) -> Result<
     (
         openssl::pkey::PKey<openssl::pkey::Private>,

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -28,6 +28,7 @@ pub mod configext;
 pub mod error;
 mod http;
 pub mod identity;
+mod renewal;
 
 use config_common::watcher::UpdateConfig;
 pub use error::{Error, InternalError};
@@ -72,14 +73,76 @@ pub async fn main(
         }
     }
 
-    let api = Api::new(settings.clone())?;
+    let mut api = Api::new(settings)?;
+
+    let auto_renew_config = if let config::ProvisioningType::Dps {
+        attestation:
+            config::DpsAttestationMethod::X509 {
+                registration_id,
+                identity_cert,
+                identity_pk,
+                identity_auto_renew: Some(auto_renew),
+            },
+        ..
+    } = &api.settings.provisioning.provisioning
+    {
+        let engine = cert_renewal::engine::new();
+        api.id_manager.identity_cert_renewal = Some(engine.clone());
+
+        Some((
+            engine,
+            registration_id.clone(),
+            identity_cert.clone(),
+            identity_pk.clone(),
+            auto_renew.clone(),
+        ))
+    } else {
+        None
+    };
+
     let api = Arc::new(futures_util::lock::Mutex::new(api));
 
-    let api_startup = api.clone();
-    let mut api_ = api_startup.lock().await;
-    let _ = api_
-        .update_config_inner(settings.clone(), ReprovisionTrigger::Startup)
+    // Configure the device identity certificate to auto-renew if enabled.
+    if let Some((engine, registration_id, identity_cert, identity_pk, auto_renew)) =
+        auto_renew_config
+    {
+        let interface = renewal::IdentityCertRenewal::new(
+            auto_renew.rotate_key,
+            &identity_cert,
+            &identity_pk,
+            registration_id.as_deref(),
+            api.clone(),
+        )
         .await?;
+
+        cert_renewal::engine::add_credential(
+            &engine,
+            &identity_cert,
+            &identity_pk,
+            auto_renew.policy.clone(),
+            interface,
+        )
+        .await
+        .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
+    }
+
+    // Attempt to reprovision the device. Failure to reprovision on startup means that provisioning
+    // with IoT Hub failed and no valid backup could be loaded. Treat this as a fatal error.
+    {
+        let mut api = api.lock().await;
+
+        if let Err(err) = api
+            .reprovision_device(auth::AuthId::LocalRoot, ReprovisionTrigger::Startup)
+            .await
+        {
+            log::error!(
+                "Failed to provision with IoT Hub, and no valid device backup was found: {}",
+                err
+            );
+
+            return Err(err.into());
+        }
+    }
 
     config_common::watcher::start_watcher(config_path, config_directory_path, api.clone());
 
@@ -165,12 +228,14 @@ impl Api {
             proxy_uri.clone(),
         );
 
+        let (authorizer, authenticator, local_identities) = get_auth(&settings);
+
         Ok(Api {
             settings,
-            authenticator: Box::new(auth::authentication::DefaultAuthenticator),
-            authorizer: Box::new(auth::authorization::DefaultAuthorizer),
+            authenticator,
+            authorizer,
             id_manager,
-            local_identities: Default::default(),
+            local_identities,
 
             key_client,
             key_engine,
@@ -608,43 +673,49 @@ impl Api {
 
         Ok(local_identity)
     }
+}
 
-    async fn update_config_inner(
-        &mut self,
-        settings: config::Settings,
-        trigger: ReprovisionTrigger,
-    ) -> Result<(), Error> {
-        let (allowed_users, _, local_modules) =
-            configext::prepare_authorized_principals(&settings.principal);
+fn get_auth(
+    settings: &config::Settings,
+) -> (
+    Box<SettingsAuthorizer>,
+    Box<SettingsAuthenticator>,
+    std::collections::BTreeMap<
+        aziot_identity_common::ModuleId,
+        Option<aziot_identity_common::LocalIdOpts>,
+    >,
+) {
+    let (allowed_users, _, local_modules) =
+        configext::prepare_authorized_principals(&settings.principal);
 
-        let authorizer = Box::new(SettingsAuthorizer {});
+    let authorizer = Box::new(SettingsAuthorizer {});
+
+    // All uids in the principals are authenticated users to this service
+    let authenticator = Box::new(SettingsAuthenticator { allowed_users });
+
+    (authorizer, authenticator, local_modules)
+}
+
+#[async_trait]
+impl UpdateConfig for Api {
+    type Config = config::Settings;
+    type Error = Error;
+
+    async fn update_config(&mut self, new_config: config::Settings) -> Result<(), Self::Error> {
+        let (authorizer, authenticator, local_modules) = get_auth(&new_config);
+
         self.authorizer = authorizer;
-
-        // All uids in the principals are authenticated users to this service
-        let authenticator = Box::new(SettingsAuthenticator {
-            allowed_users: allowed_users.clone(),
-        });
         self.authenticator = authenticator;
         self.local_identities = local_modules;
-        self.settings = settings;
+        self.settings = new_config;
 
-        // Attempt to re-provision the device. Failures need to be logged and the device should
-        // run offline.
         if let Err(err) = self
-            .reprovision_device(auth::AuthId::LocalRoot, trigger)
+            .reprovision_device(
+                auth::AuthId::LocalRoot,
+                ReprovisionTrigger::ConfigurationFileUpdate,
+            )
             .await
         {
-            // Failure to reprovision on startup means that provisioning with IoT Hub failed and
-            // no valid backup could be loaded. Treat this as a fatal error.
-            if let ReprovisionTrigger::Startup = trigger {
-                log::error!(
-                    "Failed to provision with IoT Hub, and no valid device backup was found: {}",
-                    err
-                );
-
-                return Err(err);
-            }
-
             log::warn!(
                 "Failed to reprovision device. Running offline. Reprovisioning failure reason: {}.",
                 err
@@ -655,15 +726,30 @@ impl Api {
     }
 }
 
-#[async_trait]
-impl UpdateConfig for Api {
-    type Config = config::Settings;
-    type Error = Error;
+pub(crate) async fn get_keys(
+    key_handle: aziot_key_common::KeyHandle,
+    key_engine: &Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
+) -> Result<
+    (
+        openssl::pkey::PKey<openssl::pkey::Private>,
+        openssl::pkey::PKey<openssl::pkey::Public>,
+    ),
+    String,
+> {
+    let key_handle =
+        std::ffi::CString::new(key_handle.0).map_err(|_| "bad key handle".to_string())?;
 
-    async fn update_config(&mut self, new_config: config::Settings) -> Result<(), Self::Error> {
-        self.update_config_inner(new_config, ReprovisionTrigger::ConfigurationFileUpdate)
-            .await
-    }
+    let mut key_engine = key_engine.lock().await;
+
+    let private_key = key_engine
+        .load_private_key(&key_handle)
+        .map_err(|_| "failed to load identity cert key".to_string())?;
+
+    let public_key = key_engine
+        .load_public_key(&key_handle)
+        .map_err(|_| "failed to load identity cert key".to_string())?;
+
+    Ok((private_key, public_key))
 }
 
 pub(crate) fn create_csr(

--- a/identity/aziot-identityd/src/renewal.rs
+++ b/identity/aziot-identityd/src/renewal.rs
@@ -231,7 +231,6 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
             })?;
 
         // Reprovision the device to register the new cert with DPS.
-
         let (private_key, _) = crate::get_keys(new_key_handle, &self.key_engine)
             .await
             .map_err(|_| cert_renewal::Error::retryable_error("failed to get cert key"))?;

--- a/identity/aziot-identityd/src/renewal.rs
+++ b/identity/aziot-identityd/src/renewal.rs
@@ -1,0 +1,265 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub(crate) struct IdentityCertRenewal {
+    rotate_key: bool,
+    temp_cert: String,
+
+    api: Arc<futures_util::lock::Mutex<crate::Api>>,
+    cert_client: Arc<aziot_cert_client_async::Client>,
+    key_client: Arc<aziot_key_client_async::Client>,
+    key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
+}
+
+impl IdentityCertRenewal {
+    pub async fn new(
+        rotate_key: bool,
+        cert_id: &str,
+        key_id: &str,
+        registration_id: Option<&str>,
+        api: Arc<futures_util::lock::Mutex<crate::Api>>,
+    ) -> Result<Self, crate::Error> {
+        let (cert_client, key_client, key_engine) = {
+            let api = api.lock().await;
+
+            (
+                api.cert_client.clone(),
+                api.key_client.clone(),
+                api.key_engine.clone(),
+            )
+        };
+
+        // Create the initial identity certificate if it does not exist.
+        if cert_client.get_cert(cert_id).await.is_err() {
+            let registration_id = if let Some(registration_id) = registration_id {
+                registration_id
+            } else {
+                return Err(crate::Error::Internal(
+                    crate::InternalError::CreateCertificate(
+                        "identity cert does not exist; cannot create new cert as registration ID is unknown".into()
+                    ),
+                ));
+            };
+
+            if let Ok(key_handle) = key_client.load_key_pair(key_id).await {
+                key_client
+                    .delete_key_pair(&key_handle)
+                    .await
+                    .map_err(|err| {
+                        crate::Error::Internal(crate::InternalError::CreateCertificate(
+                            format!("failed to remove old key: {}", err).into(),
+                        ))
+                    })?;
+            }
+
+            let key_handle = key_client
+                .create_key_pair_if_not_exists(key_id, Some("rsa-2048:*"))
+                .await
+                .map_err(|err| {
+                    crate::Error::Internal(crate::InternalError::CreateCertificate(
+                        format!("failed to generate new key: {}", err).into(),
+                    ))
+                })?;
+
+            let (private_key, public_key) = crate::get_keys(key_handle, &key_engine)
+                .await
+                .map_err(|err| {
+                    crate::Error::Internal(crate::InternalError::CreateCertificate(err.into()))
+                })?;
+
+            let csr = crate::create_csr(registration_id, &public_key, &private_key, None).map_err(
+                |_| {
+                    crate::Error::Internal(crate::InternalError::CreateCertificate(
+                        "failed to generate csr".into(),
+                    ))
+                },
+            )?;
+
+            cert_client
+                .create_cert(cert_id, &csr, None)
+                .await
+                .map_err(|err| {
+                    crate::Error::Internal(crate::InternalError::CreateCertificate(err.into()))
+                })?;
+
+            log::info!("Generated initial device identity certificate.");
+        }
+
+        // Determine the temporary cert ID used during renewal. Identity Service must be authorized
+        // to modify this cert with Certificates Service.
+        let temp_cert = format!("{}-temp", cert_id);
+
+        Ok(IdentityCertRenewal {
+            rotate_key,
+            temp_cert,
+            api,
+            cert_client,
+            key_client,
+            key_engine,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl cert_renewal::CertInterface for IdentityCertRenewal {
+    type NewKey = String;
+
+    async fn get_cert(
+        &mut self,
+        cert_id: &str,
+    ) -> Result<openssl::x509::X509, cert_renewal::Error> {
+        let cert = self.cert_client.get_cert(cert_id).await.map_err(|_| {
+            cert_renewal::Error::retryable_error("failed to retrieve identity cert")
+        })?;
+
+        openssl::x509::X509::from_pem(&cert)
+            .map_err(|_| cert_renewal::Error::fatal_error("failed to parse identity cert"))
+    }
+
+    async fn get_key(
+        &mut self,
+        key_id: &str,
+    ) -> Result<openssl::pkey::PKey<openssl::pkey::Private>, cert_renewal::Error> {
+        let key_handle =
+            self.key_client.load_key_pair(key_id).await.map_err(|_| {
+                cert_renewal::Error::retryable_error("failed to get identity cert key")
+            })?;
+
+        let key_handle = std::ffi::CString::new(key_handle.0)
+            .map_err(|_| cert_renewal::Error::fatal_error("bad key handle"))?;
+
+        let mut key_engine = self.key_engine.lock().await;
+
+        key_engine
+            .load_private_key(&key_handle)
+            .map_err(|_| cert_renewal::Error::retryable_error("failed to load identity cert key"))
+    }
+
+    async fn renew_cert(
+        &mut self,
+        old_cert: &openssl::x509::X509,
+        key_id: &str,
+    ) -> Result<(openssl::x509::X509, Self::NewKey), cert_renewal::Error> {
+        // Generate a new key if needed. Otherwise, retrieve the existing key.
+        let (key_id, key_handle) = if self.rotate_key {
+            let key_id = format!("{}-temp", key_id);
+
+            if let Ok(key_handle) = self.key_client.load_key_pair(&key_id).await {
+                self.key_client
+                    .delete_key_pair(&key_handle)
+                    .await
+                    .map_err(|_| {
+                        cert_renewal::Error::retryable_error("failed to clear temp key")
+                    })?;
+            }
+
+            let key_handle = self
+                .key_client
+                .create_key_pair_if_not_exists(&key_id, Some("rsa-2048:*"))
+                .await
+                .map_err(|_| cert_renewal::Error::retryable_error("failed to generate temp key"))?;
+
+            (key_id, key_handle)
+        } else {
+            let key_handle = self.key_client.load_key_pair(key_id).await.map_err(|_| {
+                cert_renewal::Error::retryable_error("failed to get identity cert key")
+            })?;
+
+            (key_id.to_string(), key_handle)
+        };
+
+        let (private_key, public_key) = crate::get_keys(key_handle, &self.key_engine)
+            .await
+            .map_err(cert_renewal::Error::retryable_error)?;
+
+        // Determine the subject of the old cert. This will be the subject of the new cert.
+        let subject = if let Some(subject) = old_cert
+            .subject_name()
+            .entries_by_nid(openssl::nid::Nid::COMMONNAME)
+            .next()
+        {
+            String::from_utf8(subject.data().as_slice().into())
+                .map_err(|_| cert_renewal::Error::fatal_error("bad cert subject"))?
+        } else {
+            return Err(cert_renewal::Error::fatal_error(
+                "cannot determine subject for csr",
+            ));
+        };
+
+        // Generate a CSR and issue the new cert under a temporary cert ID. The temporary ID
+        // does not need to be persisted, so delete it after the cert is succesfully created.
+        let csr = crate::create_csr(&subject, &public_key, &private_key, None)
+            .map_err(|_| cert_renewal::Error::retryable_error("failed to create csr"))?;
+
+        let new_cert = self
+            .cert_client
+            .create_cert(&self.temp_cert, &csr, None)
+            .await
+            .map_err(|_| cert_renewal::Error::retryable_error("failed to create new cert"))?;
+
+        if let Err(err) = self.cert_client.delete_cert(&self.temp_cert).await {
+            log::warn!(
+                "Failed to delete temporary certificate created by cert renewal: {}",
+                err
+            );
+        }
+
+        let new_cert = openssl::x509::X509::from_pem(&new_cert)
+            .map_err(|_| cert_renewal::Error::retryable_error("failed to parse new cert"))?;
+
+        Ok((new_cert, key_id))
+    }
+
+    async fn write_credentials(
+        &mut self,
+        old_cert: &openssl::x509::X509,
+        new_cert: (&str, &openssl::x509::X509),
+        key: (&str, Self::NewKey),
+    ) -> Result<(), cert_renewal::Error> {
+        let cert_id = new_cert.0;
+
+        let old_cert = old_cert
+            .to_pem()
+            .map_err(|_| cert_renewal::Error::retryable_error("bad cert"))?;
+        let new_cert = new_cert
+            .1
+            .to_pem()
+            .map_err(|_| cert_renewal::Error::retryable_error("bad cert"))?;
+
+        // Commit the new cert to storage.
+        self.cert_client
+            .import_cert(cert_id, &new_cert)
+            .await
+            .map_err(|_| cert_renewal::Error::retryable_error("failed to import new cert"))?;
+
+        // Commit the new key to storage if the key was rotated. Fall back to the old cert if
+        // the key cannot be rotated.
+        if key.0 != key.1 && self.key_client.move_key_pair(&key.1, key.0).await.is_err() {
+            self.cert_client
+                .import_cert(cert_id, &old_cert)
+                .await
+                .map_err(|_| cert_renewal::Error::fatal_error("failed to restore old cert"))?;
+        }
+
+        // Reprovisioning the device so that the new identity cert is registered. Note that if this
+        // fails, the device will remain in an error state until the next renewal retry as it can no
+        // longer fall back to the old identity cert.
+        let mut api = self.api.lock().await;
+
+        api.reprovision_device(
+            crate::auth::AuthId::LocalRoot,
+            crate::ReprovisionTrigger::Api,
+        )
+        .await
+        .map_err(|err| {
+            cert_renewal::Error::retryable_error(format!(
+                "failed to reprovision with new credentials: {}",
+                err
+            ))
+        })?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Adds feature to automatically renew device identity certificate.
- Removes behavior where device identity certificate renews within 1 day of expiry. This is superseded by the auto-renew feature.