### PR TITLE
[Draft] testing mariner toolkit change to unblock iotedge build

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -273,7 +273,7 @@ case "$OS:$ARCH" in
             'mariner:2')
                 # BranchTag='2.0-stable'
                 # WARN: 2.0-stable is broken - https://github.com/microsoft/CBL-Mariner/issues/3483
-                BranchTag='2.0.20220713-2.0'
+                BranchTag='2.0-stable'
                 ;;
         esac
 


### PR DESCRIPTION
not intended to be checked in this is purely to allow me to test using different version of the mariner toolkit for arm64.