### PR TITLE
[main] Upgrade to latest Rust version

### DIFF
--- a/key/aziot-key-openssl-engine-shared/build/main.rs
+++ b/key/aziot-key-openssl-engine-shared/build/main.rs
@@ -4,10 +4,22 @@
 #![warn(clippy::all, clippy::pedantic)]
 
 fn main() {
+    println!("cargo:rerun-if-changed=build/engine.c");
+
     openssl_build::define_version_number_cfg();
 
     let mut build = openssl_build::get_c_compiler();
     build
+        // Since we are going to use the generated archive in a shared
+        // library, we need +whole-archive to be set.  See:
+        // https://github.com/rust-lang/rust/blob/1.61.0/RELEASES.md#compatibility-notes
+        .cargo_metadata(false)
         .file("build/engine.c")
         .compile("aziot_key_openssl_shared_engine_wrapper");
+
+    println!("cargo:rustc-link-lib=static:+whole-archive=aziot_key_openssl_shared_engine_wrapper");
+    println!(
+        "cargo:rustc-link-search=native={}",
+        std::env::var("OUT_DIR").unwrap()
+    );
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60"
+channel = "1.61"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- Use `+whole-archive` when linking `aziot-key-openssl-engine-shared`

[^0]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes-11
  Namely, the point on `mem::uninitialized`.