### PR TITLE
Update all uses of checkout, upload-artifact and download-artifact Actions to v3.

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   suite-setup:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
     - uses: 'actions/checkout@v3'
@@ -39,7 +39,7 @@ jobs:
   test-run:
     needs: 'suite-setup'
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -104,7 +104,7 @@ jobs:
     needs: 'test-run'
     if: "${{ success() }}"
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
     - uses: 'actions/checkout@v3'
@@ -127,7 +127,7 @@ jobs:
     needs: 'test-run'
     if: "${{ failure() }}"
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
     - uses: 'actions/checkout@v3'

--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: 'ubuntu-18.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ github.event.inputs.branch }}"
 
@@ -63,7 +63,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ github.event.inputs.branch }}"
 
@@ -107,7 +107,7 @@ jobs:
     runs-on: 'ubuntu-18.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ github.event.inputs.branch }}"
 
@@ -130,7 +130,7 @@ jobs:
     runs-on: 'ubuntu-18.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ github.event.inputs.branch }}"
 

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -32,7 +32,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ matrix.branch }}"
 
@@ -83,7 +83,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ matrix.branch }}"
 
@@ -137,7 +137,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ matrix.branch }}"
 
@@ -170,7 +170,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ matrix.branch }}"
 

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -19,7 +19,7 @@ jobs:
   suite-setup:
     if: "github.repository == 'Azure/iot-identity-service'"
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -52,7 +52,7 @@ jobs:
     if: "github.repository == 'Azure/iot-identity-service'"
     needs: 'suite-setup'
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -124,7 +124,7 @@ jobs:
     if: "${{ github.repository == 'Azure/iot-identity-service' && success() }}"
     needs: 'test-run'
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -157,7 +157,7 @@ jobs:
     needs: 'test-run'
     if: "${{ failure() }}"
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -48,7 +48,7 @@ jobs:
           os: 'mariner:2'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         submodules: 'recursive'
     - name: 'Run'

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   packages:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -81,7 +81,7 @@ jobs:
         os_package="$(sed -e 's@[:/]@-@g' <<< "$os_package")"
         echo "artifact-name=packages_${os_package}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
     - name: 'Upload'
-      uses: 'actions/upload-artifact@v1'
+      uses: 'actions/upload-artifact@v3'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: 'packages'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   basic:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -54,7 +54,7 @@ jobs:
         esac
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Upload'
-      uses: 'actions/upload-artifact@v2'
+      uses: 'actions/upload-artifact@v3'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: |
@@ -68,7 +68,7 @@ jobs:
 
 
   aziot-key-openssl-engine-shared:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -113,7 +113,7 @@ jobs:
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
-      uses: 'actions/download-artifact@v2'
+      uses: 'actions/download-artifact@v3'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: 'target/debug'
@@ -132,7 +132,7 @@ jobs:
         PKCS11_BACKEND: "${{ matrix.pkcs11_backend }}"
 
   mock-iot-tests:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -167,7 +167,7 @@ jobs:
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
-      uses: 'actions/download-artifact@v2'
+      uses: 'actions/download-artifact@v3'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: 'target/debug'
@@ -194,7 +194,7 @@ jobs:
         SERVER_KEY: '/src/mock_iot_server_certs/server_cert_key.pem'
 
   openapi:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
     - uses: 'actions/checkout@v3'
@@ -203,7 +203,7 @@ jobs:
         make target/openapi-schema-validated
 
   codecoverage:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
     - uses: 'actions/checkout@v3'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
         - 'amd64'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         submodules: 'recursive'
     - name: 'Run'
@@ -95,7 +95,7 @@ jobs:
     needs: 'basic'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         submodules: 'recursive'
     - name: 'Generate artifact properties'
@@ -151,7 +151,7 @@ jobs:
     needs: 'basic'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
     - name: 'Generate artifact properties'
       id: 'generate-artifact-properties'
       run: |
@@ -197,7 +197,7 @@ jobs:
     runs-on: 'ubuntu-18.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
     - name: 'Test OpenAPI specs'
       run: |
         make target/openapi-schema-validated
@@ -206,7 +206,7 @@ jobs:
     runs-on: 'ubuntu-18.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         submodules: 'recursive'
 


### PR DESCRIPTION
CI has been reporting warnings for some time.

>Node.js 12 actions are deprecated. For more information see:
>https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Also switch the workflows to run on Ubuntu 22.04.