### PR TITLE
Improve stability of E2E tests

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -50,7 +50,8 @@ jobs:
         - 'debian:9'
         - 'debian:10'
         - 'debian:11'
-        - 'platform:el8'
+        # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
+        # - 'platform:el8'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         test_name:

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -745,8 +745,6 @@ case "$OS" in
         scp -i "$PWD/vm-ssh-key" "$package" "aziot@$vm_public_ip:/home/aziot/aziot-identity-service.deb"
 
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
-            set -euxo pipefail
-
             for retry in {0..3}; do
                 if [ "$retry" != "0" ]; then
                     sleep 10
@@ -758,6 +756,8 @@ case "$OS" in
                     break
                 fi
             done
+
+            set -euxo pipefail
 
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y bc curl jq perl
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y /home/aziot/aziot-identity-service.deb

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -659,9 +659,20 @@ case "$OS" in
 
     debian:*|ubuntu:*)
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
+            for retry in {0..3}; do
+                if [ "$retry" != "0" ]; then
+                    sleep 10
+                fi
+
+                sudo apt-get update -y
+
+                if [ "$?" == "0" ]; then
+                    break
+                fi
+            done
+
             set -euxo pipefail
 
-            sudo apt-get update -y
             sudo DEBIAN_FRONTEND=noninteractive \
                 apt-get \
                 -o 'Dpkg::Options::=--force-confnew' \
@@ -736,7 +747,18 @@ case "$OS" in
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
             set -euxo pipefail
 
-            sudo apt-get update -y
+            for retry in {0..3}; do
+                if [ "$retry" != "0" ]; then
+                    sleep 10
+                fi
+
+                sudo apt-get update -y
+
+                if [ "$?" == "0" ]; then
+                    break
+                fi
+            done
+
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y bc curl jq perl
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y /home/aziot/aziot-identity-service.deb
         '

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -71,7 +71,7 @@ get_package() {
                 jq -r '.workflow_runs[0].artifacts_url'
         )"
 
-        if [ "$artifacts_url" != 'null' ] && [ ! -z "$artifacts_url" ]; then
+        if [ -n "$artifacts_url" ] && [ "$artifacts_url" != 'null' ]; then
             break
         fi
     done
@@ -138,7 +138,7 @@ get_package() {
                     '.artifacts[] | select(.name == $artifact_name) | .archive_download_url'
         )"
 
-        if [ "$artifact_download_url" != 'null' ] && [ ! -z "$artifact_download_url" ]; then
+        if [ -n "$artifact_download_url" ] && [ "$artifact_download_url" != 'null' ]; then
             break
         fi
     done

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -689,6 +689,7 @@ case "$OS" in
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
             set -euxo pipefail
 
+            sudo apt-get update -y
             sudo apt-get install -y bc curl jq perl
             sudo apt-get install -y /home/aziot/aziot-identity-service.deb
         '

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -486,7 +486,7 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'OpenLogic' --offer 'CentOS' --sku '7' \
         #     --query "[?publisher == 'OpenLogic' && offer == 'CentOS'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='OpenLogic:CentOS:7_9-gen2:7.9.2021071901'
+        vm_image='OpenLogic:CentOS:7_9-gen2:7.9.2022020701'
         ;;
 
     'debian:9')
@@ -502,7 +502,7 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'Debian' --offer 'debian-10' --sku '10' \
         #     --query "[?publisher == 'Debian' && offer == 'debian-10'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Debian:debian-10:10-gen2:0.20210721.710'
+        vm_image='Debian:debian-10:10-gen2:0.20220328.962'
         ;;
 
     'debian:11')
@@ -511,7 +511,7 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'Debian' --offer 'debian-11' --sku '11-gen2' \
         #     --query "[?publisher == 'Debian' && offer == 'debian-11'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Debian:debian-11:11-gen2:0.20210814.734'
+        vm_image='Debian:debian-11:11-gen2:0.20220328.962'
         ;;
 
     'platform:el8')
@@ -531,7 +531,7 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'Canonical' --offer 'UbuntuServer' --sku '18' \
         #     --query "[?publisher == 'Canonical' && offer == 'UbuntuServer'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Canonical:UbuntuServer:18_04-lts-gen2:18.04.202109180'
+        vm_image='Canonical:UbuntuServer:18_04-lts-gen2:18.04.202204190'
         ;;
 
     'ubuntu:20.04')
@@ -543,7 +543,7 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'Canonical' --offer '0001-com-ubuntu-server-focal' --sku '20' \
         #     --query "[?publisher == 'Canonical' && offer == '0001-com-ubuntu-server-focal'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202109080'
+        vm_image='Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202204190'
         ;;
 
     *)


### PR DESCRIPTION
- Updates VMs to more recent images
- sudo apt-get update before installing jq. This resolves an issue where the package sometimes isn't found.
- Add retries to GitHub API calls
- Disable el8 in manual runs, as it's disabled in scheduled runs.