### PR TITLE
Upgrade to Rust 1.64

### DIFF
--- a/aziotctl/src/internal/check/checks/certs_match_private_keys.rs
+++ b/aziotctl/src/internal/check/checks/certs_match_private_keys.rs
@@ -21,18 +21,12 @@ impl Checker for CertsMatchPrivateKeys {
     }
 
     async fn execute(&mut self, shared: &CheckerShared, cache: &mut CheckerCache) -> CheckResult {
-        self.inner_execute(shared, cache)
-            .await
-            .unwrap_or_else(CheckResult::Failed)
+        Self::inner_execute(shared, cache).unwrap_or_else(CheckResult::Failed)
     }
 }
 
 impl CertsMatchPrivateKeys {
-    async fn inner_execute(
-        &mut self,
-        _shared: &CheckerShared,
-        cache: &mut CheckerCache,
-    ) -> Result<CheckResult> {
+    fn inner_execute(_shared: &CheckerShared, cache: &mut CheckerCache) -> Result<CheckResult> {
         if !cache.daemons_running.certd || !cache.daemons_running.keyd {
             return Ok(CheckResult::Skipped);
         }

--- a/aziotctl/src/internal/check/checks/est_server_https.rs
+++ b/aziotctl/src/internal/check/checks/est_server_https.rs
@@ -18,18 +18,12 @@ impl Checker for EstServerHttps {
     }
 
     async fn execute(&mut self, shared: &CheckerShared, cache: &mut CheckerCache) -> CheckResult {
-        self.inner_execute(shared, cache)
-            .await
-            .unwrap_or_else(CheckResult::Failed)
+        Self::inner_execute(shared, cache).unwrap_or_else(CheckResult::Failed)
     }
 }
 
 impl EstServerHttps {
-    async fn inner_execute(
-        &mut self,
-        _shared: &CheckerShared,
-        cache: &mut CheckerCache,
-    ) -> Result<CheckResult> {
+    fn inner_execute(_shared: &CheckerShared, cache: &mut CheckerCache) -> Result<CheckResult> {
         let aziot_certd_config::Config { cert_issuance, .. } = unwrap_or_skip!(&cache.cfg.certd);
 
         if !cache.daemons_running.certd {

--- a/aziotctl/src/internal/check/checks/host_local_time.rs
+++ b/aziotctl/src/internal/check/checks/host_local_time.rs
@@ -21,13 +21,12 @@ impl Checker for HostLocalTime {
 
     async fn execute(&mut self, shared: &CheckerShared, cache: &mut CheckerCache) -> CheckResult {
         self.execute_inner(shared, cache)
-            .await
             .unwrap_or_else(CheckResult::Failed)
     }
 }
 
 impl HostLocalTime {
-    async fn execute_inner(
+    fn execute_inner(
         &mut self,
         shared: &CheckerShared,
         _cache: &mut CheckerCache,

--- a/aziotctl/src/internal/check/checks/hostname.rs
+++ b/aziotctl/src/internal/check/checks/hostname.rs
@@ -24,13 +24,12 @@ impl Checker for Hostname {
 
     async fn execute(&mut self, shared: &CheckerShared, cache: &mut CheckerCache) -> CheckResult {
         self.execute_inner(shared, cache)
-            .await
             .unwrap_or_else(CheckResult::Failed)
     }
 }
 
 impl Hostname {
-    async fn execute_inner(
+    fn execute_inner(
         &mut self,
         _shared: &CheckerShared,
         cache: &mut CheckerCache,

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -751,7 +751,7 @@ pub(crate) fn get_cert_inner(
                     result.extend_from_slice(&bytes);
                 }
             }
-            Ok((!result.is_empty()).then(|| result))
+            Ok((!result.is_empty()).then_some(result))
         }
     }
 }

--- a/cert/aziot-certd/src/renewal.rs
+++ b/cert/aziot-certd/src/renewal.rs
@@ -67,7 +67,7 @@ impl EstIdRenewal {
         })
     }
 
-    async fn load_keys(
+    fn load_keys(
         &self,
         key_handle: aziot_key_common::KeyHandle,
     ) -> Result<
@@ -175,7 +175,6 @@ impl cert_renewal::CertInterface for EstIdRenewal {
 
         let (est_id_key, _) = self
             .load_keys(est_id_key)
-            .await
             .map_err(|_| cert_renewal::Error::retryable_error("failed to load EST auth key"))?;
 
         // Generate a new key if needed. Otherwise, retrieve the existing key.
@@ -206,7 +205,7 @@ impl cert_renewal::CertInterface for EstIdRenewal {
             (key_id.to_string(), key_handle)
         };
 
-        let keys = self.load_keys(key_handle).await?;
+        let keys = self.load_keys(key_handle)?;
 
         let cert = {
             let est_config = self.est_config.read().await;

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -508,6 +508,9 @@ impl Api {
         })
     }
 
+    // NOTE: clippy::unused_async is allowed since the the function will
+    // likely require async in the (now unlikely) event we implement it.
+    #[allow(clippy::unused_async)]
     pub async fn get_trust_bundle(
         &self,
         auth_id: auth::AuthId,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.63"
+channel = "1.64"
 components = ["clippy", "rustfmt"]

--- a/test-common/src/client/identity.rs
+++ b/test-common/src/client/identity.rs
@@ -44,6 +44,9 @@ impl Default for IdentityClient {
     }
 }
 
+// NOTE: Since these functions are substituted for the real functions at
+// compile time for testing, "async" is necessary.
+#[allow(clippy::unused_async)]
 impl IdentityClient {
     #[allow(clippy::needless_pass_by_value)]
     pub fn new(

--- a/test-common/src/client/key.rs
+++ b/test-common/src/client/key.rs
@@ -25,6 +25,9 @@ impl Default for KeyClient {
     }
 }
 
+// NOTE: Since these functions are substituted for the real functions at
+// compile time for testing, "async" is necessary.
+#[allow(clippy::unused_async)]
 impl KeyClient {
     pub async fn create_key_if_not_exists(
         &self,


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- `clippy::unnecessary_lazy_evaluations`: replace `${bool}.then(|| ${value})` with `${bool}.then_some(${value})`
- `clippy::unused_async`: remove `async` where functions are fully implemented and unlikely to change, otherwise allow with inline note explaining why lint is allowed
- `clippy::unused_self`: change methods to associated functions

[^0]: https://github.com/rust-lang/rust/blob/1.48.0/RELEASES.md#compatibility-notes
  Namely, the point on `mem::uninitialized`.