### PR TITLE
Increase scheduled e2e timeout

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - name: 'Run'
       run: |
-        timeout 45m ./ci/e2e-tests/suite-setup.sh
+        timeout 20m ./ci/e2e-tests/suite-setup.sh
       env:
         BRANCH: "${{ github.event.inputs.branch }}"
 

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: 'Run'
       run: |
-        timeout 10m ./ci/e2e-tests/suite-setup.sh
+        timeout 20m ./ci/e2e-tests/suite-setup.sh
       env:
         BRANCH: "${{ matrix.branch }}"
 


### PR DESCRIPTION
The suite-setup stage now takes 10 to 11 minutes to complete, so this
change increases the timeout to 20 minutes to give more of a buffer for
worst case scenaros. It also reduces the timeout in the manual workflow
for consistency.