### PR TITLE
[main] Pin cargo-tarpaulin dependencies to its lockfile

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -367,7 +367,7 @@ if [ "${OS#mariner}" = "$OS" ]; then
     cargo install cbindgen --version "=$CBINDGEN_VERSION"
 
     if [ "$OS:$ARCH" = 'ubuntu:18.04:amd64' ]; then
-        cargo install cargo-tarpaulin --version '^0.18'
+        cargo install cargo-tarpaulin --version '^0.20' --locked
     fi
 fi
 


### PR DESCRIPTION
chrono released v0.4.20 which has broken running tarpaulin.

Upstream issue: https://github.com/chronotope/chrono/issues/755.