### PR TITLE
[identityd] Fix certificate subject propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "cert-renewal",
  "http-common",
  "libc",
+ "openssl",
  "serde",
  "serde_json",
  "toml",

--- a/identity/aziot-identityd-config/Cargo.toml
+++ b/identity/aziot-identityd-config/Cargo.toml
@@ -10,14 +10,15 @@ edition = "2021"
 
 
 [dependencies]
-http-common = { path = "../../http-common" }
 libc = "0.2"
+openssl = "0.10"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
+serde_json = "1"
 url = { version = "2", features = ["serde"] }
 
 aziot-identity-common = { path = "../aziot-identity-common" }
 cert-renewal = { path = "../../cert/cert-renewal"}
+http-common = { path = "../../http-common" }
 
 [dev-dependencies]
 toml = "0.5"

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -229,7 +229,7 @@ pub struct Provisioning {
 pub enum ProvisioningType {
     Manual {
         iothub_hostname: String,
-        device_id: CsrSubject,
+        device_id: String,
         authentication: ManualAuthMethod,
     },
     Dps {

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -611,10 +611,19 @@ impl IdentityManager {
                         identity_cert,
                         identity_pk,
                     } => {
+                        let device_id = device_id.clone();
                         self.get_identity_credentials(
                             &identity_pk,
                             &identity_cert,
-                            csr_subject.as_ref(),
+                            Some(&match csr_subject {
+                                Some(config::CsrSubject::Subject { rest, .. }) => {
+                                    config::CsrSubject::Subject {
+                                        cn: device_id,
+                                        rest,
+                                    }
+                                }
+                                _ => config::CsrSubject::CommonName(device_id),
+                            }),
                         )
                         .await?
                     }
@@ -625,7 +634,7 @@ impl IdentityManager {
                         .clone()
                         .unwrap_or_else(|| iothub_hostname.clone()),
                     iothub_hostname,
-                    device_id: device_id.common_name().to_owned(),
+                    device_id,
                     credentials,
                 };
                 self.set_device(&device);

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -120,7 +120,7 @@ pub async fn main(
             auto_renew.rotate_key,
             &identity_cert,
             &identity_pk,
-            registration_id.as_deref(),
+            registration_id.as_ref(),
             api.clone(),
         )
         .await?;
@@ -306,22 +306,23 @@ impl Api {
                         ..
                     } => {
                         let registration_id = if let Some(registration_id) = registration_id {
-                            registration_id.to_string()
+                            registration_id.common_name().to_owned()
                         } else {
                             // Get the registration ID from the identity certificate if it was not provided
                             // in the config.
-                            let identity_cert = self
-                                .cert_client
-                                .get_cert(identity_cert)
-                                .await
-                                .map_err(|err| {
-                                    Error::Internal(InternalError::CreateCertificate(err.into()))
-                                })?;
+                            let identity_cert =
+                                self.cert_client.get_cert(identity_cert).await.map_err(
+                                    |err| {
+                                        Error::Internal(InternalError::CreateCertificate(
+                                            err.into(),
+                                        ))
+                                    },
+                                )?;
 
                             let identity_cert = openssl::x509::X509::from_pem(&identity_cert)
                                 .map_err(|err| {
-                                    Error::Internal(InternalError::CreateCertificate(err.into()))
-                                })?;
+                                Error::Internal(InternalError::CreateCertificate(err.into()))
+                            })?;
 
                             let cert_subject = identity_cert
                                 .subject_name()
@@ -678,8 +679,15 @@ impl Api {
                 "{}.{}.{}",
                 module_id, self.settings.hostname, localid.domain
             );
-            let csr = create_csr(&subject, &public_key, &private_key, Some(attributes))
+            let subject = openssl::x509::X509Name::try_from(&config::CsrSubject::CommonName(subject))
                 .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
+            let csr = create_csr(
+                &subject,
+                &public_key,
+                &private_key,
+                Some(attributes),
+            )
+            .map_err(|err| Error::Internal(InternalError::CreateCertificate(Box::new(err))))?;
             let certificate = self
                 .cert_client
                 .create_cert(module_id, &csr, None)
@@ -784,7 +792,7 @@ pub(crate) async fn get_keys(
 }
 
 pub(crate) fn create_csr(
-    subject: &str,
+    subject: &openssl::x509::X509NameRef,
     public_key: &openssl::pkey::PKeyRef<openssl::pkey::Public>,
     private_key: &openssl::pkey::PKeyRef<openssl::pkey::Private>,
     attributes: Option<aziot_identity_common::LocalIdAttr>,
@@ -829,16 +837,11 @@ pub(crate) fn create_csr(
         csr.add_extensions(&extensions)?;
     }
 
-    let mut subject_name = openssl::x509::X509Name::builder()?;
-    subject_name.append_entry_by_nid(openssl::nid::Nid::COMMONNAME, subject)?;
-    let subject_name = subject_name.build();
-    csr.set_subject_name(&subject_name)?;
+    csr.set_subject_name(subject)?;
     csr.set_pubkey(public_key)?;
     csr.sign(private_key, openssl::hash::MessageDigest::sha256())?;
 
-    let csr = csr.build();
-    let csr = csr.to_pem()?;
-    Ok(csr)
+    csr.build().to_pem()
 }
 
 pub struct SettingsAuthenticator {

--- a/identity/aziot-identityd/src/renewal.rs
+++ b/identity/aziot-identityd/src/renewal.rs
@@ -69,15 +69,15 @@ impl IdentityCertRenewal {
                     crate::Error::Internal(crate::InternalError::CreateCertificate(err.into()))
                 })?;
 
-            let subject = openssl::x509::X509Name::try_from(registration_id)
-                .map_err(|err| crate::Error::Internal(crate::InternalError::CreateCertificate(err.into())))?;
-            let csr = crate::create_csr(&subject, &public_key, &private_key, None).map_err(
-                |_| {
+            let subject = openssl::x509::X509Name::try_from(registration_id).map_err(|err| {
+                crate::Error::Internal(crate::InternalError::CreateCertificate(err.into()))
+            })?;
+            let csr =
+                crate::create_csr(&subject, &public_key, &private_key, None).map_err(|_| {
                     crate::Error::Internal(crate::InternalError::CreateCertificate(
                         "failed to generate csr".into(),
                     ))
-                },
-            )?;
+                })?;
 
             cert_client
                 .create_cert(cert_id, &csr, None)

--- a/identity/aziot-identityd/src/renewal.rs
+++ b/identity/aziot-identityd/src/renewal.rs
@@ -18,7 +18,7 @@ impl IdentityCertRenewal {
         rotate_key: bool,
         cert_id: &str,
         key_id: &str,
-        registration_id: Option<&str>,
+        registration_id: Option<&aziot_identityd_config::CsrSubject>,
         api: Arc<futures_util::lock::Mutex<crate::Api>>,
     ) -> Result<Self, crate::Error> {
         let (cert_client, key_client, key_engine) = {
@@ -69,7 +69,9 @@ impl IdentityCertRenewal {
                     crate::Error::Internal(crate::InternalError::CreateCertificate(err.into()))
                 })?;
 
-            let csr = crate::create_csr(registration_id, &public_key, &private_key, None).map_err(
+            let subject = openssl::x509::X509Name::try_from(registration_id)
+                .map_err(|err| crate::Error::Internal(crate::InternalError::CreateCertificate(err.into())))?;
+            let csr = crate::create_csr(&subject, &public_key, &private_key, None).map_err(
                 |_| {
                     crate::Error::Internal(crate::InternalError::CreateCertificate(
                         "failed to generate csr".into(),
@@ -181,18 +183,7 @@ impl cert_renewal::CertInterface for IdentityCertRenewal {
             .map_err(cert_renewal::Error::retryable_error)?;
 
         // Determine the subject of the old cert. This will be the subject of the new cert.
-        let subject = if let Some(subject) = old_cert_chain[0]
-            .subject_name()
-            .entries_by_nid(openssl::nid::Nid::COMMONNAME)
-            .next()
-        {
-            String::from_utf8(subject.data().as_slice().into())
-                .map_err(|_| cert_renewal::Error::fatal_error("bad cert subject"))?
-        } else {
-            return Err(cert_renewal::Error::fatal_error(
-                "cannot determine subject for csr",
-            ));
-        };
+        let subject = old_cert_chain[0].subject_name();
 
         // Generate a CSR and issue the new cert under a temporary cert ID. The temporary ID
         // does not need to be persisted, so delete it after the cert is succesfully created.


### PR DESCRIPTION
Certificate subject configuration options for EST-issued certificates were not being propagated to identityd, which meant that CSRs to issue a certificate would not be generated with the configured certificate subject.  Add additional configuration options to identityd to receive a CSR subject configuration and adjust `aziotctl config apply` to hydrate these options with the certificate issuance options extracted for `certd`.