### PR TITLE
Use github environment files

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -79,7 +79,7 @@ jobs:
           os_package="$OS"
         fi
         os_package="$(sed -e 's@[:/]@-@g' <<< "$os_package")"
-        echo "::set-output name=artifact-name::packages_${os_package}_${{ matrix.arch }}"
+        echo "artifact-name=packages_${os_package}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
     - name: 'Upload'
       uses: 'actions/upload-artifact@v1'
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,14 +45,14 @@ jobs:
       run: |
         container_os="${{ matrix.container_os }}"
         container_os="$(sed -e 's@[:/]@-@g' <<< "$container_os")"
-        echo "::set-output name=artifact-name::test-artifacts_${container_os}_${{ matrix.arch }}"
+        echo "artifact-name=test-artifacts_${container_os}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
         case "${{ matrix.arch }}" in
           'amd64') target_dir='x86_64-unknown-linux-gnu' ;;
           'arm32v7') target_dir='armv7-unknown-linux-gnueabihf' ;;
           'aarch64') target_dir='aarch64-unknown-linux-gnu' ;;
         esac
-        echo "::set-output name=target_dir::$target_dir"
+        echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Upload'
       uses: 'actions/upload-artifact@v2'
       with:
@@ -103,14 +103,14 @@ jobs:
       run: |
         container_os="${{ matrix.container_os }}"
         container_os="$(sed -e 's@[:/]@-@g' <<< "$container_os")"
-        echo "::set-output name=artifact-name::test-artifacts_${container_os}_${{ matrix.arch }}"
+        echo "artifact-name=test-artifacts_${container_os}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
         case "${{ matrix.arch }}" in
           'amd64') target_dir='x86_64-unknown-linux-gnu' ;;
           'arm32v7') target_dir='armv7-unknown-linux-gnueabihf' ;;
           'aarch64') target_dir='aarch64-unknown-linux-gnu' ;;
         esac
-        echo "::set-output name=target_dir::$target_dir"
+        echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
       uses: 'actions/download-artifact@v2'
@@ -157,14 +157,14 @@ jobs:
       run: |
         container_os="${{ matrix.container_os }}"
         container_os="$(sed -e 's@[:/]@-@g' <<< "$container_os")"
-        echo "::set-output name=artifact-name::test-artifacts_${container_os}_${{ matrix.arch }}"
+        echo "artifact-name=test-artifacts_${container_os}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
         case "${{ matrix.arch }}" in
           'amd64') target_dir='x86_64-unknown-linux-gnu' ;;
           'arm32v7') target_dir='armv7-unknown-linux-gnueabihf' ;;
           'aarch64') target_dir='aarch64-unknown-linux-gnu' ;;
         esac
-        echo "::set-output name=target_dir::$target_dir"
+        echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
       uses: 'actions/download-artifact@v2'


### PR DESCRIPTION
The "Actions" tab for the repo spews a lot of warnings about `::set-output` being deprecated by Apr 2023.  Updating the workflow to use the [new environment file](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) - mainly so I don't have to scroll down as far to find the build collateral from a given packages run.