### PR TITLE
Use plaintext buffer equal in length to the ciphertext buffer for PKCS#11 decrypt.

### DIFF
--- a/key/aziot-keys/src/key.rs
+++ b/key/aziot-keys/src/key.rs
@@ -507,7 +507,7 @@ pub(crate) unsafe fn decrypt(
                 }
             };
 
-            let mut plaintext = vec![0_u8; ciphertext.len() - 16];
+            let mut plaintext = vec![0_u8; ciphertext.len()];
             let plaintext_len = key
                 .decrypt(iv, aad, ciphertext, &mut plaintext)
                 .map_err(crate::implementation::err_external)?;


### PR DESCRIPTION
Cherry-pick from main of eeaa6ccc294530780a2d6b824040fbb85b3d7b98

The previous code used a plaintext buffer that was 16 bytes smaller than the ciphertext buffer, because the ciphertext was known to include a 16-byte tag. However at least SoftHSM requires the plaintext buffer to be at least as big as the ciphertext buffer. So this commit makes it so.

Fixes #486