### PR TITLE
Mainer Build to use Ubuntu 20.04 - release/1.4 branch

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -39,10 +39,10 @@ jobs:
           arch: 'aarch64'
         # Include this for mariner package builds. Mariner cannot be built on its own OS so we need an Ubuntu container.
         include:
-        - container_os: 'ubuntu:18.04'
+        - container_os: 'ubuntu:20.04'
           arch: 'amd64'
           os: 'mariner:1'
-        - container_os: 'ubuntu:18.04'
+        - container_os: 'ubuntu:20.04'
           arch: 'amd64'
           os: 'mariner:2'
 

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -258,7 +258,7 @@ case "$OS:$ARCH" in
         apt-get install -y \
             cmake curl gcc g++ git jq make pkg-config \
             libclang1 libssl-dev llvm-dev \
-            cpio genisoimage golang-1.17-go qemu-utils pigz python-pip python3-distutils rpm tar wget
+            cpio genisoimage golang-1.17-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
         rm -f /usr/bin/go
         ln -vs /usr/lib/go-1.17/bin/go /usr/bin/go


### PR DESCRIPTION
Updates the Mariner build to use Ubuntu 20.04 for its package build.