### PR TITLE
Upgrade to Rust 1.63

### DIFF
--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -354,7 +354,7 @@ where
     Ok(opt)
 }
 
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AziotMaxRequests {
     pub keyd: usize,
     pub certd: usize,

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -23,7 +23,7 @@ use url::Url;
 
 use http_common::Connector;
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Config {
     /// Path of home directory.
     pub homedir_path: PathBuf,
@@ -62,7 +62,7 @@ pub struct Config {
 }
 
 /// Configuration of how new certificates should be issued.
-#[derive(Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CertIssuance {
     /// Configuration of parameters for issuing certs via EST.
     pub est: Option<Est>,
@@ -76,7 +76,7 @@ pub struct CertIssuance {
 }
 
 /// Configuration of parameters for issuing certs via EST.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Est {
     /// List of certs that should be treated as trusted roots for validating the EST server's TLS certificate.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -125,7 +125,7 @@ pub fn is_default_est_renew(auto_renew: &cert_renewal::RenewalPolicy) -> bool {
 ///
 /// Note that EST servers may be configured to have only basic auth, only TLS client cert auth, or both.
 #[skip_serializing_none]
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(try_from = "EstAuthInner")]
 pub struct EstAuth {
     /// Authentication parameters when using basic HTTP authentication.
@@ -162,14 +162,14 @@ impl TryFrom<EstAuthInner> for EstAuth {
 }
 
 /// Authentication parameters when using basic HTTP authentication.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct EstAuthBasic {
     pub username: String,
     pub password: String,
 }
 
 /// Authentication parameters when using TLS client cert authentication.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct EstAuthX509 {
     /// Cert ID and private key ID for the identity cert.
     ///
@@ -200,7 +200,7 @@ pub struct CertificateWithPrivateKey {
 }
 
 /// Details for issuing a single cert.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CertIssuanceOptions {
     /// The method used to issue a certificate.
     #[serde(flatten)]
@@ -215,7 +215,7 @@ pub struct CertIssuanceOptions {
     pub subject: Option<CertSubject>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CertSubject {
     CommonName(String),
@@ -292,7 +292,7 @@ where
 
 /// The method used to issue a certificate.
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "method", rename_all = "snake_case")]
 pub enum CertIssuanceMethod {
     /// The certificate is to be issued via EST.
@@ -310,7 +310,7 @@ pub enum CertIssuanceMethod {
 }
 
 /// The location of a preloaded cert.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum PreloadedCert {
     /// A URI for the location.
@@ -325,7 +325,7 @@ pub enum PreloadedCert {
 }
 
 /// Map of service names to endpoint URIs.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Endpoints {
     /// The endpoint that the certd service binds to.
     pub aziot_certd: Connector,
@@ -348,7 +348,7 @@ impl Default for Endpoints {
 }
 
 /// Map of a Unix UID to certificate IDs with write access.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Principal {
     /// Unix UID.
     pub uid: libc::uid_t,

--- a/cert/cert-renewal/src/lib.rs
+++ b/cert/cert-renewal/src/lib.rs
@@ -47,7 +47,7 @@ fn test_cert(not_before: i64, not_after: i64) -> openssl::x509::X509 {
 }
 
 /// Common settings for configuring auto-renewal.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AutoRenewConfig {
     /// Whether to rotate the key. This requires temporary storage for a second
     /// key during credential rotation. Defaults to `true`.

--- a/cert/cert-renewal/src/policy.rs
+++ b/cert/cert-renewal/src/policy.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct RenewalPolicy {
     pub threshold: Policy,
@@ -8,7 +8,7 @@ pub struct RenewalPolicy {
 }
 
 /// Determines the policy for certificate renewal and retries.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Policy {
     /// Renew and retry as a percentage of the certificate's lifetime.
     /// This value is always between 0 and 100.

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -9,7 +9,7 @@ pub const SOCKET_DEFAULT_PERMISSION: u32 = 0o660;
 
 const SD_LISTEN_FDS_START: std::os::unix::io::RawFd = 3;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Connector {
     Tcp {
         host: std::sync::Arc<str>,

--- a/identity/aziot-identity-common/src/lib.rs
+++ b/identity/aziot-identity-common/src/lib.rs
@@ -194,14 +194,14 @@ impl From<Credentials> for AuthenticationInfo {
 }
 
 pub mod hub {
-    #[derive(Clone, Copy, Debug, serde::Deserialize, PartialEq, serde::Serialize)]
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     pub enum AuthType {
         None,
         Sas,
         X509,
     }
-    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+    #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct X509Thumbprint {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -210,7 +210,7 @@ pub mod hub {
         pub secondary_thumbprint: Option<String>,
     }
 
-    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+    #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct SymmetricKey {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -219,7 +219,7 @@ pub mod hub {
         pub secondary_key: Option<http_common::ByteString>,
     }
 
-    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+    #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct AuthMechanism {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -232,7 +232,7 @@ pub mod hub {
         pub type_: Option<AuthType>,
     }
 
-    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+    #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Module {
         pub module_id: String,

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -178,7 +178,7 @@ pub enum ProvisioningType {
     None,
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Payload {
     pub uri: url::Url,
 }

--- a/identity/aziot-identityd/src/auth/mod.rs
+++ b/identity/aziot-identityd/src/auth/mod.rs
@@ -6,7 +6,7 @@ pub mod authentication;
 pub mod authorization;
 
 /// Authenticated user types
-#[derive(Clone, PartialOrd, PartialEq)]
+#[derive(Clone, Eq, PartialEq, PartialOrd)]
 pub enum AuthId {
     Unknown,
 
@@ -18,7 +18,7 @@ pub enum AuthId {
 }
 
 /// Operation types to be authorized
-#[derive(Clone, PartialOrd, PartialEq)]
+#[derive(Clone, Eq, PartialEq, PartialOrd)]
 pub enum OperationType {
     GetModule(String),
     GetAllHubModules,

--- a/key/aziot-keyd-config/src/lib.rs
+++ b/key/aziot-keyd-config/src/lib.rs
@@ -4,7 +4,7 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::default_trait_access)]
 
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Config {
     /// Maximum number of simultaneous requests per user that keyd will service.
     #[serde(
@@ -39,7 +39,7 @@ pub struct Config {
 }
 
 /// Map of service names to endpoint URIs.
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Endpoints {
     /// The endpoint that the keyd service binds to.
     pub aziot_keyd: http_common::Connector,
@@ -56,7 +56,7 @@ impl Default for Endpoints {
 }
 
 /// Map of a Unix UID to key IDs with access.
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Principal {
     /// Unix UID.
     pub uid: libc::uid_t,

--- a/pkcs11/pkcs11/src/lib.rs
+++ b/pkcs11/pkcs11/src/lib.rs
@@ -33,14 +33,14 @@ pub use session::{
     GetKeyError, ImportKeyError, Key, KeyPair, KeyUsage, LoginError, PublicKey, Session,
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Uri {
     pub slot_identifier: UriSlotIdentifier,
     pub object_label: Option<String>,
     pub pin: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UriSlotIdentifier {
     Label(String),
     SlotId(pkcs11_sys::CK_SLOT_ID),
@@ -54,7 +54,7 @@ impl std::fmt::Display for Uri {
             UriSlotIdentifier::Label(token_label) => {
                 write!(f, "token=")?;
                 let value = percent_encoding::utf8_percent_encode(
-                    &*token_label,
+                    &**token_label,
                     percent_encoding::NON_ALPHANUMERIC,
                 );
                 for s in value {
@@ -78,7 +78,7 @@ impl std::fmt::Display for Uri {
         if let Some(object_label) = &self.object_label {
             write!(f, ";object=")?;
             let value = percent_encoding::utf8_percent_encode(
-                &*object_label,
+                &**object_label,
                 percent_encoding::NON_ALPHANUMERIC,
             );
             for s in value {
@@ -89,7 +89,7 @@ impl std::fmt::Display for Uri {
         if let Some(pin) = &self.pin {
             write!(f, "?pin-value=")?;
             let value =
-                percent_encoding::utf8_percent_encode(&*pin, percent_encoding::NON_ALPHANUMERIC);
+                percent_encoding::utf8_percent_encode(&**pin, percent_encoding::NON_ALPHANUMERIC);
             for s in value {
                 write!(f, "{}", s)?;
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.62"
+channel = "1.63"
 components = ["clippy", "rustfmt"]

--- a/tpm/aziot-tpmd-config/src/lib.rs
+++ b/tpm/aziot-tpmd-config/src/lib.rs
@@ -18,7 +18,7 @@ const fn valid_persistent_index(index: u32) -> bool {
     index <= 0x7F_FF_FF
 }
 
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Config {
     /// Maximum number of simultaneous requests per user that tpmd will service.
     #[serde(
@@ -39,7 +39,7 @@ pub struct Config {
 }
 
 // NOTE: For sharing with super-config
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SharedConfig {
     #[serde(default = "default_tcti", skip_serializing_if = "is_default_tcti")]
     pub tcti: std::ffi::CString,
@@ -65,7 +65,7 @@ impl Default for SharedConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TpmAuthConfig {
     #[serde(default, skip_serializing_if = "empty_cstr")]
     pub endorsement: std::ffi::CString,
@@ -110,7 +110,7 @@ where
 }
 
 /// Map of service names to endpoint URIs.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Endpoints {
     /// The endpoint that the tpmd service binds to.
     pub aziot_tpmd: http_common::Connector,


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- `clippy::borrow_deref_ref`: add additional dereference
- `clippy::derive_partial_eq_without_eq`: derive `Eq` where possible

[^0]: https://github.com/rust-lang/rust/blob/1.48.0/RELEASES.md#compatibility-notes
  Namely, the point on `mem::uninitialized`.