### PR TITLE
[tpmd] Fix regression in TPM authentication key index (#451)

### DIFF
--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -227,8 +227,8 @@
 # # The TPM index at which to persist the DPS authentication key. The index is
 # # taken as an offset from the base address for persistent objects
 # # (0x81000000), and must lie in the range 0x00_00_00--0x7F_FF_FF. The default
-# # value is 0x00_01_00.
-# auth_key_index = "0x00_01_00"
+# # value is 0x00_10_00.
+# auth_key_index = "0x00_10_00"
 
 # # Authorization values for use of the endorsement and owner hierarchies, if
 # # necessary. By default, these are empty strings.

--- a/tpm/aziot-tpmd-config/src/lib.rs
+++ b/tpm/aziot-tpmd-config/src/lib.rs
@@ -10,7 +10,7 @@ const _: () = assert!(valid_persistent_index(default_ak_index()));
 const AUTH_KEY_BOUND_MESSAGE: &str = "integer in range 0x00_00_00..=0x7F_FF_FF";
 
 const fn default_ak_index() -> u32 {
-    0x00_01_00
+    0x00_10_00
 }
 
 /// TPM2 Specification Part 3: 28.5.1.c.1


### PR DESCRIPTION
The default index was incorrectly written, and the value inherited from the configuration was not used in the key import subroutine.

Resolves #450 and Azure/iotedge#6638.