### PR TITLE
Add no-socket-throttle feature to http-common

### DIFF
--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -28,3 +28,5 @@ url = { version = "2", features = ["serde"] }
 [dev-dependencies]
 serde_json = "1"
 
+[features]
+no-socket-throttle = []

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -39,6 +39,8 @@ pub enum Incoming {
     },
     Unix {
         listener: tokio::net::UnixListener,
+
+        #[cfg(not(feature = "no-socket-throttle"))]
         user_state: std::collections::BTreeMap<libc::uid_t, std::sync::Arc<atomic::AtomicUsize>>,
     },
 }
@@ -59,6 +61,7 @@ impl Incoming {
             + 'static,
         <H as hyper::service::Service<hyper::Request<hyper::Body>>>::Future: Send,
     {
+        #[cfg(not(feature = "no-socket-throttle"))]
         const MAX_REQUESTS_PER_USER: usize = 10;
 
         // Keep track of the number of running tasks.
@@ -100,6 +103,8 @@ impl Incoming {
 
             Incoming::Unix {
                 listener,
+
+                #[cfg(not(feature = "no-socket-throttle"))]
                 user_state,
             } => loop {
                 let accept = listener.accept();
@@ -112,6 +117,8 @@ impl Incoming {
                         let unix_stream = unix_stream?.0;
 
                         let ucred = unix_stream.peer_cred()?;
+
+                        #[cfg(not(feature = "no-socket-throttle"))]
                         let servers_available = user_state
                             .entry(ucred.uid())
                             .or_insert_with(|| {
@@ -124,28 +131,42 @@ impl Incoming {
                         tasks.fetch_add(1, atomic::Ordering::AcqRel);
                         let server_tasks = tasks.clone();
                         tokio::spawn(async move {
-                            let available = servers_available
-                                .fetch_update(
-                                    atomic::Ordering::AcqRel,
-                                    atomic::Ordering::Acquire,
-                                    |current| current.checked_sub(1),
-                                )
-                                .is_ok();
+                            #[cfg(not(feature = "no-socket-throttle"))]
+                            {
+                                let available = servers_available
+                                    .fetch_update(
+                                        atomic::Ordering::AcqRel,
+                                        atomic::Ordering::Acquire,
+                                        |current| current.checked_sub(1),
+                                    )
+                                    .is_ok();
 
-                            if available {
-                                if let Err(http_err) = hyper::server::conn::Http::new()
-                                    .serve_connection(unix_stream, server)
-                                    .await
-                                {
-                                    log::info!("Error while serving HTTP connection: {}", http_err);
+                                if available {
+                                    if let Err(http_err) = hyper::server::conn::Http::new()
+                                        .serve_connection(unix_stream, server)
+                                        .await
+                                    {
+                                        log::info!(
+                                            "Error while serving HTTP connection: {}",
+                                            http_err
+                                        );
+                                    }
+
+                                    servers_available.fetch_add(1, atomic::Ordering::AcqRel);
+                                } else {
+                                    log::info!(
+                                        "Max simultaneous connections reached for user {}",
+                                        ucred.uid()
+                                    );
                                 }
+                            }
 
-                                servers_available.fetch_add(1, atomic::Ordering::AcqRel);
-                            } else {
-                                log::info!(
-                                    "Max simultaneous connections reached for user {}",
-                                    ucred.uid()
-                                );
+                            #[cfg(feature = "no-socket-throttle")]
+                            if let Err(http_err) = hyper::server::conn::Http::new()
+                                .serve_connection(unix_stream, server)
+                                .await
+                            {
+                                log::info!("Error while serving HTTP connection: {}", http_err);
                             }
 
                             server_tasks.fetch_sub(1, atomic::Ordering::AcqRel);
@@ -300,6 +321,8 @@ impl Connector {
 
                 Ok(Incoming::Unix {
                     listener,
+
+                    #[cfg(not(feature = "no-socket-throttle"))]
                     user_state: Default::default(),
                 })
             }
@@ -699,6 +722,8 @@ fn fd_to_listener(fd: std::os::unix::io::RawFd) -> std::io::Result<Incoming> {
         let listener = tokio::net::UnixListener::from_std(listener)?;
         Ok(Incoming::Unix {
             listener,
+
+            #[cfg(not(feature = "no-socket-throttle"))]
             user_state: Default::default(),
         })
     } else {


### PR DESCRIPTION
Adds a cargo feature `no-socket-throttle` to http-common. Enabling this disables socket throttling when serving connections on UNIX sockets.

This is in response to #433. The 1.3.0 update consolidated the server code between iotedge and this repo, and unintentionally introduced this repo's throttling mechanism to the Edge daemon. The Edge daemon does not need to throttle the management socket, as only users in the iotedge group can access the management socket. By default, this prevents modules from calling the management socket.