### PR TITLE
Use the Dist tag to adhere to package naming guidelines.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ rpm: dist
 rpm:
 	# Move dist tarball to rpmbuild sources directory
 	mkdir -p $(RPMBUILDDIR)/SOURCES
-	mv /tmp/aziot-identity-service-$(PACKAGE_VERSION).tar.gz $(RPMBUILDDIR)/SOURCES/aziot-identity-service-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).tar.gz
+	mv /tmp/aziot-identity-service-$(PACKAGE_VERSION).tar.gz $(RPMBUILDDIR)/SOURCES/aziot-identity-service-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE).$(PACKAGE_DIST).tar.gz
 
 	# Copy spec file to rpmbuild specs directory
 	mkdir -p $(RPMBUILDDIR)/SPECS

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -22,10 +22,12 @@ case "$OS" in
         case "$OS" in
             'centos:7')
                 TARGET_DIR="centos7/$ARCH"
+                PackageExtension="el7"
                 ;;
 
             'platform:el8')
                 TARGET_DIR="el8/$ARCH"
+                PackageExtension="el8"
                 ;;
         esac
 
@@ -38,10 +40,10 @@ case "$OS" in
         rm -rf "packages/$TARGET_DIR"
         mkdir -p "packages/$TARGET_DIR"
         cp \
-            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.x86_64.rpm" \
-            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-debuginfo-$PACKAGE_VERSION-$PACKAGE_RELEASE.x86_64.rpm" \
-            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-devel-$PACKAGE_VERSION-$PACKAGE_RELEASE.x86_64.rpm" \
-            ~/"rpmbuild/SRPMS/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.src.rpm" \
+            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.x86_64.rpm" \
+            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-debuginfo-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.x86_64.rpm" \
+            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-devel-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.x86_64.rpm" \
+            ~/"rpmbuild/SRPMS/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.src.rpm" \
             "packages/$TARGET_DIR/"
         ;;
 

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -22,12 +22,12 @@ case "$OS" in
         case "$OS" in
             'centos:7')
                 TARGET_DIR="centos7/$ARCH"
-                PackageExtension="el7"
+                PACKAGE_DIST="el7"
                 ;;
 
             'platform:el8')
                 TARGET_DIR="el8/$ARCH"
-                PackageExtension="el8"
+                PACKAGE_DIST="el8"
                 ;;
         esac
 
@@ -35,15 +35,15 @@ case "$OS" in
 
         rm -rf ~/rpmbuild
 
-        make ARCH="$ARCH" PACKAGE_VERSION="$PACKAGE_VERSION" PACKAGE_RELEASE="$PACKAGE_RELEASE" V=1 rpm
+        make ARCH="$ARCH" PACKAGE_VERSION="$PACKAGE_VERSION" PACKAGE_RELEASE="$PACKAGE_RELEASE" PACKAGE_DIST="$PACKAGE_DIST" V=1 rpm
 
         rm -rf "packages/$TARGET_DIR"
         mkdir -p "packages/$TARGET_DIR"
         cp \
-            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.x86_64.rpm" \
-            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-debuginfo-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.x86_64.rpm" \
-            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-devel-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.x86_64.rpm" \
-            ~/"rpmbuild/SRPMS/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.src.rpm" \
+            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PACKAGE_DIST.x86_64.rpm" \
+            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-debuginfo-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PACKAGE_DIST.x86_64.rpm" \
+            ~/"rpmbuild/RPMS/x86_64/aziot-identity-service-devel-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PACKAGE_DIST.x86_64.rpm" \
+            ~/"rpmbuild/SRPMS/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PACKAGE_DIST.src.rpm" \
             "packages/$TARGET_DIR/"
         ;;
 

--- a/contrib/enterprise-linux/aziot-identity-service.spec
+++ b/contrib/enterprise-linux/aziot-identity-service.spec
@@ -4,7 +4,7 @@
 
 Name: aziot-identity-service
 Version: @version@
-Release: @release@
+Release: @release@%{?dist}
 Summary: Azure IoT Identity Service and related services
 License: MIT
 URL: https://github.com/azure/iot-identity-service


### PR DESCRIPTION
Noticed the package name didn't include the '.el7' or '.el8' to distinguish one from the other.  Adding the [Dist tag](https://docs.fedoraproject.org/en-US/packaging-guidelines/DistTag/) to the spec file to correct this.  Looks like the one for Mariner already had it.