### PR TITLE
Fix scheduled E2E test by adding branch name to storage account name

### DIFF
--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -94,10 +94,9 @@ setupCustomAllocationPolicy() {
         dotnet add package Microsoft.Azure.Devices.Provisioning.Service -v 1.16.3
         dotnet add package Microsoft.Azure.Devices.Shared -v 1.27.0
 
-        # Create storeage account needed by function app
-        sa_name="sa${GITHUB_RUN_ID}r${GITHUB_RUN_NUMBER}"
+        # Create storage account needed by function app
         az storage account create \
-            --name $sa_name \
+            --name "$dps_allocation_storage_account" \
             --location $AZURE_LOCATION \
             --resource-group $AZURE_RESOURCE_GROUP_NAME \
             --sku Standard_LRS \
@@ -111,7 +110,7 @@ setupCustomAllocationPolicy() {
             --functions-version 3 \
             --name "$dps_allocation_functionapp_name" \
             --disable-app-insights \
-            --storage-account $sa_name \
+            --storage-account "$dps_allocation_storage_account" \
             --tags "suite_id=$suite_id"
 
         # Publishing the app sometimes fails, so retry up to 3 times

--- a/ci/e2e-tests/suite-common.sh
+++ b/ci/e2e-tests/suite-common.sh
@@ -28,3 +28,4 @@ echo "suite_common_resource_name: $suite_common_resource_name" >&2
 dps_allocation_function_name='DpsCustomAllocation'
 dps_allocation_functionapp_name="alloc-app-${suite_common_resource_name}"
 foo_devices_iot_hub="${suite_common_resource_name}-foo-devices"
+dps_allocation_storage_account="$(printf '%s' "$suite_id" | tr '[:upper:]' '[:lower:]' | tr -d -C 'a-z0-9')"


### PR DESCRIPTION
Follow-on to PR #473. This fixes an additional place where the scheduled E2E tests fail because of naming conflicts when running tests on main and release/1.4 concurrently. Specifically, this adds the branch name to the storage account name to make it unique.