### PR TITLE
Add rotate_key to template

### DIFF
--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -130,6 +130,7 @@
 ## USING AUTO-RENEWAL FOR AN INDIVIDUAL ENROLLMENT WILL CAUSE THE DEVICE TO BE UNABLE
 ## TO REPROVISION.
 # [provisioning.attestation.identity_cert.auto_renew]
+# rotate_key = true
 # threshold = "80%"
 # retry = "4%"
 
@@ -180,6 +181,7 @@
 ## Controls the renewal of EST identity certs. These certs are issued by the EST server after
 ## initial authentication with the bootstrap cert and managed by Certificates Service.
 # [cert_issuance.est.identity_auto_renew]
+# rotate_key = true
 # threshold = "80%"
 # retry = "4%"
 #


### PR DESCRIPTION
Add previously missing option rotate_key to cert renewal config in template.