### PR TITLE
[tpmd] Fix regression in TPM authentication key index

### DIFF
--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -227,8 +227,8 @@
 # # The TPM index at which to persist the DPS authentication key. The index is
 # # taken as an offset from the base address for persistent objects
 # # (0x81000000), and must lie in the range 0x00_00_00--0x7F_FF_FF. The default
-# # value is 0x00_01_00.
-# auth_key_index = "0x00_01_00"
+# # value is 0x00_10_00.
+# auth_key_index = "0x00_10_00"
 
 # # Authorization values for use of the endorsement and owner hierarchies, if
 # # necessary. By default, these are empty strings.

--- a/tpm/aziot-tpmd-config/src/lib.rs
+++ b/tpm/aziot-tpmd-config/src/lib.rs
@@ -10,7 +10,7 @@ const _: () = assert!(valid_persistent_index(default_ak_index()));
 const AUTH_KEY_BOUND_MESSAGE: &str = "integer in range 0x00_00_00..=0x7F_FF_FF";
 
 const fn default_ak_index() -> u32 {
-    0x00_01_00
+    0x00_10_00
 }
 
 /// TPM2 Specification Part 3: 28.5.1.c.1

--- a/tpm/aziot-tpmd/src/lib.rs
+++ b/tpm/aziot-tpmd/src/lib.rs
@@ -128,13 +128,9 @@ impl Api {
                         .expect("existing storage root key was evicted, but could not be read!")
                 }
             };
-        let auth_key_index = tss_minimal::handle::PERSISTENT_OBJECT_BASE + config.shared.auth_key_index;
-        let auth_key = context
-            .from_tpm_public(
-                auth_key_index,
-                None,
-            )
-            .ok();
+        let auth_key_index =
+            tss_minimal::handle::PERSISTENT_OBJECT_BASE + config.shared.auth_key_index;
+        let auth_key = context.from_tpm_public(auth_key_index, None).ok();
 
         Ok(Self {
             context,

--- a/tpm/aziot-tpmd/src/lib.rs
+++ b/tpm/aziot-tpmd/src/lib.rs
@@ -46,6 +46,7 @@ pub struct Api {
     endorsement_key: Persistent,
     storage_root_key: Persistent,
     auth_key: Option<Persistent>,
+    auth_key_index: u32,
 }
 
 impl Api {
@@ -127,9 +128,10 @@ impl Api {
                         .expect("existing storage root key was evicted, but could not be read!")
                 }
             };
+        let auth_key_index = tss_minimal::handle::PERSISTENT_OBJECT_BASE + config.shared.auth_key_index;
         let auth_key = context
             .from_tpm_public(
-                tss_minimal::handle::PERSISTENT_OBJECT_BASE + config.shared.auth_key_index,
+                auth_key_index,
                 None,
             )
             .ok();
@@ -139,6 +141,7 @@ impl Api {
             endorsement_key,
             storage_root_key,
             auth_key,
+            auth_key_index,
         })
     }
 
@@ -184,7 +187,7 @@ impl Api {
             if let Err(e) = res {
                 // NOTE: It is likely that another process interacting with the
                 // TPM evicted the key.
-                log::warn!("could not evict previous auth key: {e}");
+                log::warn!("could not evict previous auth key: {}", e);
             }
         }
 
@@ -256,7 +259,7 @@ impl Api {
                 Persistent::OWNER_HIERARCHY,
                 &auth_key_handle,
                 &Persistent::PASSWORD_SESSION,
-                0x8100_1000,
+                self.auth_key_index,
             )?
             .expect("Esys_EvictControl with a transient handle returns a persistent handle");
 


### PR DESCRIPTION
The default index was incorrectly written, and the value inherited from
the configuration was not used in the key import subroutine.

Resolves #450 and Azure/iotedge#6638.