### PR TITLE
Fix E2E test failures

### DIFF
--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -69,13 +69,16 @@ jobs:
         # - 'platform:el8'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
-        # The scheduled E2E test in the release/1.x branch fails until the changes are merged. Disabling for now.
-        #- 'ubuntu:22.04'
+        - 'ubuntu:22.04'
         test_name:
         - 'manual-symmetric-key'
         - 'manual-x509'
         - 'dps-symmetric-key'
         - 'dps-x509'
+        exclude:
+          # The scheduled E2E test in the release/1.x branch would fail until the changes are merged. Excluding for now.
+          - os: 'ubuntu:22.04'
+            branch: 'release/1.4'
 
       max-parallel: 10
 

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         branch:
         - 'main'
-        - 'release/1.3'
+        - 'release/1.4'
 
       max-parallel: 10
 
@@ -60,7 +60,7 @@ jobs:
       matrix:
         branch:
         - 'main'
-        - 'release/1.3'
+        - 'release/1.4'
         os:
         - 'centos:7'
         - 'debian:10'
@@ -69,7 +69,8 @@ jobs:
         # - 'platform:el8'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
-        - 'ubuntu:22.04'
+        # The scheduled E2E test in the release/1.x branch fails until the changes are merged. Disabling for now.
+        #- 'ubuntu:22.04'
         test_name:
         - 'manual-symmetric-key'
         - 'manual-x509'
@@ -128,7 +129,7 @@ jobs:
       matrix:
         branch:
         - 'main'
-        - 'release/1.3'
+        - 'release/1.4'
 
       max-parallel: 10
 
@@ -161,7 +162,7 @@ jobs:
       matrix:
         branch:
         - 'main'
-        - 'release/1.3'
+        - 'release/1.4'
 
       max-parallel: 10
 

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -603,14 +603,14 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'Canonical' --offer '0001-com-ubuntu-server-focal' --sku '20' \
         #     --query "[?publisher == 'Canonical' && offer == '0001-com-ubuntu-server-focal'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202209130'
+        vm_image='Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202210180'
         ;;
 
     'ubuntu:22.04')
         # az vm image list --all \
         #     --publisher 'Canonical' --offer '0001-com-ubuntu-minimal-jammy' --sku 'minimal-22' \
         #     --query "[?publisher == 'Canonical' && offer == '0001-com-ubuntu-minimal-jammy'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts-gen2:22.04.202209210'
+        vm_image='Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts-gen2:22.04.202210180'
         ;;
 
      *)

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -553,7 +553,7 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'OpenLogic' --offer 'CentOS' --sku '7' \
         #     --query "[?publisher == 'OpenLogic' && offer == 'CentOS'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='OpenLogic:CentOS:7_9-gen2:7.9.2022020701'
+        vm_image='OpenLogic:CentOS:7_9-gen2:latest'
         ;;
 
     'debian:10')
@@ -562,7 +562,7 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'Debian' --offer 'debian-10' --sku '10' \
         #     --query "[?publisher == 'Debian' && offer == 'debian-10'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Debian:debian-10:10-gen2:0.20220328.962'
+        vm_image='Debian:debian-10:10-gen2:latest'
         ;;
 
     'debian:11')
@@ -571,7 +571,7 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'Debian' --offer 'debian-11' --sku '11-gen2' \
         #     --query "[?publisher == 'Debian' && offer == 'debian-11'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Debian:debian-11:11-gen2:0.20220328.962'
+        vm_image='Debian:debian-11:11-gen2:latest'
         ;;
 
     'platform:el8')
@@ -584,14 +584,14 @@ case "$OS" in
         #    az vm image terms accept --urn "$vm_image"
         #
         # The Azure SP does not have permissions to do this. Use your regular Azure account.
-        vm_image='almalinux:almalinux:8_4-gen2:8.4.20210729'
+        vm_image='almalinux:almalinux:8_4-gen2:latest'
         ;;
 
     'ubuntu:18.04')
         # az vm image list --all \
         #     --publisher 'Canonical' --offer 'UbuntuServer' --sku '18' \
         #     --query "[?publisher == 'Canonical' && offer == 'UbuntuServer'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Canonical:UbuntuServer:18_04-lts-gen2:18.04.202204190'
+        vm_image='Canonical:UbuntuServer:18_04-lts-gen2:latest'
         ;;
 
     'ubuntu:20.04')
@@ -603,14 +603,14 @@ case "$OS" in
         # az vm image list --all \
         #     --publisher 'Canonical' --offer '0001-com-ubuntu-server-focal' --sku '20' \
         #     --query "[?publisher == 'Canonical' && offer == '0001-com-ubuntu-server-focal'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202210180'
+        vm_image='Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest'
         ;;
 
     'ubuntu:22.04')
         # az vm image list --all \
         #     --publisher 'Canonical' --offer '0001-com-ubuntu-minimal-jammy' --sku 'minimal-22' \
         #     --query "[?publisher == 'Canonical' && offer == '0001-com-ubuntu-minimal-jammy'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts-gen2:22.04.202210180'
+        vm_image='Canonical:0001-com-ubuntu-minimal-jammy:minimal-22_04-lts-gen2:latest'
         ;;
 
      *)

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -39,7 +39,8 @@ override_dh_auto_install:
 	esac; \
 	case "$$(openssl version)" in \
 	    'OpenSSL 3.0.'*) engines_dir="/usr/lib/$$arch_libdir/engines-3";; \
-		'*') engines_dir="/usr/lib/$$arch_libdir/engines-1.1"; exit1;; \
+	    'OpenSSL 1.1.'*) engines_dir="/usr/lib/$$arch_libdir/engines-1.1";; \
+		'*') exit 1;; \
 	esac; \
 	make -j \
 		DESTDIR="$$PWD/debian/aziot-identity-service" \


### PR DESCRIPTION
Errors addressed:
1. contrib/debian/rules wasn't setting the correct engines libdir for openssl 1.1
2. scheduled E2E test runs on the release/1.x branch don't know about Ubuntu 22.04 yet and complain it isn't known and error out
3. accidentally changed the vm_image for Ubuntu 20.04 in a prior change.  updating it and 22.04 to the most recent VM image for each respectively.

Sidenote: Including a change to have the E2E tests targeting the release/1.4 branch instead of release/1.3.