### PR TITLE
[main] Upgrade to latest Rust version

### DIFF
--- a/aziotctl/src/internal/check/checks/certs_match_private_keys.rs
+++ b/aziotctl/src/internal/check/checks/certs_match_private_keys.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::fmt::Write;
+
 use anyhow::{anyhow, Result};
 use serde::Serialize;
 
@@ -48,7 +50,12 @@ impl CertsMatchPrivateKeys {
                         if !err_aggregated.is_empty() {
                             err_aggregated.push('\n');
                         }
-                        err_aggregated.push_str(&format!("preloaded cert with ID {:?} does not match preloaded private key with ID {:?}", id, id));
+                        write!(
+                            &mut err_aggregated,
+                            "preloaded cert with ID {:?} does not match preloaded private key with ID {:?}",
+                            id,
+                            id
+                        ).expect("std::fmt::Write for String should not fail");
                     }
                 }
             }

--- a/aziotctl/src/internal/check/checks/read_certs.rs
+++ b/aziotctl/src/internal/check/checks/read_certs.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::fmt::Write;
+
 use anyhow::{anyhow, Context, Result};
 use serde::Serialize;
 
@@ -75,7 +77,8 @@ impl ReadCerts {
                     if !err_aggregated.is_empty() {
                         err_aggregated.push('\n');
                     }
-                    err_aggregated.push_str(&format!("{:?}", err));
+                    write!(&mut err_aggregated, "{:?}", err)
+                        .expect("std::fmt::Write for String should not fail");
                 }
             }
         }

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -545,10 +546,12 @@ impl IdentityManager {
     > {
         let mut module_derived_name = module.module_id;
 
-        module_derived_name.push_str(&format!(
+        write!(
+            &mut module_derived_name,
             ":{}",
             module.generation_id.ok_or(Error::ModuleNotFound)?
-        ));
+        )
+        .expect("std::fmt::Write for String should not fail");
 
         let mut primary_derived_name = module_derived_name.clone();
         primary_derived_name.push_str(":primary");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.61"
+channel = "1.62"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- Replace `s.push_str(&format!(..))` with `write!(&mut s, ..)`

[^0]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes-11
  Namely, the point on `mem::uninitialized`.