### PR TITLE
Correct eviction hierarchy for endorsement key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,15 @@ endif
 
 ifeq ($(ARCH), arm32v7)
 	CARGO_TARGET = armv7-unknown-linux-gnueabihf
+    CROSS_HOST_TRIPLE = arm-linux-gnueabihf
 	DPKG_ARCH_FLAGS = --host-arch armhf
 else ifeq ($(ARCH), aarch64)
 	CARGO_TARGET = aarch64-unknown-linux-gnu
+    CROSS_HOST_TRIPLE = aarch64-linux-gnu
 	DPKG_ARCH_FLAGS = --host-arch arm64 --host-type aarch64-linux-gnu --target-type aarch64-linux-gnu
 else
 	CARGO_TARGET = x86_64-unknown-linux-gnu
+    CROSS_HOST_TRIPLE = x86_64-linux-gnu
 	DPKG_ARCH_FLAGS =
 endif
 
@@ -103,7 +106,7 @@ default:
 			--disable-static \
 			--disable-weakcrypto \
 			--enable-debug=info \
-			--host=$$CROSS_HOST_TRIPLE \
+			--host=$(CROSS_HOST_TRIPLE) \
 			--libdir=$(AZIOT_PRIVATE_LIBRARIES) \
 			--prefix=$(prefix); \
 		$(MAKE) libdir=$(AZIOT_PRIVATE_LIBRARIES) prefix=$(prefix) -j; \

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -343,19 +343,16 @@ CBINDGEN_VERSION='0.15.0'
 
 case "$ARCH" in
     'amd64')
-        export CROSS_HOST_TRIPLE=x86_64-linux-gnu
         ;;
 
     'arm32v7')
-        export CROSS_HOST_TRIPLE=arm-linux-gnueabihf
-        export PKG_CONFIG_armv7_unknown_linux_gnueabihf="$CROSS_HOST_TRIPLE-pkg-config"
+        export PKG_CONFIG_armv7_unknown_linux_gnueabihf="arm-linux-gnueabihf-pkg-config"
 
         rustup target add armv7-unknown-linux-gnueabihf
         ;;
 
     'aarch64')
-        export CROSS_HOST_TRIPLE=aarch64-linux-gnu
-        export PKG_CONFIG_aarch64_unknown_linux_gnu="$CROSS_HOST_TRIPLE-pkg-config"
+        export PKG_CONFIG_aarch64_unknown_linux_gnu="aarch64-linux-gnu-pkg-config"
 
         rustup target add aarch64-unknown-linux-gnu
         ;;

--- a/docs-dev/running/pkcs11.md
+++ b/docs-dev/running/pkcs11.md
@@ -2,7 +2,7 @@
 
 Follow the user steps at <https://azure.github.io/iot-identity-service/pkcs11/>
 
-If you want to use tpm2-pkcs11 with the TPM simulator, see [`ibmswtpm2`](ibmswtpm2.md)
+If you want to use tpm2-pkcs11 with the TPM simulator, see [`swtpm`](swtpm.md)
 
 To verify your HSM and its PKCS#11 library with aziot-keyd, see [Testing the openssl engine.](aziot-keyd.md#testing-the-openssl-engine)
 

--- a/tpm/aziot-tpmd/src/lib.rs
+++ b/tpm/aziot-tpmd/src/lib.rs
@@ -70,7 +70,7 @@ impl Api {
                 Ok(handle) => handle,
                 Err(e) => {
                     log::error!(
-                        "could not read endorsement key from {}: {}",
+                        "could not read endorsement key from {:#x}: {}",
                         tss_minimal::handle::ENDORSEMENT_KEY,
                         e
                     );
@@ -83,7 +83,7 @@ impl Api {
                     )?;
                     context
                         .evict(
-                            Persistent::ENDORSEMENT_HIERARCHY,
+                            Persistent::OWNER_HIERARCHY,
                             &handle,
                             &Persistent::PASSWORD_SESSION,
                             tss_minimal::handle::ENDORSEMENT_KEY,
@@ -96,7 +96,7 @@ impl Api {
                 Ok(handle) => handle,
                 Err(e) => {
                     log::error!(
-                        "could not read storage root key from {}: {}",
+                        "could not read storage root key from {:#x}: {}",
                         tss_minimal::handle::STORAGE_ROOT_KEY,
                         e
                     );


### PR DESCRIPTION
`aziot-tpmd` was incorrectly attempting to evict to the endorsement hierarchy instead of the owner hierarchy when persisting the endorsement key.