### PR TITLE
Mariner Toolkit Update Golang Dependency

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -132,10 +132,10 @@ case "$OS:$ARCH" in
         apt-get install -y \
             cmake curl gcc g++ git jq make pkg-config \
             libclang1 libssl-dev llvm-dev \
-            cpio genisoimage golang-1.13-go qemu-utils pigz python-pip python3-distutils rpm tar wget
+            cpio genisoimage golang-1.17-go qemu-utils pigz python-pip python3-distutils rpm tar wget
 
         rm -f /usr/bin/go
-        ln -vs /usr/lib/go-1.13/bin/go /usr/bin/go
+        ln -vs /usr/lib/go-1.17/bin/go /usr/bin/go
         if [ -f /.dockerenv ]; then
             mv /.dockerenv /.dockerenv.old
         fi


### PR DESCRIPTION
Mariner just updated their stable branch for 1.0 and 2.0 which requires golang 1.17 to be used when building their toolkits. This change will prevent the toolkit build from failing and stopping mariner package creation. 