### PR TITLE
Truncate CNs to 64 characters in conversion to X509Name

### DIFF
--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -235,7 +235,7 @@ impl std::convert::TryFrom<&CertSubject> for openssl::x509::X509Name {
                         let mut cn = value.to_string();
                         cn.truncate(CN_MAX_LENGTH);
 
-                        builder.append_entry_by_text(name, value)?;
+                        builder.append_entry_by_text(name, &cn)?;
                     } else {
                         builder.append_entry_by_text(name, value)?;
                     }

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -217,13 +217,28 @@ impl std::convert::TryFrom<&CertSubject> for openssl::x509::X509Name {
     fn try_from(
         subject: &CertSubject,
     ) -> Result<openssl::x509::X509Name, openssl::error::ErrorStack> {
+        // X.509 requires CNs to be shorter than 64 characters.
+        const CN_MAX_LENGTH: usize = 64;
+
         let mut builder = openssl::x509::X509Name::builder()?;
 
         match subject {
-            CertSubject::CommonName(cn) => builder.append_entry_by_text("CN", cn)?,
+            CertSubject::CommonName(cn) => {
+                let mut cn = cn.to_string();
+                cn.truncate(CN_MAX_LENGTH);
+
+                builder.append_entry_by_nid(openssl::nid::Nid::COMMONNAME, &cn)?;
+            }
             CertSubject::Subject(fields) => {
                 for (name, value) in fields {
-                    builder.append_entry_by_text(name, value)?;
+                    if name.to_lowercase() == "cn" {
+                        let mut cn = value.to_string();
+                        cn.truncate(CN_MAX_LENGTH);
+
+                        builder.append_entry_by_text(name, value)?;
+                    } else {
+                        builder.append_entry_by_text(name, value)?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Truncate CNs to 64 characters. The conversion won't work if they exceed the allowable length.