### PR TITLE
Disable Mariner 2 build to unblock pipeline

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -42,9 +42,9 @@ jobs:
         - container_os: 'ubuntu:18.04'
           arch: 'amd64'
           os: 'mariner:1'
-        - container_os: 'ubuntu:18.04'
-          arch: 'amd64'
-          os: 'mariner:2'
+        # - container_os: 'ubuntu:18.04'
+        #   arch: 'amd64'
+        #   os: 'mariner:2'
 
     steps:
     - uses: 'actions/checkout@v1'


### PR DESCRIPTION
The are some ongoing problems with building the identity service RPM for Mariner 2.0. While they get sorted out, I'm disabling the Mariner 2 build to unblock the other packages.