### PR TITLE
Allow socket throttle limits to be configurable

### DIFF
--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -519,6 +519,7 @@ pub fn run(
     };
 
     let tpmd_config = aziot_tpmd_config::Config {
+        max_requests: aziot_max_requests.tpmd,
         shared: tpm,
         endpoints: aziot_tpmd_config::Endpoints {
             aziot_tpmd: aziot_tpmd_endpoint,

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -26,7 +26,7 @@ pub fn run(
         localid,
         cloud_timeout_sec,
         cloud_retries,
-        max_requests,
+        aziot_max_requests,
         mut aziot_keys,
         mut preloaded_keys,
         cert_issuance,
@@ -497,7 +497,7 @@ pub fn run(
         }
 
         aziot_keyd_config::Config {
-            max_requests,
+            max_requests: aziot_max_requests.keyd,
 
             aziot_keys,
 

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -473,6 +473,8 @@ pub fn run(
         aziot_certd_config::Config {
             homedir_path: super::AZIOT_CERTD_HOMEDIR_PATH.into(),
 
+            max_requests: aziot_max_requests.certd,
+
             cert_issuance: aziot_certd_config::CertIssuance {
                 est,
                 local_ca,

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -26,6 +26,7 @@ pub fn run(
         localid,
         cloud_timeout_sec,
         cloud_retries,
+        max_requests,
         mut aziot_keys,
         mut preloaded_keys,
         cert_issuance,
@@ -496,6 +497,8 @@ pub fn run(
         }
 
         aziot_keyd_config::Config {
+            max_requests,
+
             aziot_keys,
 
             preloaded_keys: preloaded_keys

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -298,6 +298,8 @@ pub fn run(
 
         homedir: super::AZIOT_IDENTITYD_HOMEDIR_PATH.into(),
 
+        max_requests: aziot_max_requests.identityd,
+
         cloud_timeout_sec,
 
         cloud_retries,

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -51,6 +51,12 @@ pub struct Config {
     )]
     pub cloud_retries: u32,
 
+    #[serde(
+        default = "http_common::Incoming::default_max_requests",
+        skip_serializing_if = "http_common::Incoming::is_default_max_requests"
+    )]
+    pub max_requests: usize,
+
     pub provisioning: Provisioning,
 
     pub localid: Option<aziot_identityd_config::LocalId>,

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -51,11 +51,8 @@ pub struct Config {
     )]
     pub cloud_retries: u32,
 
-    #[serde(
-        default = "http_common::Incoming::default_max_requests",
-        skip_serializing_if = "http_common::Incoming::is_default_max_requests"
-    )]
-    pub max_requests: usize,
+    #[serde(default, skip_serializing_if = "AziotMaxRequests::is_default")]
+    pub aziot_max_requests: AziotMaxRequests,
 
     pub provisioning: Provisioning,
 
@@ -355,6 +352,31 @@ where
         None => (),
     }
     Ok(opt)
+}
+
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct AziotMaxRequests {
+    pub keyd: usize,
+    pub certd: usize,
+    pub tpmd: usize,
+    pub identityd: usize,
+}
+
+impl Default for AziotMaxRequests {
+    fn default() -> AziotMaxRequests {
+        AziotMaxRequests {
+            keyd: http_common::Incoming::default_max_requests(),
+            certd: http_common::Incoming::default_max_requests(),
+            tpmd: http_common::Incoming::default_max_requests(),
+            identityd: http_common::Incoming::default_max_requests(),
+        }
+    }
+}
+
+impl AziotMaxRequests {
+    pub fn is_default(&self) -> bool {
+        self == &AziotMaxRequests::default()
+    }
 }
 
 mod base64 {

--- a/aziotctl/aziotctl-common/test-files/apply/throttle-limits/certd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/throttle-limits/certd.toml
@@ -1,0 +1,6 @@
+homedir_path = "/var/lib/aziot/certd"
+max_requests = 30
+
+[cert_issuance]
+
+[preloaded_certs]

--- a/aziotctl/aziotctl-common/test-files/apply/throttle-limits/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/throttle-limits/config.toml
@@ -1,0 +1,9 @@
+[provisioning]
+source = "manual"
+connection_string = "HostName=example.azure-devices.net;DeviceId=my-device;SharedAccessKey=YXppb3QtaWRlbnRpdHktc2VydmljZXxhemlvdC1pZGU="
+
+[aziot_max_requests]
+keyd = 20
+certd = 30
+tpmd = 40
+identityd = 50

--- a/aziotctl/aziotctl-common/test-files/apply/throttle-limits/device-id
+++ b/aziotctl/aziotctl-common/test-files/apply/throttle-limits/device-id
@@ -1,0 +1,1 @@
+aziot-identity-service|aziot-ide

--- a/aziotctl/aziotctl-common/test-files/apply/throttle-limits/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/throttle-limits/identityd.toml
@@ -1,0 +1,12 @@
+hostname = "my-device"
+homedir = "/var/lib/aziot/identityd"
+max_requests = 50
+
+[provisioning]
+source = "manual"
+iothub_hostname = "example.azure-devices.net"
+device_id = "my-device"
+
+[provisioning.authentication]
+method = "sas"
+device_id_pk = "device-id"

--- a/aziotctl/aziotctl-common/test-files/apply/throttle-limits/keyd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/throttle-limits/keyd.toml
@@ -1,0 +1,11 @@
+max_requests = 20
+
+[aziot_keys]
+homedir_path = "/var/lib/aziot/keyd"
+
+[preloaded_keys]
+device-id = "file:///var/secrets/aziot/keyd/device-id"
+
+[[principal]]
+uid = 5556
+keys = ["aziot_identityd_master_id", "device-id"]

--- a/aziotctl/aziotctl-common/test-files/apply/throttle-limits/tpmd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/throttle-limits/tpmd.toml
@@ -1,0 +1,1 @@
+max_requests = 40

--- a/aziotctl/src/config/mp.rs
+++ b/aziotctl/src/config/mp.rs
@@ -73,6 +73,8 @@ To reconfigure IoT Identity Service, run:
 
         cloud_retries: aziot_identityd_config::Settings::default_cloud_retries(),
 
+        max_requests: http_common::Incoming::default_max_requests(),
+
         aziot_keys: Default::default(),
 
         preloaded_keys: Default::default(),

--- a/aziotctl/src/config/mp.rs
+++ b/aziotctl/src/config/mp.rs
@@ -73,7 +73,7 @@ To reconfigure IoT Identity Service, run:
 
         cloud_retries: aziot_identityd_config::Settings::default_cloud_retries(),
 
-        max_requests: http_common::Incoming::default_max_requests(),
+        aziot_max_requests: Default::default(),
 
         aziot_keys: Default::default(),
 

--- a/aziotctl/src/internal/check/checks/host_connect_iothub.rs
+++ b/aziotctl/src/internal/check/checks/host_connect_iothub.rs
@@ -216,6 +216,7 @@ mod tests {
         let identity_options = Settings {
             hostname: hostname.to_owned(),
             homedir: PathBuf::new(),
+            max_requests: 10,
             cloud_retries: 1,
             cloud_timeout_sec: 1,
             provisioning: device_provisioning,

--- a/aziotd/src/main.rs
+++ b/aziotd/src/main.rs
@@ -206,7 +206,7 @@ where
     log::info!("Starting server...");
 
     let mut incoming = connector
-        .incoming(SOCKET_DEFAULT_PERMISSION, None)
+        .incoming(SOCKET_DEFAULT_PERMISSION, 10, None)
         .await
         .map_err(|err| ErrorKind::Service(Box::new(err)))?;
 

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -28,6 +28,13 @@ pub struct Config {
     /// Path of home directory.
     pub homedir_path: PathBuf,
 
+    /// Maximum number of simultaneous requests per user that certd will service.
+    #[serde(
+        default = "http_common::Incoming::default_max_requests",
+        skip_serializing_if = "http_common::Incoming::is_default_max_requests"
+    )]
+    pub max_requests: usize,
+
     /// Configuration of how new certificates should be issued.
     #[serde(default)]
     pub cert_issuance: CertIssuance,
@@ -358,6 +365,7 @@ mod tests {
     fn parse_config() {
         let actual = r#"
 homedir_path = "/var/lib/aziot/certd"
+max_requests = 50
 
 [cert_issuance]
 device-ca = { method = "est", common_name = "custom-name" }
@@ -411,6 +419,8 @@ certs = ["test"]
             actual,
             Config {
                 homedir_path: "/var/lib/aziot/certd".into(),
+
+                max_requests: 50,
 
                 cert_issuance: CertIssuance {
                     est: Some(Est {
@@ -576,6 +586,8 @@ aziot_certd = "unix:///run/aziot/certd.sock"
             Config {
                 homedir_path: "/var/lib/aziot/certd".into(),
 
+                max_requests: http_common::Incoming::default_max_requests(),
+
                 cert_issuance: Default::default(),
 
                 preloaded_certs: Default::default(),
@@ -599,6 +611,7 @@ aziot_certd = "unix:///run/aziot/certd.sock"
     fn serialize_config() {
         let configuration = Config {
             homedir_path: "/var/lib/aziot/certd".into(),
+            max_requests: 50,
 
             cert_issuance: CertIssuance {
                 est: Some(Est {

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -53,6 +53,7 @@ pub async fn main(
 ) -> Result<(Incoming, http::Service), Box<dyn StdError>> {
     let Config {
         homedir_path,
+        max_requests,
         cert_issuance,
         preloaded_certs,
         endpoints:
@@ -108,7 +109,7 @@ pub async fn main(
     let service = http::Service { api };
 
     let incoming = connector
-        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, 10, None)
+        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, max_requests, None)
         .await?;
 
     Ok((incoming, service))
@@ -306,13 +307,14 @@ impl UpdateConfig for Api {
     async fn update_config(&mut self, new_config: Self::Config) -> Result<(), Self::Error> {
         log::info!("Detected change in config files. Updating config.");
 
-        // Don't allow changes to homedir path or endpoints while daemon is running.
+        // Don't allow changes to homedir path, endpoints, or throttle limit while daemon is running.
         // Only update other fields.
         let Config {
             cert_issuance,
             preloaded_certs,
             principal,
             homedir_path: _,
+            max_requests: _,
             endpoints: _,
         } = new_config;
 

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -39,7 +39,7 @@ use aziot_certd_config::{
     EstAuthBasic, PreloadedCert, Principal,
 };
 use config_common::watcher::UpdateConfig;
-use http_common::Connector;
+use http_common::Incoming;
 
 use error::{Error, InternalError};
 
@@ -50,7 +50,7 @@ pub async fn main(
     config: Config,
     config_path: PathBuf,
     config_directory_path: PathBuf,
-) -> Result<(Connector, http::Service), Box<dyn StdError>> {
+) -> Result<(Incoming, http::Service), Box<dyn StdError>> {
     let Config {
         homedir_path,
         cert_issuance,
@@ -107,7 +107,11 @@ pub async fn main(
 
     let service = http::Service { api };
 
-    Ok((connector, service))
+    let incoming = connector
+        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, 10, None)
+        .await?;
+
+    Ok((incoming, service))
 }
 
 struct Api {

--- a/docs/socket-throttling.md
+++ b/docs/socket-throttling.md
@@ -1,6 +1,6 @@
 # Socket Throttling
 
-Each of the services' sockets implement a throttling mechanism to prevent a malicious process from making continuous requests and denying service to other processes. This throttling mechanism limits each caller to making 10 simultaneous requests per socket. Each caller is identified by its UID, so two processes sharing the same UNIX user will be throttled together.
+Each of the services' sockets implement a throttling mechanism to prevent a malicious process from making continuous requests and denying service to other processes. By default, this throttling mechanism limits each caller to making 10 simultaneous requests per socket. Each caller is identified by its UID, so two processes sharing the same UNIX user will be throttled together.
 
 If requests on a socket exceed this limit, a service will deny all further requests on its socket until the number of in-progress requests falls below 10. When a service denies a request, it closes the socket connection without sending a reply; this will be reported as an OS-level error (not an HTTP API error) to the caller. It is always the caller's responsibility to retry a request that failed due to throttling.
 
@@ -11,3 +11,23 @@ In addition to closing the socket connection, services will also log a message. 
 ```
 
 Note that even the services' users (i.e. `aziotks`, `aziotcs`, `aziotid`) are subject to throttling when they make a request to other services.
+
+## Raising the throttling limit
+
+The default limit is 10 simultaneous requests per user. Should this be insufficient, a higher throttling limit can be specified in config.toml.
+
+Each service's config.toml can specifiy the `max_requests` setting. For example, to raise the throttling limit for keyd to 50, add the following to keyd's config.toml.
+
+```toml
+max_requests = 50
+```
+
+The throttling limit can be specified in the super config for each service by adding the `[aziot_max_requests]`. For example:
+
+```toml
+[aziot_max_requests]
+keyd = 20
+certd = 30
+tpmd = 40
+identityd = 50
+```

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -28,5 +28,3 @@ url = { version = "2", features = ["serde"] }
 [dev-dependencies]
 serde_json = "1"
 
-[features]
-no-socket-throttle = []

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -28,3 +28,5 @@ url = { version = "2", features = ["serde"] }
 [dev-dependencies]
 serde_json = "1"
 
+[features]
+no-socket-throttle = []

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -3,6 +3,7 @@
 use std::sync::atomic;
 
 use futures_util::future;
+use nix::sys::socket::{AddressFamily, SockaddrLike, SockaddrStorage};
 
 pub const SOCKET_DEFAULT_PERMISSION: u32 = 0o660;
 
@@ -621,25 +622,18 @@ impl std::error::Error for ConnectorError {
 /// Returns an Err if the socket type is invalid. TCP sockets are only valid for debug builds,
 /// so this function returns an Err for release builds using a TCP socket.
 fn is_unix_fd(fd: std::os::unix::io::RawFd) -> std::io::Result<bool> {
-    let sock_addr: nix::sys::socket::SockaddrStorage = nix::sys::socket::getsockname(fd)
+    let sock_addr = nix::sys::socket::getsockname::<SockaddrStorage>(fd)
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
 
-    match nix::sys::socket::SockaddrLike::family(&sock_addr) {
-        Some(nix::sys::socket::AddressFamily::Unix) => Ok(true),
+    match sock_addr.family() {
+        Some(AddressFamily::Unix) => Ok(true),
 
         // Only debug builds can set up HTTP servers. Release builds must use unix sockets.
-        Some(nix::sys::socket::AddressFamily::Inet | nix::sys::socket::AddressFamily::Inet6)
-            if cfg!(debug_assertions) =>
-        {
-            Ok(false)
-        }
+        Some(AddressFamily::Inet | AddressFamily::Inet6) if cfg!(debug_assertions) => Ok(false),
 
-        sock_addr => Err(std::io::Error::new(
+        family => Err(std::io::Error::new(
             std::io::ErrorKind::Other,
-            format!(
-                "systemd socket has unsupported address family {:?}",
-                sock_addr
-            ),
+            format!("systemd socket has unsupported address family {:?}", family),
         )),
     }
 }

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -4,6 +4,8 @@ use std::sync::atomic;
 
 use futures_util::future;
 
+pub const SOCKET_DEFAULT_PERMISSION: u32 = 0o660;
+
 const SD_LISTEN_FDS_START: std::os::unix::io::RawFd = 3;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -168,6 +168,14 @@ impl Incoming {
 
         Ok(())
     }
+
+    pub fn default_max_requests() -> usize {
+        10
+    }
+
+    pub fn is_default_max_requests(max_requests: &usize) -> bool {
+        *max_requests == Incoming::default_max_requests()
+    }
 }
 
 impl Connector {

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -39,6 +39,8 @@ pub enum Incoming {
     },
     Unix {
         listener: tokio::net::UnixListener,
+
+        #[cfg(not(feature = "no-socket-throttle"))]
         user_state: std::collections::BTreeMap<libc::uid_t, std::sync::Arc<atomic::AtomicUsize>>,
     },
 }
@@ -59,6 +61,7 @@ impl Incoming {
             + 'static,
         <H as hyper::service::Service<hyper::Request<hyper::Body>>>::Future: Send,
     {
+        #[cfg(not(feature = "no-socket-throttle"))]
         const MAX_REQUESTS_PER_USER: usize = 10;
 
         // Keep track of the number of running tasks.
@@ -100,6 +103,8 @@ impl Incoming {
 
             Incoming::Unix {
                 listener,
+
+                #[cfg(not(feature = "no-socket-throttle"))]
                 user_state,
             } => loop {
                 let accept = listener.accept();
@@ -112,6 +117,8 @@ impl Incoming {
                         let unix_stream = unix_stream?.0;
 
                         let ucred = unix_stream.peer_cred()?;
+
+                        #[cfg(not(feature = "no-socket-throttle"))]
                         let servers_available = user_state
                             .entry(ucred.uid())
                             .or_insert_with(|| {
@@ -124,28 +131,42 @@ impl Incoming {
                         tasks.fetch_add(1, atomic::Ordering::AcqRel);
                         let server_tasks = tasks.clone();
                         tokio::spawn(async move {
-                            let available = servers_available
-                                .fetch_update(
-                                    atomic::Ordering::AcqRel,
-                                    atomic::Ordering::Acquire,
-                                    |current| current.checked_sub(1),
-                                )
-                                .is_ok();
+                            #[cfg(not(feature = "no-socket-throttle"))]
+                            {
+                                let available = servers_available
+                                    .fetch_update(
+                                        atomic::Ordering::AcqRel,
+                                        atomic::Ordering::Acquire,
+                                        |current| current.checked_sub(1),
+                                    )
+                                    .is_ok();
 
-                            if available {
-                                if let Err(http_err) = hyper::server::conn::Http::new()
-                                    .serve_connection(unix_stream, server)
-                                    .await
-                                {
-                                    log::info!("Error while serving HTTP connection: {}", http_err);
+                                if available {
+                                    if let Err(http_err) = hyper::server::conn::Http::new()
+                                        .serve_connection(unix_stream, server)
+                                        .await
+                                    {
+                                        log::info!(
+                                            "Error while serving HTTP connection: {}",
+                                            http_err
+                                        );
+                                    }
+
+                                    servers_available.fetch_add(1, atomic::Ordering::AcqRel);
+                                } else {
+                                    log::info!(
+                                        "Max simultaneous connections reached for user {}",
+                                        ucred.uid()
+                                    );
                                 }
+                            }
 
-                                servers_available.fetch_add(1, atomic::Ordering::AcqRel);
-                            } else {
-                                log::info!(
-                                    "Max simultaneous connections reached for user {}",
-                                    ucred.uid()
-                                );
+                            #[cfg(feature = "no-socket-throttle")]
+                            if let Err(http_err) = hyper::server::conn::Http::new()
+                                .serve_connection(unix_stream, server)
+                                .await
+                            {
+                                log::info!("Error while serving HTTP connection: {}", http_err);
                             }
 
                             server_tasks.fetch_sub(1, atomic::Ordering::AcqRel);
@@ -300,6 +321,8 @@ impl Connector {
 
                 Ok(Incoming::Unix {
                     listener,
+
+                    #[cfg(not(feature = "no-socket-throttle"))]
                     user_state: Default::default(),
                 })
             }
@@ -699,6 +722,8 @@ fn fd_to_listener(fd: std::os::unix::io::RawFd) -> std::io::Result<Incoming> {
         let listener = tokio::net::UnixListener::from_std(listener)?;
         Ok(Incoming::Unix {
             listener,
+
+            #[cfg(not(feature = "no-socket-throttle"))]
             user_state: Default::default(),
         })
     } else {

--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -19,7 +19,8 @@ pub use dynrange::DynRangeBounds;
 
 mod connector;
 pub use connector::AsyncStream;
-pub use connector::{Connector, ConnectorError, Stream};
+pub use connector::SOCKET_DEFAULT_PERMISSION;
+pub use connector::{Connector, ConnectorError, Incoming, Stream};
 
 mod proxy;
 pub use proxy::{get_proxy_uri, MaybeProxyConnector};

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -18,6 +18,13 @@ pub struct Settings {
 
     pub homedir: std::path::PathBuf,
 
+    /// Maximum number of simultaneous requests per user that identityd will service.
+    #[serde(
+        default = "http_common::Incoming::default_max_requests",
+        skip_serializing_if = "http_common::Incoming::is_default_max_requests"
+    )]
+    pub max_requests: usize,
+
     #[serde(
         default = "Settings::default_cloud_timeout",
         deserialize_with = "deserialize_cloud_timeout",

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -60,7 +60,7 @@ pub async fn main(
     settings: config::Settings,
     config_path: std::path::PathBuf,
     config_directory_path: std::path::PathBuf,
-) -> Result<(http_common::Connector, http::Service), Box<dyn std::error::Error>> {
+) -> Result<(http_common::Incoming, http::Service), Box<dyn std::error::Error>> {
     let settings = settings.check().map_err(InternalError::BadSettings)?;
 
     let homedir_path = &settings.homedir;
@@ -149,7 +149,11 @@ pub async fn main(
 
     let service = http::Service { api };
 
-    Ok((connector, service))
+    let incoming = connector
+        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, 10, None)
+        .await?;
+
+    Ok((incoming, service))
 }
 
 pub struct Api {

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -65,6 +65,7 @@ pub async fn main(
 
     let homedir_path = &settings.homedir;
     let connector = settings.endpoints.aziot_identityd.clone();
+    let max_requests = settings.max_requests;
 
     if !homedir_path.exists() {
         if let Err(err) = std::fs::create_dir_all(&homedir_path) {
@@ -150,7 +151,7 @@ pub async fn main(
     let service = http::Service { api };
 
     let incoming = connector
-        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, 10, None)
+        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, max_requests, None)
         .await?;
 
     Ok((incoming, service))

--- a/key/aziot-keyd-config/src/lib.rs
+++ b/key/aziot-keyd-config/src/lib.rs
@@ -6,6 +6,13 @@
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Config {
+    /// Maximum number of simultaneous requests per user that keyd will service.
+    #[serde(
+        default = "http_common::Incoming::default_max_requests",
+        skip_serializing_if = "http_common::Incoming::is_default_max_requests"
+    )]
+    pub max_requests: usize,
+
     /// Parameters passed down to libaziot-keys. The allowed names and values are determined by the libaziot-keys implementation.
     #[serde(default)]
     pub aziot_keys: std::collections::BTreeMap<String, String>,

--- a/key/aziot-keyd-config/src/lib.rs
+++ b/key/aziot-keyd-config/src/lib.rs
@@ -70,6 +70,8 @@ mod tests {
     #[test]
     fn parse_config() {
         let actual = r#"
+max_requests = 50
+
 [aziot_keys]
 homedir_path = "/var/lib/aziot/keyd"
 pkcs11_lib_path = "/usr/lib64/pkcs11/libsofthsm2.so"
@@ -88,6 +90,7 @@ keys = ["test"]
         assert_eq!(
             actual,
             super::Config {
+                max_requests: 50,
                 aziot_keys: [
                     ("homedir_path", "/var/lib/aziot/keyd"),
                     ("pkcs11_lib_path", "/usr/lib64/pkcs11/libsofthsm2.so"),
@@ -134,6 +137,8 @@ aziot_keyd = "unix:///run/aziot/keyd.sock"
         assert_eq!(
             actual,
             super::Config {
+                max_requests: http_common::Incoming::default_max_requests(),
+
                 aziot_keys: Default::default(),
 
                 preloaded_keys: Default::default(),

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -30,6 +30,7 @@ pub async fn main(
     config_directory_path: std::path::PathBuf,
 ) -> Result<(http_common::Incoming, http::Service), Box<dyn std::error::Error>> {
     let Config {
+        max_requests,
         aziot_keys,
         preloaded_keys,
         endpoints: Endpoints {
@@ -90,7 +91,7 @@ pub async fn main(
     let service = http::Service { api };
 
     let incoming = connector
-        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, 10, None)
+        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, max_requests, None)
         .await?;
 
     Ok((incoming, service))
@@ -518,6 +519,7 @@ impl UpdateConfig for Api {
 
         // Only allow runtime updates to principals.
         let Config {
+            max_requests: _,
             aziot_keys: _,
             preloaded_keys: _,
             endpoints: _,

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -28,7 +28,7 @@ pub async fn main(
     config: Config,
     config_path: std::path::PathBuf,
     config_directory_path: std::path::PathBuf,
-) -> Result<(http_common::Connector, http::Service), Box<dyn std::error::Error>> {
+) -> Result<(http_common::Incoming, http::Service), Box<dyn std::error::Error>> {
     let Config {
         aziot_keys,
         preloaded_keys,
@@ -89,7 +89,11 @@ pub async fn main(
 
     let service = http::Service { api };
 
-    Ok((connector, service))
+    let incoming = connector
+        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, 10, None)
+        .await?;
+
+    Ok((incoming, service))
 }
 
 struct Api {

--- a/tpm/aziot-tpmd-config/src/lib.rs
+++ b/tpm/aziot-tpmd-config/src/lib.rs
@@ -20,6 +20,13 @@ const fn valid_persistent_index(index: u32) -> bool {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct Config {
+    /// Maximum number of simultaneous requests per user that tpmd will service.
+    #[serde(
+        default = "http_common::Incoming::default_max_requests",
+        skip_serializing_if = "http_common::Incoming::is_default_max_requests"
+    )]
+    pub max_requests: usize,
+
     #[serde(flatten)]
     pub shared: SharedConfig,
 
@@ -129,6 +136,7 @@ mod tests {
         assert_eq!(
             actual,
             super::Config {
+                max_requests: http_common::Incoming::default_max_requests(),
                 shared: super::SharedConfig {
                     tcti: std::ffi::CString::new("device").unwrap(),
                     auth_key_index: super::default_ak_index(),
@@ -146,6 +154,7 @@ mod tests {
     #[test]
     fn parse_config_with_tcti_and_auth_key_index() {
         let actual = r#"
+max_requests = 50
 tcti = "swtpm:port=2321"
 auth_key_index = 0x01_02_03
 "#;
@@ -154,6 +163,7 @@ auth_key_index = 0x01_02_03
         assert_eq!(
             actual,
             super::Config {
+                max_requests: 50,
                 shared: super::SharedConfig {
                     tcti: std::ffi::CString::new("swtpm:port=2321").unwrap(),
                     auth_key_index: 0x01_02_03,
@@ -180,6 +190,7 @@ owner = "world"
         assert_eq!(
             actual,
             super::Config {
+                max_requests: http_common::Incoming::default_max_requests(),
                 shared: super::SharedConfig {
                     tcti: std::ffi::CString::new("device").unwrap(),
                     auth_key_index: super::default_ak_index(),
@@ -221,6 +232,7 @@ aziot_tpmd = "unix:///custom/path/tpmd.sock"
         assert_eq!(
             actual,
             super::Config {
+                max_requests: http_common::Incoming::default_max_requests(),
                 shared: super::SharedConfig {
                     tcti: std::ffi::CString::new("device").unwrap(),
                     auth_key_index: super::default_ak_index(),

--- a/tpm/aziot-tpmd/src/lib.rs
+++ b/tpm/aziot-tpmd/src/lib.rs
@@ -31,7 +31,11 @@ pub async fn main(
     let incoming = config
         .endpoints
         .aziot_tpmd
-        .incoming(http_common::SOCKET_DEFAULT_PERMISSION, 10, None)
+        .incoming(
+            http_common::SOCKET_DEFAULT_PERMISSION,
+            config.max_requests,
+            None,
+        )
         .await?;
 
     Ok((incoming, service))


### PR DESCRIPTION
A better solution to https://github.com/Azure/iot-identity-service/issues/433 is to add a config option to allow the throttling limits to be configurable. This PR adds the `max_requests` option, which controls the throttling limit.

Reverts #438 and removes the no-socket-throttle feature.