### PR TITLE
Fix release/1.2 build

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -211,9 +211,9 @@ CBINDGEN_VERSION='0.15.0'
 
 # Mariner build installs them as part of the specfile
 if [ "$OS" != 'mariner' ]; then
-    cargo install bindgen --version "=$BINDGEN_VERSION"
+    cargo install bindgen --version "=$BINDGEN_VERSION" --locked
 
-    cargo install cbindgen --version "=$CBINDGEN_VERSION"
+    cargo install cbindgen --version "=$CBINDGEN_VERSION" --locked
 fi
 
 export CARGO_INCREMENTAL=0


### PR DESCRIPTION
- Update Golang Dependency for Mariner

  Mariner just updated their stable branch for 1.0 and 2.0 which requires
  golang 1.17 to be used when building their toolkits. This change will
  prevent the toolkit build from failing and stopping
  mariner package creation.

- Enforce bindgen and cbindgen to compile with the dependencies in
  their lockfile instead of newer ones.

  If `--locked` is not specified, cargo-install ignores the package's lockfile
  and installs the latest version of all deps. This is a problem for
  release/1.2 because some of these deps have updated to E2021 while claiming
  to be semver-compatible and the Rust used in release/1.2 doesn't support it.