### PR TITLE
Scheduled E2E Tests: Fix Function app name conflict

### DIFF
--- a/ci/e2e-tests/suite-common.sh
+++ b/ci/e2e-tests/suite-common.sh
@@ -26,5 +26,5 @@ echo "suite_common_resource_name: $suite_common_resource_name" >&2
 
 # Variables related to the DPS custom allocation policy
 dps_allocation_function_name='DpsCustomAllocation'
-dps_allocation_functionapp_name="AllocApp${GITHUB_RUN_ID}r${GITHUB_RUN_NUMBER}"
+dps_allocation_functionapp_name="alloc-app-${suite_common_resource_name}"
 foo_devices_iot_hub="${suite_common_resource_name}-foo-devices"


### PR DESCRIPTION
Fixes the E2E tests that are currently failing because main and release/1.4 jobs are running concurrently using the same function app name. This changes the function app name to include the branch name.