### PR TITLE
many: allow build-time setting of the socket directory

### DIFF
--- a/aziotctl/.cargo/config.toml
+++ b/aziotctl/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+SOCKET_DIR = "/run/aziot"

--- a/aziotctl/src/system.rs
+++ b/aziotctl/src/system.rs
@@ -53,7 +53,7 @@ pub struct ReprovisionOptions {
     #[arg(
         value_name = "Identity Service URI",
         long,
-        default_value = "unix:///run/aziot/identityd.sock"
+        default_value = concat!("unix://", env!("SOCKET_DIR"), "/identityd.sock")
     )]
     uri: url::Url,
 }
@@ -72,7 +72,7 @@ pub async fn system(options: Options) -> Result<()> {
         #[cfg(not(debug_assertions))]
         Options::Reprovision(_) => {
             reprovision(
-                &url::Url::parse("unix:///run/aziot/identityd.sock")
+                &url::Url::parse(concat!("unix://", env!("SOCKET_DIR"), "/identityd.sock"))
                     .expect("hard-coded URI should parse"),
             )
             .await

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -338,10 +338,10 @@ impl Default for Endpoints {
     fn default() -> Self {
         Endpoints {
             aziot_certd: Connector::Unix {
-                socket_path: Path::new("/run/aziot/certd.sock").into(),
+                socket_path: Path::new(concat!(env!("SOCKET_DIR"), "/certd.sock")).into(),
             },
             aziot_keyd: Connector::Unix {
-                socket_path: Path::new("/run/aziot/keyd.sock").into(),
+                socket_path: Path::new(concat!(env!("SOCKET_DIR"), "/keyd.sock")).into(),
             },
         }
     }
@@ -554,10 +554,10 @@ certs = ["test"]
 
                 endpoints: Endpoints {
                     aziot_certd: Connector::Unix {
-                        socket_path: Path::new("/run/aziot/certd.sock").into()
+                        socket_path: Path::new(concat!(env!("SOCKET_DIR"), "/certd.sock")).into()
                     },
                     aziot_keyd: Connector::Unix {
-                        socket_path: Path::new("/run/aziot/keyd.sock").into()
+                        socket_path: Path::new(concat!(env!("SOCKET_DIR"), "/keyd.sock")).into()
                     },
                 },
 
@@ -739,10 +739,10 @@ aziot_certd = "unix:///run/aziot/certd.sock"
 
             endpoints: Endpoints {
                 aziot_certd: Connector::Unix {
-                    socket_path: Path::new("/run/aziot/certd.sock").into(),
+                    socket_path: Path::new(concat!(env!("SOCKET_DIR"), "/certd.sock")).into(),
                 },
                 aziot_keyd: Connector::Unix {
-                    socket_path: Path::new("/run/aziot/keyd.sock").into(),
+                    socket_path: Path::new(concat!(env!("SOCKET_DIR"), "/keyd.sock")).into(),
                 },
             },
 

--- a/cert/aziot-certd/aziot-certd.socket
+++ b/cert/aziot-certd/aziot-certd.socket
@@ -3,7 +3,7 @@ Description=Azure IoT Certificates Service API socket
 PartOf=aziot-certd.service
 
 [Socket]
-ListenStream=/run/aziot/certd.sock
+ListenStream=@socket_dir@/certd.sock
 SocketMode=0660
 DirectoryMode=0755
 SocketUser=aziotcs

--- a/contrib/debian/postrm
+++ b/contrib/debian/postrm
@@ -30,7 +30,7 @@ case "$1" in
 
 		# Delete directories used by aziot-identity-service.
 		rm -rf /etc/aziot
-		rm -rf /run/aziot
+		rm -rf @socket_dir@
 		rm -rf /var/lib/aziot
 
 		# Delete aziot-identity-service users.

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -874,9 +874,10 @@ mod tests {
                 },
             ),
             (
-                "unix:///run/aziot/keyd.sock",
+                concat!("unix://", env!("SOCKET_DIR"), "/keyd.sock"),
                 super::Connector::Unix {
-                    socket_path: std::path::Path::new("/run/aziot/keyd.sock").into(),
+                    socket_path: std::path::Path::new(concat!(env!("SOCKET_DIR"), "/keyd.sock"))
+                        .into(),
                 },
             ),
         ] {

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -283,16 +283,18 @@ impl Default for Endpoints {
     fn default() -> Self {
         Endpoints {
             aziot_certd: http_common::Connector::Unix {
-                socket_path: std::path::Path::new("/run/aziot/certd.sock").into(),
+                socket_path: std::path::Path::new(concat!(env!("SOCKET_DIR"), "/certd.sock"))
+                    .into(),
             },
             aziot_identityd: http_common::Connector::Unix {
-                socket_path: std::path::Path::new("/run/aziot/identityd.sock").into(),
+                socket_path: std::path::Path::new(concat!(env!("SOCKET_DIR"), "/identityd.sock"))
+                    .into(),
             },
             aziot_keyd: http_common::Connector::Unix {
-                socket_path: std::path::Path::new("/run/aziot/keyd.sock").into(),
+                socket_path: std::path::Path::new(concat!(env!("SOCKET_DIR"), "/keyd.sock")).into(),
             },
             aziot_tpmd: http_common::Connector::Unix {
-                socket_path: std::path::Path::new("/run/aziot/tpmd.sock").into(),
+                socket_path: std::path::Path::new(concat!(env!("SOCKET_DIR"), "/tpmd.sock")).into(),
             },
         }
     }

--- a/identity/aziot-identityd/aziot-identityd.socket
+++ b/identity/aziot-identityd/aziot-identityd.socket
@@ -3,7 +3,7 @@ Description=Azure IoT Identity Service API socket
 PartOf=aziot-identityd.service
 
 [Socket]
-ListenStream=/run/aziot/identityd.sock
+ListenStream=@socket_dir@/identityd.sock
 SocketMode=0660
 DirectoryMode=0755
 SocketUser=aziotid

--- a/key/aziot-key-openssl-engine-shared/src/lib.rs
+++ b/key/aziot-key-openssl-engine-shared/src/lib.rs
@@ -27,9 +27,10 @@ unsafe extern "C" fn aziot_key_openssl_engine_shared_bind(
 
 unsafe extern "C" fn engine_init(e: *mut openssl_sys::ENGINE) -> std::os::raw::c_int {
     let result = r#catch(Some(|| Error::ENGINE_INIT), || {
-        let key_connector: http_common::Connector = "unix:///run/aziot/keyd.sock"
-            .parse()
-            .expect("hard-coded URI must parse successfully");
+        let key_connector: http_common::Connector =
+            concat!("unix://", env!("SOCKET_DIR"), "/keyd.sock")
+                .parse()
+                .expect("hard-coded URI must parse successfully");
         let key_client = aziot_key_client::Client::new(
             aziot_key_common_http::ApiVersion::V2021_05_01,
             key_connector,

--- a/key/aziot-keyd-config/src/lib.rs
+++ b/key/aziot-keyd-config/src/lib.rs
@@ -49,7 +49,7 @@ impl Default for Endpoints {
     fn default() -> Self {
         Endpoints {
             aziot_keyd: http_common::Connector::Unix {
-                socket_path: std::path::Path::new("/run/aziot/keyd.sock").into(),
+                socket_path: std::path::Path::new(concat!(env!("SOCKET_DIR"), "/keyd.sock")).into(),
             },
         }
     }
@@ -113,7 +113,11 @@ keys = ["test"]
 
                 endpoints: super::Endpoints {
                     aziot_keyd: http_common::Connector::Unix {
-                        socket_path: std::path::Path::new("/run/aziot/keyd.sock").into()
+                        socket_path: std::path::Path::new(concat!(
+                            env!("SOCKET_DIR"),
+                            "/keyd.sock"
+                        ))
+                        .into()
                     },
                 },
 

--- a/key/aziot-keyd/aziot-keyd.socket
+++ b/key/aziot-keyd/aziot-keyd.socket
@@ -3,7 +3,7 @@ Description=Azure IoT Keys Service API socket
 PartOf=aziot-keyd.service
 
 [Socket]
-ListenStream=/run/aziot/keyd.sock
+ListenStream=@socket_dir@/keyd.sock
 SocketMode=0660
 DirectoryMode=0755
 SocketUser=aziotks

--- a/tpm/aziot-tpmd-config/src/lib.rs
+++ b/tpm/aziot-tpmd-config/src/lib.rs
@@ -120,7 +120,7 @@ impl Default for Endpoints {
     fn default() -> Self {
         Endpoints {
             aziot_tpmd: http_common::Connector::Unix {
-                socket_path: std::path::Path::new("/run/aziot/tpmd.sock").into(),
+                socket_path: std::path::Path::new(concat!(env!("SOCKET_DIR"), "/tpmd.sock")).into(),
             },
         }
     }
@@ -144,7 +144,11 @@ mod tests {
                 },
                 endpoints: super::Endpoints {
                     aziot_tpmd: http_common::Connector::Unix {
-                        socket_path: std::path::Path::new("/run/aziot/tpmd.sock").into()
+                        socket_path: std::path::Path::new(concat!(
+                            env!("SOCKET_DIR"),
+                            "/tpmd.sock"
+                        ))
+                        .into()
                     },
                 },
             }
@@ -171,7 +175,11 @@ auth_key_index = 0x01_02_03
                 },
                 endpoints: super::Endpoints {
                     aziot_tpmd: http_common::Connector::Unix {
-                        socket_path: std::path::Path::new("/run/aziot/tpmd.sock").into()
+                        socket_path: std::path::Path::new(concat!(
+                            env!("SOCKET_DIR"),
+                            "/tpmd.sock"
+                        ))
+                        .into()
                     },
                 },
             }
@@ -201,7 +209,11 @@ owner = "world"
                 },
                 endpoints: super::Endpoints {
                     aziot_tpmd: http_common::Connector::Unix {
-                        socket_path: std::path::Path::new("/run/aziot/tpmd.sock").into()
+                        socket_path: std::path::Path::new(concat!(
+                            env!("SOCKET_DIR"),
+                            "/tpmd.sock"
+                        ))
+                        .into()
                     },
                 },
             }

--- a/tpm/aziot-tpmd/aziot-tpmd.socket
+++ b/tpm/aziot-tpmd/aziot-tpmd.socket
@@ -3,7 +3,7 @@ Description=Azure IoT TPM Service API socket
 PartOf=aziot-tpmd.service
 
 [Socket]
-ListenStream=/run/aziot/tpmd.sock
+ListenStream=@socket_dir@/tpmd.sock
 SocketMode=0660
 DirectoryMode=0755
 SocketUser=aziottpm


### PR DESCRIPTION
A proposal for allowing build-time setting of the directory the *.sock files are created in. This follows the model of @micahl's patches doing something similar for usernames.

I mostly identified locations with a search. I did leave a couple of `/run/aziot/` paths untouched when it was obvious they were part of a test (i.e. lines 133 & 148 of key/aziot-keyd-config/src/lib.rs or lines 579, 580, 597, and 600 in cert/aziot-certd-config/src/lib.rs). I didn't touch any CI or E2E pieces.

Motivations:

This is part of our joint initiative to support the identity service in a snap package. We've done some initial PoC work to show that it works. As it stands right now, the way we can make it work is by making a carveout in confinement to allow the services to create their sockets to listen on at the normal location (`/run/aziot/*.sock`). This works, and is fine. 

However, because of [the way snaps handle systemd socket-activated services](https://snapcraft.io/docs/snapcraft-yaml-reference#:~:text=apps.%0A%3Capp%2Dname%3E.%0Asockets,and%20%40snap.%5C%3Csnap%20name%5C%3E.%3Csuffix%3E) (which the identity services already have the ability to run as), we cannot leverage them at this path (they need to be at a path prefixed by `$SNAP_DATA` or `$SNAP_COMMON`, which are `/var/snap/azure-iot-identity/current/` or `/var/snap/azure-iot-identity/common/` respectively). It's worth noting that today, we can actually already sort of do this because when systemd handles the socket, the services get passed an open FD, not associated with an particular path. However, the `aziotctl` tool needs to know where these sockets live, even when managed by systemd.

Additionally, the truly idiomatic, "snappy" way would be to share them to other snaps as part of a [content interface](https://snapcraft.io/docs/content-interface) (much less privileged than the other way of carving out a highly privileged [system-files interface](https://snapcraft.io/docs/system-files-interface) to `/run/aziot`). This has the advantage of providing us with an extra set of event-triggered hook scripts that run when the content interface connects & disconnects, which can give us some additional flexibility in dropping in config files, registering consumers with the identity service, ensuring consistent config between the identity service & the edge agent, etc.

Where precisely I would override these paths to is a little up in the air. My initial idea would be to somewhere in `/var/snap/azure-iot-identity/common/` but where within that file structure isn't particularly important to me. 

Understand that changing may have carry-on effects on client compatibility, if those clients have a specific expectation about where to find the socket. My initial thinking is that at least at first, consumers of the *snapped* iot-identity service will primarily be other snaps, and so adapting those consumers to understand the new path will just be part of packaging them as snaps.