### PR TITLE
[tpmd] Use standard location for SRK persistence, revert AK index

### DIFF
--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -227,8 +227,8 @@
 # # The TPM index at which to persist the DPS authentication key. The index is
 # # taken as an offset from the base address for persistent objects
 # # (0x81000000), and must lie in the range 0x00_00_00--0x7F_FF_FF. The default
-# # value is 0x00_10_00.
-# auth_key_index = "0x00_10_00"
+# # value is 0x00_01_00.
+# auth_key_index = "0x00_01_00"
 
 # # Authorization values for use of the endorsement and owner hierarchies, if
 # # necessary. By default, these are empty strings.

--- a/tpm/aziot-tpmd-config/src/lib.rs
+++ b/tpm/aziot-tpmd-config/src/lib.rs
@@ -10,7 +10,7 @@ const _: () = assert!(valid_persistent_index(default_ak_index()));
 const AUTH_KEY_BOUND_MESSAGE: &str = "integer in range 0x00_00_00..=0x7F_FF_FF";
 
 const fn default_ak_index() -> u32 {
-    0x00_10_00
+    0x00_01_00
 }
 
 /// TPM2 Specification Part 3: 28.5.1.c.1

--- a/tpm/tss-minimal/src/handle.rs
+++ b/tpm/tss-minimal/src/handle.rs
@@ -6,9 +6,12 @@ use std::fmt;
 
 use crate::{private, EsysContext};
 
+/// Trusted Platform Module Library Part 1: Architecture: 37.3 Owner and Platform Evict Objects
 pub const PERSISTENT_OBJECT_BASE: u32 = 0x81_00_00_00;
+/// TCG TPM v2.0 Provisioning Guidance: Table 2
 pub const ENDORSEMENT_KEY: u32 = PERSISTENT_OBJECT_BASE + 0x01_00_01;
-pub const STORAGE_ROOT_KEY: u32 = PERSISTENT_OBJECT_BASE + 0x00_10_00;
+/// TCG TPM v2.0 Provisioning Guidance: Table 2
+pub const STORAGE_ROOT_KEY: u32 = PERSISTENT_OBJECT_BASE + 0x00_00_01;
 
 /// Returns the index of the resource within the ESYS context. Note that this
 /// is not equivalent to the index of the resource on the TPM.


### PR DESCRIPTION
The storage root key was persisted at incorrect index.  The index should be `PERSISTENT_OBJECT_BASE + 0x00_00_01`, whereas the index used was `PERSISTENT_OBJECT_BASE + 0x00_10_00`[^1].

*Cf.* #450.

[^1]: https://github.com/Azure/iot-identity-service/blob/ed4c0e51f0b36cb18dba371898a534711988edee/tpm/tss-minimal/src/handle.rs#L11