### PR TITLE
Change futures_util Mutex to tokio Mutex 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,6 @@ dependencies = [
  "aziot-tpm-common",
  "base64",
  "chrono",
- "futures-util",
  "http-common",
  "hyper",
  "hyper-openssl",
@@ -761,7 +760,6 @@ name = "config-common"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "futures-util",
  "log",
  "notify",
  "serde",
@@ -2371,6 +2369,7 @@ dependencies = [
  "mio 0.8.4",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "tokio-macros",

--- a/cert/aziot-certd/Cargo.toml
+++ b/cert/aziot-certd/Cargo.toml
@@ -25,7 +25,7 @@ percent-encoding = "2"
 regex = "1"
 serde = "1"
 serde_json = "1"
-tokio = { version = "1", features = ["sync", "time"] }
+tokio = { version = "1", features = ["parking_lot", "sync", "time"] }
 url = "2"
 wildmatch = "2"
 

--- a/cert/aziot-certd/src/http/create.rs
+++ b/cert/aziot-certd/src/http/create.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     user: libc::uid_t,
 }
 

--- a/cert/aziot-certd/src/http/get_or_import_or_delete.rs
+++ b/cert/aziot-certd/src/http/get_or_import_or_delete.rs
@@ -7,7 +7,7 @@ lazy_static::lazy_static! {
 }
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     cert_id: String,
     user: libc::uid_t,
 }

--- a/cert/aziot-certd/src/http/mod.rs
+++ b/cert/aziot-certd/src/http/mod.rs
@@ -5,7 +5,7 @@ mod get_or_import_or_delete;
 
 #[derive(Clone)]
 pub struct Service {
-    pub(crate) api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    pub(crate) api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 http_common::make_service! {

--- a/cert/aziot-certd/src/lib.rs
+++ b/cert/aziot-certd/src/lib.rs
@@ -26,13 +26,13 @@ use std::sync::Arc;
 
 use async_recursion::async_recursion;
 use async_trait::async_trait;
-use futures_util::lock::Mutex;
 use openssl::asn1::Asn1Time;
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, PKeyRef, Private, Public};
 use openssl::stack::Stack;
 use openssl::x509::{extension, X509Name, X509NameRef, X509Req, X509ReqRef, X509};
 use openssl2::FunctionalEngine;
+use tokio::sync::Mutex;
 
 use aziot_certd_config::{
     CertIssuance, CertIssuanceMethod, CertificateWithPrivateKey, Config, Endpoints, EstAuth,

--- a/cert/cert-renewal/Cargo.toml
+++ b/cert/cert-renewal/Cargo.toml
@@ -11,7 +11,7 @@ futures-util = "0.3"
 log = "0.4"
 openssl = "0.10"
 serde = "1"
-tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
+tokio = { version = "1", features = ["macros", "parking_lot", "rt", "sync", "time"] }
 
 aziot-cert-client-async = { path = "../aziot-cert-client-async" }
 aziot-key-client-async = { path = "../../key/aziot-key-client-async" }

--- a/cert/cert-renewal/src/cert_interface.rs
+++ b/cert/cert-renewal/src/cert_interface.rs
@@ -59,7 +59,7 @@ pub(crate) struct TestInterface {
 }
 
 #[cfg(test)]
-type ArcMutex<T> = std::sync::Arc<futures_util::lock::Mutex<T>>;
+type ArcMutex<T> = std::sync::Arc<tokio::sync::Mutex<T>>;
 
 #[cfg(test)]
 pub(crate) mod test_interface {
@@ -72,7 +72,7 @@ pub(crate) mod test_interface {
             renew_err: None,
         };
 
-        let interface = futures_util::lock::Mutex::new(interface);
+        let interface = tokio::sync::Mutex::new(interface);
 
         std::sync::Arc::new(interface)
     }

--- a/cert/cert-renewal/src/engine.rs
+++ b/cert/cert-renewal/src/engine.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use futures_util::lock::Mutex;
+use tokio::sync::Mutex;
 
 type ArcMutex<T> = std::sync::Arc<Mutex<T>>;
 
@@ -164,7 +164,7 @@ where
         reschedule_tx,
     };
 
-    let engine = std::sync::Arc::new(futures_util::lock::Mutex::new(engine));
+    let engine = std::sync::Arc::new(tokio::sync::Mutex::new(engine));
     let renewal_engine = engine.clone();
 
     tokio::spawn(async move {

--- a/config-common/Cargo.toml
+++ b/config-common/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2021"
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
-futures-util = { version = "0.3", optional = true }
 log = { version = "0.4", optional = true }
 notify = { version = "4", optional = true }
 serde = "1"
-tokio = { version = "1", features = ["rt", "sync"], optional = true }
+tokio = { version = "1", features = ["parking_lot", "rt", "sync"], optional = true }
 toml = "0.5"
 
 
 [features]
-watcher = ["async-trait", "futures-util", "log", "notify", "tokio"]
+watcher = ["async-trait", "log", "notify", "tokio"]

--- a/config-common/src/watcher.rs
+++ b/config-common/src/watcher.rs
@@ -16,7 +16,7 @@ pub trait UpdateConfig {
 pub fn start_watcher<TApi>(
     config_path: PathBuf,
     config_directory_path: PathBuf,
-    api: std::sync::Arc<futures_util::lock::Mutex<TApi>>,
+    api: std::sync::Arc<tokio::sync::Mutex<TApi>>,
 ) where
     TApi: UpdateConfig + Send + 'static,
 {

--- a/identity/aziot-cloud-client-async/Cargo.toml
+++ b/identity/aziot-cloud-client-async/Cargo.toml
@@ -9,14 +9,13 @@ publish = false
 async-trait = "0.1"
 base64 = "0.13"
 chrono = "0.4"
-futures-util = "0.3"
 hyper = "0.14"
 hyper-openssl = "0.9"
 log = "0.4"
 percent-encoding = "2"
 serde = "1"
 serde_json = "1"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["parking_lot", "time"] }
 url = "2"
 
 aziot-cert-client-async = { path = "../../cert/aziot-cert-client-async" }

--- a/identity/aziot-identityd/Cargo.toml
+++ b/identity/aziot-identityd/Cargo.toml
@@ -24,7 +24,7 @@ percent-encoding = "2"
 regex = "1"
 serde = "1"
 serde_json = "1.0"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["parking_lot", "time"] }
 toml = "0.5"
 url = "2"
 

--- a/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
+++ b/identity/aziot-identityd/src/http/create_or_list_module_identity.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     id_type: Option<String>,
     user: aziot_identityd_config::Credentials,
 }

--- a/identity/aziot-identityd/src/http/get_caller_identity.rs
+++ b/identity/aziot-identityd/src/http/get_caller_identity.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     user: aziot_identityd_config::Credentials,
 }
 

--- a/identity/aziot-identityd/src/http/get_device_identity.rs
+++ b/identity/aziot-identityd/src/http/get_device_identity.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     user: aziot_identityd_config::Credentials,
 }
 

--- a/identity/aziot-identityd/src/http/get_provisioning_info.rs
+++ b/identity/aziot-identityd/src/http/get_provisioning_info.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 #[async_trait::async_trait]

--- a/identity/aziot-identityd/src/http/get_trust_bundle.rs
+++ b/identity/aziot-identityd/src/http/get_trust_bundle.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     user: aziot_identityd_config::Credentials,
 }
 

--- a/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
+++ b/identity/aziot-identityd/src/http/get_update_or_delete_module_identity.rs
@@ -7,7 +7,7 @@ lazy_static::lazy_static! {
 }
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     module_id: String,
     id_type: Option<String>,
     user: aziot_identityd_config::Credentials,

--- a/identity/aziot-identityd/src/http/mod.rs
+++ b/identity/aziot-identityd/src/http/mod.rs
@@ -10,7 +10,7 @@ mod reprovision_device;
 
 #[derive(Clone)]
 pub struct Service {
-    pub(crate) api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    pub(crate) api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 http_common::make_service! {

--- a/identity/aziot-identityd/src/http/reprovision_device.rs
+++ b/identity/aziot-identityd/src/http/reprovision_device.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     user: aziot_identityd_config::Credentials,
 }
 

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -22,18 +22,14 @@ pub struct IdentityManager {
     req_timeout: std::time::Duration,
     req_retries: u32,
     key_client: Arc<aziot_key_client_async::Client>,
-    key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
+    key_engine: Arc<tokio::sync::Mutex<openssl2::FunctionalEngine>>,
     cert_client: Arc<aziot_cert_client_async::Client>,
     tpm_client: Arc<aziot_tpm_client_async::Client>,
     proxy_uri: Option<hyper::Uri>,
 
     pub(crate) iot_hub_device: Option<aziot_identity_common::IoTHubDevice>,
     pub(crate) identity_cert_renewal: Option<
-        Arc<
-            futures_util::lock::Mutex<
-                cert_renewal::RenewalEngine<crate::renewal::IdentityCertRenewal>,
-            >,
-        >,
+        Arc<tokio::sync::Mutex<cert_renewal::RenewalEngine<crate::renewal::IdentityCertRenewal>>>,
     >,
 }
 
@@ -41,7 +37,7 @@ impl IdentityManager {
     pub fn new(
         settings: &aziot_identityd_config::Settings,
         key_client: Arc<aziot_key_client_async::Client>,
-        key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
+        key_engine: Arc<tokio::sync::Mutex<openssl2::FunctionalEngine>>,
         cert_client: Arc<aziot_cert_client_async::Client>,
         tpm_client: Arc<aziot_tpm_client_async::Client>,
         iot_hub_device: Option<aziot_identity_common::IoTHubDevice>,

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -102,7 +102,7 @@ pub async fn main(
         None
     };
 
-    let api = Arc::new(futures_util::lock::Mutex::new(api));
+    let api = Arc::new(tokio::sync::Mutex::new(api));
 
     // Configure the device identity certificate to auto-renew if enabled.
     if let Some((engine, registration_id, identity_cert, identity_pk, auto_renew)) =
@@ -168,7 +168,7 @@ pub struct Api {
     >,
 
     key_client: Arc<aziot_key_client_async::Client>,
-    key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
+    key_engine: Arc<tokio::sync::Mutex<openssl2::FunctionalEngine>>,
     cert_client: Arc<aziot_cert_client_async::Client>,
     tpm_client: Arc<aziot_tpm_client_async::Client>,
     proxy_uri: Option<hyper::Uri>,
@@ -196,7 +196,7 @@ impl Api {
             let key_client = Arc::new(key_client);
             let key_engine = aziot_key_openssl_engine::load(key_client)
                 .map_err(|err| Error::Internal(InternalError::LoadKeyOpensslEngine(err)))?;
-            let key_engine = Arc::new(futures_util::lock::Mutex::new(key_engine));
+            let key_engine = Arc::new(tokio::sync::Mutex::new(key_engine));
             key_engine
         };
 
@@ -748,7 +748,7 @@ impl UpdateConfig for Api {
 
 pub(crate) async fn get_keys(
     key_handle: aziot_key_common::KeyHandle,
-    key_engine: &futures_util::lock::Mutex<openssl2::FunctionalEngine>,
+    key_engine: &tokio::sync::Mutex<openssl2::FunctionalEngine>,
 ) -> Result<
     (
         openssl::pkey::PKey<openssl::pkey::Private>,

--- a/identity/aziot-identityd/src/renewal.rs
+++ b/identity/aziot-identityd/src/renewal.rs
@@ -7,10 +7,10 @@ pub(crate) struct IdentityCertRenewal {
     rotate_key: bool,
     temp_cert: String,
 
-    api: Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: Arc<tokio::sync::Mutex<crate::Api>>,
     cert_client: Arc<aziot_cert_client_async::Client>,
     key_client: Arc<aziot_key_client_async::Client>,
-    key_engine: Arc<futures_util::lock::Mutex<openssl2::FunctionalEngine>>,
+    key_engine: Arc<tokio::sync::Mutex<openssl2::FunctionalEngine>>,
 }
 
 impl IdentityCertRenewal {
@@ -18,8 +18,13 @@ impl IdentityCertRenewal {
         rotate_key: bool,
         cert_id: &str,
         key_id: &str,
+<<<<<<< HEAD
         registration_id: Option<&str>,
         api: Arc<futures_util::lock::Mutex<crate::Api>>,
+=======
+        registration_id: Option<&aziot_identityd_config::CsrSubject>,
+        api: Arc<tokio::sync::Mutex<crate::Api>>,
+>>>>>>> 5ff39f3 (Change futures_util Mutex to tokio Mutex (#485))
     ) -> Result<Self, crate::Error> {
         let (cert_client, key_client, key_engine) = {
             let api = api.lock().await;

--- a/identity/aziot-identityd/src/renewal.rs
+++ b/identity/aziot-identityd/src/renewal.rs
@@ -18,13 +18,8 @@ impl IdentityCertRenewal {
         rotate_key: bool,
         cert_id: &str,
         key_id: &str,
-<<<<<<< HEAD
-        registration_id: Option<&str>,
-        api: Arc<futures_util::lock::Mutex<crate::Api>>,
-=======
         registration_id: Option<&aziot_identityd_config::CsrSubject>,
         api: Arc<tokio::sync::Mutex<crate::Api>>,
->>>>>>> 5ff39f3 (Change futures_util Mutex to tokio Mutex (#485))
     ) -> Result<Self, crate::Error> {
         let (cert_client, key_client, key_engine) = {
             let api = api.lock().await;

--- a/key/aziot-keyd/Cargo.toml
+++ b/key/aziot-keyd/Cargo.toml
@@ -20,7 +20,7 @@ percent-encoding = "2"
 regex = "1"
 serde = "1"
 serde_json = "1"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["parking_lot", "time"] }
 url = "2"
 wildmatch = "2"
 

--- a/key/aziot-keyd/src/http/create_delete_key.rs
+++ b/key/aziot-keyd/src/http/create_delete_key.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     user: libc::uid_t,
 }
 

--- a/key/aziot-keyd/src/http/create_delete_key_pair.rs
+++ b/key/aziot-keyd/src/http/create_delete_key_pair.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     user: libc::uid_t,
 }
 

--- a/key/aziot-keyd/src/http/create_derived_key.rs
+++ b/key/aziot-keyd/src/http/create_derived_key.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 #[async_trait::async_trait]

--- a/key/aziot-keyd/src/http/decrypt.rs
+++ b/key/aziot-keyd/src/http/decrypt.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 #[async_trait::async_trait]

--- a/key/aziot-keyd/src/http/encrypt.rs
+++ b/key/aziot-keyd/src/http/encrypt.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 #[async_trait::async_trait]

--- a/key/aziot-keyd/src/http/export_derived_key.rs
+++ b/key/aziot-keyd/src/http/export_derived_key.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 #[async_trait::async_trait]

--- a/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
+++ b/key/aziot-keyd/src/http/get_key_pair_public_parameter.rs
@@ -7,7 +7,7 @@ lazy_static::lazy_static! {
 }
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     parameter_name: String,
 }
 

--- a/key/aziot-keyd/src/http/load_move.rs
+++ b/key/aziot-keyd/src/http/load_move.rs
@@ -7,7 +7,7 @@ lazy_static::lazy_static! {
 }
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
     type_: String,
     key_id: String,
     user: libc::uid_t,

--- a/key/aziot-keyd/src/http/mod.rs
+++ b/key/aziot-keyd/src/http/mod.rs
@@ -12,7 +12,7 @@ mod sign;
 
 #[derive(Clone)]
 pub struct Service {
-    pub(crate) api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    pub(crate) api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 http_common::make_service! {

--- a/key/aziot-keyd/src/http/sign.rs
+++ b/key/aziot-keyd/src/http/sign.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 #[async_trait::async_trait]

--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -84,7 +84,7 @@ pub async fn main(
             principals: principal_to_map(principal),
         }
     };
-    let api = std::sync::Arc::new(futures_util::lock::Mutex::new(api));
+    let api = std::sync::Arc::new(tokio::sync::Mutex::new(api));
 
     config_common::watcher::start_watcher(config_path, config_directory_path, api.clone());
 

--- a/test-common/Cargo.toml
+++ b/test-common/Cargo.toml
@@ -11,7 +11,7 @@ futures-util = "0.3"
 hyper = { version = "0.14", features = ["server"] }
 openssl = "0.10"
 serde_json = "1"
-tokio = { version = "1", features = ["net"] }
+tokio = { version = "1", features = ["net", "parking_lot"] }
 tokio-openssl = "0.6"
 
 aziot-key-client = { path = "../key/aziot-key-client" }

--- a/test-common/src/client/cert.rs
+++ b/test-common/src/client/cert.rs
@@ -6,8 +6,7 @@ pub struct CertClient {
     //
     // The test client may need to mutate this map of certs, so the workaround is to place it in
     // a RefCell and use replace_with.
-    pub certs:
-        futures_util::lock::Mutex<std::cell::RefCell<std::collections::BTreeMap<String, Vec<u8>>>>,
+    pub certs: tokio::sync::Mutex<std::cell::RefCell<std::collections::BTreeMap<String, Vec<u8>>>>,
 
     pub issuer: openssl::x509::X509,
     pub issuer_key: openssl::pkey::PKey<openssl::pkey::Private>,

--- a/test-common/src/client/identity.rs
+++ b/test-common/src/client/identity.rs
@@ -20,7 +20,7 @@ pub struct IdentityClient {
     // The test client may need to mutate this map of identities, so the workaround is to place it in
     // a RefCell and use replace_with.
     pub identities:
-        futures_util::lock::Mutex<std::cell::RefCell<std::collections::BTreeMap<String, Identity>>>,
+        tokio::sync::Mutex<std::cell::RefCell<std::collections::BTreeMap<String, Identity>>>,
 }
 
 impl Default for IdentityClient {
@@ -28,7 +28,7 @@ impl Default for IdentityClient {
         let mut identities = std::collections::BTreeMap::new();
         identities.insert("testModule".to_string(), test_identity("testModule"));
 
-        let identities = futures_util::lock::Mutex::new(std::cell::RefCell::new(identities));
+        let identities = tokio::sync::Mutex::new(std::cell::RefCell::new(identities));
 
         IdentityClient {
             get_provisioning_info_ok: true,

--- a/tpm/aziot-tpmd/Cargo.toml
+++ b/tpm/aziot-tpmd/Cargo.toml
@@ -12,7 +12,7 @@ hyper = "0.14"
 log = "0.4"
 serde = "1"
 serde_json = "1"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["parking_lot", "time"] }
 url = "2"
 
 aziot-tpm-common = { path = "../aziot-tpm-common" }

--- a/tpm/aziot-tpmd/src/http/get_tpm_keys.rs
+++ b/tpm/aziot-tpmd/src/http/get_tpm_keys.rs
@@ -5,7 +5,7 @@ use http_common::server::RouteResponse;
 use crate::error::{Error, InternalError};
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 #[async_trait::async_trait]

--- a/tpm/aziot-tpmd/src/http/import_auth_key.rs
+++ b/tpm/aziot-tpmd/src/http/import_auth_key.rs
@@ -5,7 +5,7 @@ use http_common::server::RouteResponse;
 use crate::error::{Error, InternalError};
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 #[async_trait::async_trait]

--- a/tpm/aziot-tpmd/src/http/mod.rs
+++ b/tpm/aziot-tpmd/src/http/mod.rs
@@ -6,7 +6,7 @@ mod sign_with_auth_key;
 
 #[derive(Clone)]
 pub struct Service {
-    pub(crate) api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    pub(crate) api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 http_common::make_service! {

--- a/tpm/aziot-tpmd/src/http/sign_with_auth_key.rs
+++ b/tpm/aziot-tpmd/src/http/sign_with_auth_key.rs
@@ -5,7 +5,7 @@ use http_common::server::RouteResponse;
 use crate::error::{Error, InternalError};
 
 pub(super) struct Route {
-    api: std::sync::Arc<futures_util::lock::Mutex<crate::Api>>,
+    api: std::sync::Arc<tokio::sync::Mutex<crate::Api>>,
 }
 
 #[async_trait::async_trait]

--- a/tpm/aziot-tpmd/src/lib.rs
+++ b/tpm/aziot-tpmd/src/lib.rs
@@ -24,7 +24,7 @@ pub async fn main(
     _: std::path::PathBuf,
 ) -> Result<(http_common::Incoming, http::Service), Box<dyn std::error::Error>> {
     let api = Api::new(&config).map_err(|e| Error::Internal(InternalError::InitTpm(e)))?;
-    let api = std::sync::Arc::new(futures_util::lock::Mutex::new(api));
+    let api = std::sync::Arc::new(tokio::sync::Mutex::new(api));
 
     let service = http::Service { api };
 


### PR DESCRIPTION
Using a fair mutex resolves an issue where multiple requests weren't completing in order and causing a timeout for earlier requests. 

Cherry-picked: https://github.com/Azure/iot-identity-service/commit/5ff39f34b4427952cee355a3810c24fec35a884c