### PR TITLE
Remove macro_export from wrap_rc

### DIFF
--- a/tpm/tss-minimal/src/error.rs
+++ b/tpm/tss-minimal/src/error.rs
@@ -3,18 +3,6 @@
 use std::ffi::CStr;
 use std::fmt;
 
-pub fn try_decode_rc(rc: u32) -> Option<String> {
-    let msg = unsafe { rc_sys::Tss2_RC_Decode(rc) };
-
-    if msg.is_null() {
-        return None;
-    }
-
-    let cstr = unsafe { CStr::from_ptr(msg) };
-    cstr.to_str().ok().map(ToOwned::to_owned)
-}
-
-#[macro_export]
 macro_rules! wrap_rc {
     ($e:expr) => {{
         let rc = unsafe { $e };
@@ -24,6 +12,19 @@ macro_rules! wrap_rc {
             Ok(())
         }
     }};
+}
+
+pub(crate) use wrap_rc;
+
+pub fn try_decode_rc(rc: u32) -> Option<String> {
+    let msg = unsafe { rc_sys::Tss2_RC_Decode(rc) };
+
+    if msg.is_null() {
+        return None;
+    }
+
+    let cstr = unsafe { CStr::from_ptr(msg) };
+    cstr.to_str().ok().map(ToOwned::to_owned)
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tpm/tss-minimal/src/lib.rs
+++ b/tpm/tss-minimal/src/lib.rs
@@ -8,7 +8,6 @@ pub mod handle;
 pub mod marshal;
 pub mod types;
 
-#[macro_use]
 mod error;
 mod private {
     pub trait Sealed {}
@@ -24,6 +23,8 @@ use std::ops::{Deref, DerefMut};
 use std::ptr::{self, NonNull};
 
 use esys_sys::ESYS_TR_NONE;
+
+use crate::error::wrap_rc;
 
 #[derive(Debug)]
 pub struct EsysContext(*mut esys_sys::ESYS_CONTEXT);

--- a/tpm/tss-minimal/src/marshal.rs
+++ b/tpm/tss-minimal/src/marshal.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use crate::{types, wrap_rc, Result};
+use crate::error::wrap_rc;
+use crate::{types, Result};
 
 pub trait Marshal<T> {
     fn marshal(&mut self, data: &T) -> Result<()>;


### PR DESCRIPTION
Causes errors from external crates due to pub(crate) visibility of Error.0.