### PR TITLE
Allow cert chains for identity certs

### DIFF
--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -458,9 +458,13 @@ async fn create_cert_inner<'a>(
                     )
                     .await
                     {
-                        // Identity certificates are TLS client certificates. The full chain is not needed for authentication,
-                        // so discard it.
-                        let id_cert = id_cert_chain[0].to_pem()?;
+                        let mut id_cert = Vec::new();
+
+                        for cert in id_cert_chain {
+                            let mut cert = cert.to_pem()?;
+
+                            id_cert.append(&mut cert);
+                        }
 
                         Some((id_cert, id_pk))
                     } else {

--- a/identity/aziot-identity-common/src/lib.rs
+++ b/identity/aziot-identity-common/src/lib.rs
@@ -161,7 +161,7 @@ pub enum Credentials {
     SharedPrivateKey(String),
 
     X509 {
-        identity_cert: (String, openssl::x509::X509),
+        identity_cert: (String, Vec<openssl::x509::X509>),
         identity_pk: (String, openssl::pkey::PKey<openssl::pkey::Private>),
     },
 

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -673,7 +673,13 @@ impl IdentityManager {
                             ..
                         } = &credentials
                         {
-                            get_cert_subject(&identity_cert.1)?
+                            if identity_cert.1.is_empty() {
+                                return Err(Error::Internal(InternalError::CreateCertificate(
+                                    "no certs in stack".into(),
+                                )));
+                            }
+
+                            get_cert_subject(&identity_cert.1[0])?
                         } else {
                             // get_identity_credentials will always return an X509 variant of Credentials.
                             unreachable!()
@@ -805,14 +811,12 @@ impl IdentityManager {
                     .await
                     .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
 
-            // Identity certificates are TLS client certificates. The full chain is not needed for authentication,
-            // so discard it.
-            (cert_chain[0].clone(), private_key)
+            (cert_chain, private_key)
         } else {
             let key_handle = self.key_client.load_key_pair(identity_pk).await;
 
             if let Ok(cert) = self.cert_client.get_cert(identity_cert).await {
-                let cert = openssl::x509::X509::from_pem(&cert)
+                let cert = openssl::x509::X509::stack_from_pem(&cert)
                     .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
 
                 let key_handle = key_handle
@@ -860,12 +864,18 @@ impl IdentityManager {
                     .await
                     .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
 
-                let cert = openssl::x509::X509::from_pem(&cert)
+                let cert = openssl::x509::X509::stack_from_pem(&cert)
                     .map_err(|err| Error::Internal(InternalError::CreateCertificate(err.into())))?;
 
                 (cert, private_key)
             }
         };
+
+        if cert.is_empty() {
+            return Err(Error::Internal(InternalError::CreateCertificate(
+                "no certs in stack".into(),
+            )));
+        }
 
         Ok(aziot_identity_common::Credentials::X509 {
             identity_cert: (identity_cert.to_string(), cert),

--- a/identity/aziot-identityd/src/renewal.rs
+++ b/identity/aziot-identityd/src/renewal.rs
@@ -260,7 +260,7 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
             .map_err(|_| cert_renewal::Error::retryable_error("failed to get cert key"))?;
 
         let credentials = aziot_identity_common::Credentials::X509 {
-            identity_cert: (cert_id.to_string(), new_cert_chain[0].clone()),
+            identity_cert: (cert_id.to_string(), new_cert_chain.to_vec()),
             identity_pk: (new_key.clone(), private_key),
         };
 
@@ -289,7 +289,7 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
             .await
             .map_err(|_| cert_renewal::Error::retryable_error("failed to import new cert"))?;
 
-        let cert = openssl::x509::X509::from_pem(&cert)
+        let cert = openssl::x509::X509::stack_from_pem(&cert)
             .map_err(|_| cert_renewal::Error::retryable_error("bad cert"))?;
 
         // Commit the new key to storage if the key was rotated.


### PR DESCRIPTION
Fixes a bug introduced by the ID cert renewal code where cert chains were dropped. DPS allows identity certs issued by intermediate CAs as long as the full chain is provided.