### PR TITLE
Changed to use Mariner 2.0-Stable

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -42,9 +42,9 @@ jobs:
         - container_os: 'ubuntu:18.04'
           arch: 'amd64'
           os: 'mariner:1'
-        # - container_os: 'ubuntu:18.04'
-        #   arch: 'amd64'
-        #   os: 'mariner:2'
+        - container_os: 'ubuntu:18.04'
+          arch: 'amd64'
+          os: 'mariner:2'
 
     steps:
     - uses: 'actions/checkout@v1'

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -271,9 +271,7 @@ case "$OS:$ARCH" in
                 BranchTag='1.0-stable'
                 ;;
             'mariner:2')
-                # BranchTag='2.0-stable'
-                # WARN: 2.0-stable is broken - https://github.com/microsoft/CBL-Mariner/issues/3483
-                BranchTag='2.0.20220713-2.0'
+                BranchTag='2.0-stable'
                 ;;
         esac
 


### PR DESCRIPTION
A fix was recently checked into the mariner 2.0 branch which allows us to build using 2.0-stable now. 