### PR TITLE
Upgrade to Rust 1.65

### DIFF
--- a/aziotctl/aziotctl-common/src/system/restart.rs
+++ b/aziotctl/aziotctl-common/src/system/restart.rs
@@ -23,7 +23,7 @@ pub fn restart(services: &[&ServiceDefinition]) -> Result<()> {
 fn start(name: &str) -> Result<()> {
     print!("Starting {}...", name);
     let result = Command::new("systemctl")
-        .args(&["start", name])
+        .args(["start", name])
         .output()
         .context("Failed to call systemctl start")?;
 

--- a/aziotctl/aziotctl-common/src/system/status.rs
+++ b/aziotctl/aziotctl-common/src/system/status.rs
@@ -94,7 +94,7 @@ enum State {
 impl State {
     fn from_systemctl(unit: &str) -> Result<State> {
         let result = Command::new("systemctl")
-            .args(&["is-active", unit])
+            .args(["is-active", unit])
             .output()
             .context("Failed to call systemctl is-active")?;
 
@@ -189,7 +189,7 @@ struct SocketStatus<'a> {
 
 fn print_journalctl_logs(unit: &str) -> Result<()> {
     Command::new("journalctl")
-        .args(&["-u", unit, "--no-pager", "-e", "-n", "10"])
+        .args(["-u", unit, "--no-pager", "-e", "-n", "10"])
         .spawn()
         .context("Failed to spawn new process for printing logs")?
         .wait()

--- a/aziotctl/aziotctl-common/src/system/stop.rs
+++ b/aziotctl/aziotctl-common/src/system/stop.rs
@@ -11,7 +11,7 @@ pub fn stop(services: &[&ServiceDefinition]) -> Result<()> {
     for service in services.iter().map(|s| s.service) {
         print!("Stopping {}...", service);
         let result = Command::new("systemctl")
-            .args(&["stop", service])
+            .args(["stop", service])
             .output()
             .context("Failed to call systemctl stop")?;
 

--- a/aziotctl/aziotctl-common/src/system/system_logs.rs
+++ b/aziotctl/aziotctl-common/src/system/system_logs.rs
@@ -9,6 +9,9 @@ pub fn get_system_logs(processes: &[&str], additional_args: &[&OsStr]) -> Result
     let processes = processes.iter().flat_map(|p| vec!["-u", p]);
     let default_args = [OsStr::new("-e"), OsStr::new("--no-pager")];
 
+    // NOTE: Clippy is incorrectly suggesting to remove the borrow on
+    // default_args.
+    #[allow(clippy::needless_borrow)]
     Command::new("journalctl")
         .args(processes)
         .args(if additional_args.is_empty() {

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -176,7 +176,7 @@ impl Api {
             .transpose()?;
 
         let x509 = create_cert_inner(
-            &mut *this,
+            &mut this,
             &id,
             (&req, &pubkey),
             issuer.as_ref().map(|(x509, pk)| (&**x509, &**pk)),

--- a/cert/cert-renewal/src/policy.rs
+++ b/cert/cert-renewal/src/policy.rs
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn deserialize_err() {
         // Empty policy.
-        let input = toml::Value::String("".to_string());
+        let input = toml::Value::String(String::new());
         let err: Result<Policy, toml::de::Error> = serde::Deserialize::deserialize(input);
         err.unwrap_err();
 

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -68,7 +68,7 @@ pub async fn main(
     let max_requests = settings.max_requests;
 
     if !homedir_path.exists() {
-        if let Err(err) = std::fs::create_dir_all(&homedir_path) {
+        if let Err(err) = std::fs::create_dir_all(homedir_path) {
             log::error!("Failed to create home directory: {}", err);
 
             return Err(error::InternalError::CreateHomeDir(err).into());

--- a/key/aziot-keys/src/implementation.rs
+++ b/key/aziot-keys/src/implementation.rs
@@ -322,7 +322,7 @@ pub(crate) unsafe extern "C" fn verify(
             _ => return Err(err_invalid_parameter("mechanism", "unrecognized value")),
         };
 
-        *ok_out.as_mut() = if ok { 1 } else { 0 };
+        *ok_out.as_mut() = ok.into();
 
         Ok(())
     })

--- a/key/aziot-keys/src/key_pair.rs
+++ b/key/aziot-keys/src/key_pair.rs
@@ -672,7 +672,7 @@ fn create_inner(
             };
 
             let private_key_pem = private_key.private_key_to_pem_pkcs8()?;
-            std::fs::write(&path, &private_key_pem).map_err(crate::implementation::err_external)?;
+            std::fs::write(path, &private_key_pem).map_err(crate::implementation::err_external)?;
 
             Ok(())
         }

--- a/mini-sntp/src/lib.rs
+++ b/mini-sntp/src/lib.rs
@@ -318,7 +318,7 @@ mod tests {
         let SntpTimeQueryResult {
             local_clock_offset,
             round_trip_delay,
-        } = query(&("pool.ntp.org", 123))?;
+        } = query(("pool.ntp.org", 123))?;
 
         println!("local clock offset: {}", local_clock_offset);
         println!("round-trip delay: {}", round_trip_delay);

--- a/pkcs11/pkcs11/src/lib.rs
+++ b/pkcs11/pkcs11/src/lib.rs
@@ -54,7 +54,7 @@ impl std::fmt::Display for Uri {
             UriSlotIdentifier::Label(token_label) => {
                 write!(f, "token=")?;
                 let value = percent_encoding::utf8_percent_encode(
-                    &**token_label,
+                    token_label,
                     percent_encoding::NON_ALPHANUMERIC,
                 );
                 for s in value {
@@ -78,7 +78,7 @@ impl std::fmt::Display for Uri {
         if let Some(object_label) = &self.object_label {
             write!(f, ";object=")?;
             let value = percent_encoding::utf8_percent_encode(
-                &**object_label,
+                object_label,
                 percent_encoding::NON_ALPHANUMERIC,
             );
             for s in value {
@@ -89,7 +89,7 @@ impl std::fmt::Display for Uri {
         if let Some(pin) = &self.pin {
             write!(f, "?pin-value=")?;
             let value =
-                percent_encoding::utf8_percent_encode(&**pin, percent_encoding::NON_ALPHANUMERIC);
+                percent_encoding::utf8_percent_encode(pin, percent_encoding::NON_ALPHANUMERIC);
             for s in value {
                 write!(f, "{}", s)?;
             }
@@ -128,7 +128,7 @@ impl std::str::FromStr for Uri {
 
             let key = percent_encoding::percent_decode(key.as_bytes());
             let key: std::borrow::Cow<'a, _> = key.into();
-            let typed_key = match key_discriminant(&*key) {
+            let typed_key = match key_discriminant(&key) {
                 Some(typed_key) => typed_key,
                 None => return Ok(None),
             };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.64"
+channel = "1.65"
 components = ["clippy", "rustfmt"]

--- a/test-common/src/tokio_openssl2.rs
+++ b/test-common/src/tokio_openssl2.rs
@@ -23,7 +23,7 @@ impl Incoming {
         private_key: &openssl::pkey::PKey<openssl::pkey::Private>,
         verify_client: bool,
     ) -> std::io::Result<Self> {
-        let listener = std::net::TcpListener::bind(&(addr, port))?;
+        let listener = std::net::TcpListener::bind((addr, port))?;
         listener.set_nonblocking(true)?;
         let listener = tokio::net::TcpListener::from_std(listener)?;
 


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- `clippy::bool_to_int_with_if`: replace `if ${BOOL} { 1 } else { 0 }` with `${BOOL}.into()`
- `clippy::explicit_auto_deref`: remove redundant dereferences
- `clippy::manual_string_new`: replace `"".to_owned()` with `String::new()`
- `clippy::needless_borrow`: remove unnecessary borrows

Switching to `let .. else` where appropriate was skipped in the interest of keeping the changeset small.

[^0]: https://github.com/rust-lang/rust/blob/1.48.0/RELEASES.md#compatibility-notes
  Namely, the point on `mem::uninitialized`.