### PR TITLE
[Cherry-Pick] Add aarch64 Build for Mariner 1.0 and 2.0 to main branch

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -120,7 +120,7 @@ case "$OS:$ARCH" in
             libc-dev libc-dev:arm64 libclang1 libssl-dev:arm64 llvm-dev
         ;;
 
-    'mariner:1:amd64' | 'mariner:2:amd64')
+    'mariner:1:amd64' | 'mariner:2:amd64' | 'mariner:1:aarch64' | 'mariner:2:aarch64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 
@@ -177,7 +177,20 @@ mkdir -p ~/.cargo/bin
 export PATH="$PATH:$(realpath ~/.cargo/bin)"
 
 if ! [ -f ~/.cargo/bin/rustup ]; then
-    curl -Lo ~/.cargo/bin/rustup 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init'
+    baseArch="$(uname -m)"
+    case "$baseArch" in
+        'x86_64')
+            curl -Lo ~/.cargo/bin/rustup 'https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init'
+            ;;
+
+        'aarch64')
+            curl -Lo ~/.cargo/bin/rustup 'https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-gnu/rustup-init'
+            ;;
+        *)
+            echo "Unsupported ARCH $baseArch" >&2
+            exit 1
+            ;;
+    esac
     chmod +x ~/.cargo/bin/rustup
     hash -r
 fi

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -111,9 +111,15 @@ case "$OS" in
 
     'mariner:1' | 'mariner:2')
         case "$ARCH" in
-            'arm32v7'|'aarch64')
+            'arm32v7')
                 echo "Cross-compilation on $OS is not supported" >&2
                 exit 1
+                ;;
+            'aarch64')
+                MarinerArch=aarch64
+                ;;
+            'amd64')
+                MarinerArch=x86_64
                 ;;
         esac
 
@@ -214,8 +220,8 @@ EOF
         rm -rf "/src/packages/$TARGET_DIR"
         mkdir -p "/src/packages/$TARGET_DIR"
         cp \
-            "$MarinerRPMBUILDDIR/out/RPMS/x86_64/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.x86_64.rpm" \
-            "$MarinerRPMBUILDDIR/out/RPMS/x86_64/aziot-identity-service-devel-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.x86_64.rpm" \
+            "$MarinerRPMBUILDDIR/out/RPMS/$MarinerArch/aziot-identity-service-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.$MarinerArch.rpm" \
+            "$MarinerRPMBUILDDIR/out/RPMS/$MarinerArch/aziot-identity-service-devel-$PACKAGE_VERSION-$PACKAGE_RELEASE.$PackageExtension.$MarinerArch.rpm" \
             "/src/packages/$TARGET_DIR"
         ;;
 


### PR DESCRIPTION
Cherry Pick from: https://github.com/Azure/iot-identity-service/pull/408

Adds aarch64 build for Mariner 1.0 and 2.0. This will not build the aarch64 version in the current package build pipelines. this will instead update the corresponding build scripts to work for aarch64 machines. The mariner aarch64 builds were not added to the normal package build yaml since mariner does not support cross-compiling and requires the packages to be built in a native aarch64 machine.