### PR TITLE
Mariner 2.0 Build uses Prod Packages

### DIFF
--- a/ci/package.sh
+++ b/ci/package.sh
@@ -143,7 +143,6 @@ case "$OS" in
                 PackageExtension="cm1"
                 ;;
             'mariner:2')
-                # mariner 2.0 pacakges are currntly only available in preview change this to use production after mariner 2.0's release
                 UsePreview=n
                 TARGET_DIR="mariner2/$ARCH"
                 PackageExtension="cm2"

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -144,7 +144,7 @@ case "$OS" in
                 ;;
             'mariner:2')
                 # mariner 2.0 pacakges are currntly only available in preview change this to use production after mariner 2.0's release
-                UsePreview=y
+                UsePreview=n
                 TARGET_DIR="mariner2/$ARCH"
                 PackageExtension="cm2"
                 ;;


### PR DESCRIPTION
Since Mariner 2.0 has GAed we should change this to use the packages from their monthly release in prod. This will be more stable than using the preview repos which has had errors in the past. This should also help fix the name resolution issue seen for the Mariner 2.0 build.