### PR TITLE
Change Mariner 2.0 Build to Use Production Resources

### DIFF
--- a/ci/package.sh
+++ b/ci/package.sh
@@ -140,8 +140,7 @@ case "$OS" in
                 PackageExtension="cm1"
                 ;;
             'mariner:2')
-                # mariner 2.0 pacakges are currntly only available in preview change this to use production after mariner 2.0's release
-                UsePreview=y
+                UsePreview=n
                 TARGET_DIR="mariner2/$ARCH"
                 PackageExtension="cm2"
                 ;;


### PR DESCRIPTION
changed the preview flag to n, this will force the mariner toolkit to use the production RPM dependencies from packages.microsoft.com. 