### PR TITLE
[certd] Fix panic when truncating certificate CN

### DIFF
--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -386,12 +386,13 @@ mod tests {
     fn common_name_truncation_does_not_panic() {
         let long_name_unicode_boundary =
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaá";
-        let expected_truncation =
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let expected_truncation = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
         let expected_x509 = {
             let mut builder = openssl::x509::X509Name::builder().unwrap();
-            builder.append_entry_by_nid(openssl::nid::Nid::COMMONNAME, expected_truncation).unwrap();
+            builder
+                .append_entry_by_nid(openssl::nid::Nid::COMMONNAME, expected_truncation)
+                .unwrap();
             builder.build()
         };
         let common_name = CertSubject::CommonName(long_name_unicode_boundary.to_owned());

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -253,7 +253,8 @@ impl std::convert::TryFrom<&CertSubject> for openssl::x509::X509Name {
 
         match subject {
             CertSubject::CommonName(cn) => {
-                builder.append_entry_by_nid(openssl::nid::Nid::COMMONNAME, truncate_cn_length(cn))?;
+                builder
+                    .append_entry_by_nid(openssl::nid::Nid::COMMONNAME, truncate_cn_length(cn))?;
             }
             CertSubject::Subject(fields) => {
                 for (name, value) in fields {

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -380,8 +380,9 @@ mod tests {
     #[test]
     fn common_name_truncation_does_not_panic() {
         let long_name_unicode_boundary =
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaáa";
+        let expected_truncation =
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaá";
-        let expected_truncation = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
         let expected_x509 = {
             let mut builder = openssl::x509::X509Name::builder().unwrap();

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -258,6 +258,14 @@ impl std::convert::TryFrom<&CertSubject> for openssl::x509::X509Name {
             }
             CertSubject::Subject(fields) => {
                 for (name, value) in fields {
+                    // NOTE: Size limits exist for other X509Name fields as
+                    // well [RFC5280].  We only truncate the Common Name since
+                    // we have only encountered customer issues with Common Name
+                    // length so far [1, 2].
+                    //
+                    // Ref[RFC5280]: https://www.rfc-editor.org/rfc/rfc5280
+                    // Ref[1]: https://github.com/Azure/iotedge/issues/6288
+                    // Ref[2]: https://github.com/Azure/iot-identity-service/pull/411#discussion_r871640144
                     if name.eq_ignore_ascii_case("cn") {
                         builder.append_entry_by_text(name, truncate_cn_length(value))?;
                     } else {

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -238,6 +238,9 @@ impl std::convert::TryFrom<&CertSubject> for openssl::x509::X509Name {
                 cn.len()
             } else {
                 let lower_bound = CN_MAX_LENGTH.saturating_sub(3);
+                // NOTE: RangeInclusive<usize> does not implement
+                // ExactSizeIterator (!?), so we cannot use rposition as is done
+                // in floor_char_boundary.
                 let new_index = (lower_bound..=CN_MAX_LENGTH)
                     .filter(|&i| cn.is_char_boundary(i))
                     .last();

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -245,7 +245,7 @@ impl std::convert::TryFrom<&CertSubject> for openssl::x509::X509Name {
                     .filter(|&i| cn.is_char_boundary(i))
                     .last();
                 // SAFETY: we know that the character boundary will be within four bytes
-                &cn[..unsafe { lower_bound + new_index.unwrap_unchecked() }]
+                &cn[..unsafe { new_index.unwrap_unchecked() }]
             }
         }
 


### PR DESCRIPTION
[`String::truncate`](https://doc.rust-lang.org/std/string/struct.String.html#method.truncate) panics when the truncation point is not at a valid UTF-8 character boundary.  To fix this, take at most 64 characters from the parsed CN string before setting the X509 CN field.