### PR TITLE
Change cert renewal to use cert chains

### DIFF
--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -451,14 +451,16 @@ async fn create_cert_inner<'a>(
 
                 // Get the EST identity cert if configured. If it does not exist, create it.
                 let client_credentials = if let Some(x509) = &auth.x509 {
-                    if let Ok((id_cert, id_pk)) = cert_renewal::engine::get_credential(
+                    if let Ok((id_cert_chain, id_pk)) = cert_renewal::engine::get_credential(
                         &api.renewal_engine,
                         &x509.identity.cert,
                         &x509.identity.pk,
                     )
                     .await
                     {
-                        let id_cert = id_cert.to_pem()?;
+                        // Identity certificates are TLS client certificates. The full chain is not needed for authentication,
+                        // so discard it.
+                        let id_cert = id_cert_chain[0].to_pem()?;
 
                         Some((id_cert, id_pk))
                     } else {

--- a/cert/cert-renewal/src/cert_interface.rs
+++ b/cert/cert-renewal/src/cert_interface.rs
@@ -184,15 +184,15 @@ impl CertInterface for ArcMutex<TestInterface> {
 
     async fn write_credentials(
         &mut self,
-        _old_cert: &[openssl::x509::X509],
-        new_cert: (&str, &[openssl::x509::X509]),
+        _old_cert_chain: &[openssl::x509::X509],
+        new_cert_chain: (&str, &[openssl::x509::X509]),
         key: (&str, Self::NewKey),
     ) -> Result<(), crate::Error> {
         let mut interface = self.lock().await;
 
         interface
             .certs
-            .insert(new_cert.0.to_string(), new_cert.1.to_vec())
+            .insert(new_cert_chain.0.to_string(), new_cert_chain.1.to_vec())
             .unwrap();
         interface.keys.insert(key.0.to_string(), key.1).unwrap();
 

--- a/cert/cert-renewal/src/cert_interface.rs
+++ b/cert/cert-renewal/src/cert_interface.rs
@@ -6,8 +6,9 @@ pub trait CertInterface {
     /// temporary key, and later written to persistent storage with the renewed cert.
     type NewKey: Send + Sync;
 
-    /// Retrieve a certificate from the provided `cert_id`.
-    async fn get_cert(&mut self, cert_id: &str) -> Result<openssl::x509::X509, crate::Error>;
+    /// Retrieve a certificate from the provided `cert_id`. May return a chain where the certificate
+    /// with `cert_id` is element 0.
+    async fn get_cert(&mut self, cert_id: &str) -> Result<Vec<openssl::x509::X509>, crate::Error>;
 
     /// Retrieve a private key from the provided `key_id`.
     async fn get_key(
@@ -17,9 +18,9 @@ pub trait CertInterface {
 
     /// Renew the provided certificate.
     ///
-    /// This function should renew `old_cert` and its key and return the renewed certificate and
-    /// key. It MUST leave `old_cert` and its key intact upon returning; i.e. it must not erase
-    /// `old_cert` or its key.
+    /// This function should renew `old_cert_chain` and its key and return the renewed certificate and
+    /// key. It MUST leave `old_cert_chain` and its key intact upon returning; i.e. it must not erase
+    /// `old_cert_chain` or its key.
     ///
     /// After this function returns, the renewal engine needs to perform additional checks and
     /// calculations on the renewed certificate. If the renewal engine determines the new certificate
@@ -29,9 +30,9 @@ pub trait CertInterface {
     /// `write_credentials`. The old certificate and its key may then be overwritten.
     async fn renew_cert(
         &mut self,
-        old_cert: &openssl::x509::X509,
+        old_cert_chain: &[openssl::x509::X509],
         key_id: &str,
-    ) -> Result<(openssl::x509::X509, Self::NewKey), crate::Error>;
+    ) -> Result<(Vec<openssl::x509::X509>, Self::NewKey), crate::Error>;
 
     /// Write the new credentials to storage, replacing any existing credentials with the same IDs.
     ///
@@ -43,8 +44,8 @@ pub trait CertInterface {
     /// function must revert any changes to `cert` before returning an error.
     async fn write_credentials(
         &mut self,
-        old_cert: &openssl::x509::X509,
-        new_cert: (&str, &openssl::x509::X509),
+        old_cert_chain: &[openssl::x509::X509],
+        new_cert_chain: (&str, &[openssl::x509::X509]),
         key: (&str, Self::NewKey),
     ) -> Result<(), crate::Error>;
 }
@@ -53,7 +54,7 @@ pub trait CertInterface {
 #[derive(Clone, Debug)]
 pub(crate) struct TestInterface {
     pub keys: std::collections::BTreeMap<String, openssl::pkey::PKey<openssl::pkey::Private>>,
-    pub certs: std::collections::BTreeMap<String, openssl::x509::X509>,
+    pub certs: std::collections::BTreeMap<String, Vec<openssl::x509::X509>>,
     pub renew_err: Option<crate::Error>,
 }
 
@@ -99,7 +100,9 @@ pub(crate) mod test_interface {
             cert.set_not_after(&not_after).unwrap();
         });
 
-        interface.certs.insert(cert_id.to_string(), cert.clone());
+        interface
+            .certs
+            .insert(cert_id.to_string(), vec![cert.clone()]);
         interface.keys.insert(key_id.to_string(), key);
 
         cert
@@ -120,7 +123,7 @@ pub(crate) mod test_interface {
 impl CertInterface for ArcMutex<TestInterface> {
     type NewKey = openssl::pkey::PKey<openssl::pkey::Private>;
 
-    async fn get_cert(&mut self, cert_id: &str) -> Result<openssl::x509::X509, crate::Error> {
+    async fn get_cert(&mut self, cert_id: &str) -> Result<Vec<openssl::x509::X509>, crate::Error> {
         let interface = self.lock().await;
 
         if let Some(cert) = interface.certs.get(cert_id) {
@@ -145,23 +148,23 @@ impl CertInterface for ArcMutex<TestInterface> {
 
     async fn renew_cert(
         &mut self,
-        old_cert: &openssl::x509::X509,
+        old_cert: &[openssl::x509::X509],
         _key_id: &str,
-    ) -> Result<(openssl::x509::X509, Self::NewKey), crate::Error> {
+    ) -> Result<(Vec<openssl::x509::X509>, Self::NewKey), crate::Error> {
         let interface = self.lock().await;
 
         if let Some(err) = &interface.renew_err {
             Err(err.clone())
         } else {
-            Ok(test_common::credential::custom_test_certificate(
+            let (cert, key) = test_common::credential::custom_test_certificate(
                 // This is ignored as the subject name, but still used as the issuer name.
                 "test-cert",
                 |cert| {
-                    cert.set_subject_name(old_cert.subject_name()).unwrap();
+                    cert.set_subject_name(old_cert[0].subject_name()).unwrap();
 
                     // Match the lifetime of the new cert to the old cert.
-                    let not_before = crate::Time::from(old_cert.not_before());
-                    let not_after = crate::Time::from(old_cert.not_after());
+                    let not_before = crate::Time::from(old_cert[0].not_before());
+                    let not_after = crate::Time::from(old_cert[0].not_after());
                     let lifetime = not_after - not_before;
                     assert!(lifetime > 0);
 
@@ -173,21 +176,23 @@ impl CertInterface for ArcMutex<TestInterface> {
                     let not_after = openssl::asn1::Asn1Time::from_unix(not_after).unwrap();
                     cert.set_not_after(&not_after).unwrap();
                 },
-            ))
+            );
+
+            Ok((vec![cert], key))
         }
     }
 
     async fn write_credentials(
         &mut self,
-        _old_cert: &openssl::x509::X509,
-        new_cert: (&str, &openssl::x509::X509),
+        _old_cert: &[openssl::x509::X509],
+        new_cert: (&str, &[openssl::x509::X509]),
         key: (&str, Self::NewKey),
     ) -> Result<(), crate::Error> {
         let mut interface = self.lock().await;
 
         interface
             .certs
-            .insert(new_cert.0.to_string(), new_cert.1.clone())
+            .insert(new_cert.0.to_string(), new_cert.1.to_vec())
             .unwrap();
         interface.keys.insert(key.0.to_string(), key.1).unwrap();
 

--- a/identity/aziot-identityd/src/renewal.rs
+++ b/identity/aziot-identityd/src/renewal.rs
@@ -109,12 +109,12 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
     async fn get_cert(
         &mut self,
         cert_id: &str,
-    ) -> Result<openssl::x509::X509, cert_renewal::Error> {
+    ) -> Result<Vec<openssl::x509::X509>, cert_renewal::Error> {
         let cert = self.cert_client.get_cert(cert_id).await.map_err(|_| {
             cert_renewal::Error::retryable_error("failed to retrieve identity cert")
         })?;
 
-        openssl::x509::X509::from_pem(&cert)
+        openssl::x509::X509::stack_from_pem(&cert)
             .map_err(|_| cert_renewal::Error::fatal_error("failed to parse identity cert"))
     }
 
@@ -139,9 +139,9 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
 
     async fn renew_cert(
         &mut self,
-        old_cert: &openssl::x509::X509,
+        old_cert_chain: &[openssl::x509::X509],
         key_id: &str,
-    ) -> Result<(openssl::x509::X509, Self::NewKey), cert_renewal::Error> {
+    ) -> Result<(Vec<openssl::x509::X509>, Self::NewKey), cert_renewal::Error> {
         // Generate a new key if needed. Otherwise, retrieve the existing key.
         let (key_id, key_handle) = if self.rotate_key {
             let key_id = format!("{}-temp", key_id);
@@ -175,7 +175,7 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
             .map_err(cert_renewal::Error::retryable_error)?;
 
         // Determine the subject of the old cert. This will be the subject of the new cert.
-        let subject = if let Some(subject) = old_cert
+        let subject = if let Some(subject) = old_cert_chain[0]
             .subject_name()
             .entries_by_nid(openssl::nid::Nid::COMMONNAME)
             .next()
@@ -206,24 +206,30 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
             );
         }
 
-        let new_cert = openssl::x509::X509::from_pem(&new_cert)
+        let new_cert_chain = openssl::x509::X509::stack_from_pem(&new_cert)
             .map_err(|_| cert_renewal::Error::retryable_error("failed to parse new cert"))?;
 
-        Ok((new_cert, key_id))
+        Ok((new_cert_chain, key_id))
     }
 
     async fn write_credentials(
         &mut self,
-        _old_cert: &openssl::x509::X509,
-        new_cert: (&str, &openssl::x509::X509),
+        _old_cert: &[openssl::x509::X509],
+        new_cert_chain: (&str, &[openssl::x509::X509]),
         key: (&str, Self::NewKey),
     ) -> Result<(), cert_renewal::Error> {
-        let (cert_id, new_cert) = (new_cert.0, new_cert.1);
+        let (cert_id, new_cert_chain) = (new_cert_chain.0, new_cert_chain.1);
         let (old_key, new_key) = (key.0, key.1);
 
-        let new_cert_pem = new_cert
-            .to_pem()
-            .map_err(|_| cert_renewal::Error::retryable_error("bad cert"))?;
+        let mut new_cert_chain_pem = Vec::new();
+
+        for cert in new_cert_chain {
+            let mut cert = cert
+                .to_pem()
+                .map_err(|_| cert_renewal::Error::retryable_error("bad cert"))?;
+
+            new_cert_chain_pem.append(&mut cert);
+        }
 
         let new_key_handle =
             self.key_client.load_key_pair(&new_key).await.map_err(|_| {
@@ -236,7 +242,7 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
             .map_err(|_| cert_renewal::Error::retryable_error("failed to get cert key"))?;
 
         let credentials = aziot_identity_common::Credentials::X509 {
-            identity_cert: (cert_id.to_string(), new_cert.clone()),
+            identity_cert: (cert_id.to_string(), new_cert_chain[0].clone()),
             identity_pk: (new_key.clone(), private_key),
         };
 
@@ -261,7 +267,7 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
         // Commit the new cert to storage.
         let cert = self
             .cert_client
-            .import_cert(cert_id, &new_cert_pem)
+            .import_cert(cert_id, &new_cert_chain_pem)
             .await
             .map_err(|_| cert_renewal::Error::retryable_error("failed to import new cert"))?;
 


### PR DESCRIPTION
CA certificates require their full chain to be saved. Change cert renewal to work with cert chains.