### PR TITLE
[identityd] Fix certificate subject propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "cert-renewal",
  "http-common",
  "libc",
+ "openssl",
  "serde",
  "serde_json",
  "toml",

--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -112,7 +112,7 @@ pub fn run(
                     }
 
                     super_config::ManualAuthMethod::X509 { identity } => {
-                        match identity {
+                        let csr_subject = match identity {
                             super_config::X509Identity::Issued { identity_cert } => {
                                 let auth =
                                     if let super_config::CertIssuanceMethod::Est { url: _, auth } =
@@ -131,11 +131,26 @@ pub fn run(
 
                                 aziotid_keys.keys.push(super::DEVICE_ID_ID.to_owned());
 
-                                cert_issuance_certs.insert(
-                                    super::DEVICE_ID_ID.to_owned(),
-                                    into_cert_options(identity_cert, auth),
-                                );
+                                let issuance_options = into_cert_options(identity_cert, auth);
+                                let csr_subject = match &issuance_options.subject {
+                                    Some(aziot_certd_config::CertSubject::Subject(entries)) => {
+                                        Some(aziot_identityd_config::CsrSubject::Subject {
+                                            cn: device_id.clone(),
+                                            rest: entries
+                                                .iter()
+                                                .filter_map(|(k, v)| {
+                                                    (!k.eq_ignore_ascii_case("cn"))
+                                                        .then(|| (k.to_uppercase(), v.clone()))
+                                                })
+                                                .collect(),
+                                        })
+                                    }
+                                    _ => None,
+                                };
+                                cert_issuance_certs
+                                    .insert(super::DEVICE_ID_ID.to_owned(), issuance_options);
                                 aziotid_certs.certs.push(super::DEVICE_ID_ID.to_owned());
+                                csr_subject
                             }
 
                             super_config::X509Identity::Preloaded {
@@ -149,12 +164,15 @@ pub fn run(
                                     super::DEVICE_ID_ID.to_owned(),
                                     aziot_certd_config::PreloadedCert::Uri(identity_cert),
                                 );
+
+                                None
                             }
-                        }
+                        };
 
                         aziot_identityd_config::ManualAuthMethod::X509 {
                             identity_cert: super::DEVICE_ID_ID.to_owned(),
                             identity_pk: super::DEVICE_ID_ID.to_owned(),
+                            csr_subject,
                         }
                     }
                 };
@@ -195,7 +213,7 @@ pub fn run(
                         registration_id,
                         identity,
                     } => {
-                        let auto_renew = match identity {
+                        let (registration_id, auto_renew) = match identity {
                             super_config::X509Identity::Issued { identity_cert } => {
                                 let auto_renew = identity_cert.auto_renew.clone();
 
@@ -232,13 +250,36 @@ pub fn run(
                                     }
                                 }
 
-                                cert_issuance_certs.insert(
-                                    super::DEVICE_ID_ID.to_owned(),
-                                    into_cert_options(identity_cert, auth),
-                                );
+                                let issuance_options = into_cert_options(identity_cert, auth);
+                                let csr_subject = registration_id
+                                    .and_then(|id| {
+                                        issuance_options
+                                            .subject
+                                            .as_ref()
+                                            .map(|subject| (id, subject))
+                                    })
+                                    .map(|(id, subject)| match subject {
+                                        aziot_certd_config::CertSubject::CommonName(_) => {
+                                            aziot_identityd_config::CsrSubject::CommonName(id)
+                                        }
+                                        aziot_certd_config::CertSubject::Subject(entries) => {
+                                            aziot_identityd_config::CsrSubject::Subject {
+                                                cn: id,
+                                                rest: entries
+                                                    .iter()
+                                                    .filter_map(|(k, v)| {
+                                                        (!k.eq_ignore_ascii_case("cn"))
+                                                            .then(|| (k.to_uppercase(), v.clone()))
+                                                    })
+                                                    .collect(),
+                                            }
+                                        }
+                                    });
+                                cert_issuance_certs
+                                    .insert(super::DEVICE_ID_ID.to_owned(), issuance_options);
                                 aziotid_certs.certs.push(super::DEVICE_ID_ID.to_owned());
 
-                                auto_renew
+                                (csr_subject, auto_renew)
                             }
 
                             super_config::X509Identity::Preloaded {
@@ -253,7 +294,11 @@ pub fn run(
                                     aziot_certd_config::PreloadedCert::Uri(identity_cert),
                                 );
 
-                                None
+                                (
+                                    registration_id
+                                        .map(aziot_identityd_config::CsrSubject::CommonName),
+                                    None,
+                                )
                             }
                         };
 

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/identityd.toml
@@ -8,9 +8,13 @@ scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
+
+[provisioning.attestation.registration_id]
+CN = "my-device"
+L = "AQ"
+ST = "Antarctica"
 
 [provisioning.attestation.identity_auto_renew]
 rotate_key = false

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
@@ -8,9 +8,9 @@ scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
+registration_id = "my-device"
 
 [provisioning.attestation.identity_auto_renew]
 rotate_key = true

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-custom-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-custom-bootstrap/identityd.toml
@@ -8,6 +8,6 @@ scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
+registration_id = "my-device"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/identityd.toml
@@ -8,6 +8,10 @@ scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
+
+[provisioning.attestation.registration_id]
+CN = "my-device"
+L = "AQ"
+ST = "Antarctica"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/identityd.toml
@@ -8,6 +8,6 @@ scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
+registration_id = "my-device"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/identityd.toml
@@ -8,6 +8,6 @@ scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
+registration_id = "my-device"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/identityd.toml
@@ -8,6 +8,6 @@ scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
+registration_id = "my-device"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509/identityd.toml
@@ -8,6 +8,6 @@ scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
+registration_id = "my-device"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/identityd.toml
@@ -10,3 +10,8 @@ device_id = "my-device"
 method = "x509"
 identity_cert = "device-id"
 identity_pk = "device-id"
+
+[provisioning.authentication.csr_subject]
+CN = "my-device"
+L = "AQ"
+ST = "Antarctica"

--- a/cert/aziot-certd-config/src/lib.rs
+++ b/cert/aziot-certd-config/src/lib.rs
@@ -23,7 +23,7 @@ use url::Url;
 
 use http_common::Connector;
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Config {
     /// Path of home directory.
     pub homedir_path: PathBuf,
@@ -62,7 +62,7 @@ pub struct Config {
 }
 
 /// Configuration of how new certificates should be issued.
-#[derive(Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CertIssuance {
     /// Configuration of parameters for issuing certs via EST.
     pub est: Option<Est>,
@@ -76,7 +76,7 @@ pub struct CertIssuance {
 }
 
 /// Configuration of parameters for issuing certs via EST.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Est {
     /// List of certs that should be treated as trusted roots for validating the EST server's TLS certificate.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -125,7 +125,7 @@ pub fn is_default_est_renew(auto_renew: &cert_renewal::RenewalPolicy) -> bool {
 ///
 /// Note that EST servers may be configured to have only basic auth, only TLS client cert auth, or both.
 #[skip_serializing_none]
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(try_from = "EstAuthInner")]
 pub struct EstAuth {
     /// Authentication parameters when using basic HTTP authentication.
@@ -162,14 +162,14 @@ impl TryFrom<EstAuthInner> for EstAuth {
 }
 
 /// Authentication parameters when using basic HTTP authentication.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct EstAuthBasic {
     pub username: String,
     pub password: String,
 }
 
 /// Authentication parameters when using TLS client cert authentication.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct EstAuthX509 {
     /// Cert ID and private key ID for the identity cert.
     ///
@@ -200,7 +200,7 @@ pub struct CertificateWithPrivateKey {
 }
 
 /// Details for issuing a single cert.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CertIssuanceOptions {
     /// The method used to issue a certificate.
     #[serde(flatten)]
@@ -215,7 +215,7 @@ pub struct CertIssuanceOptions {
     pub subject: Option<CertSubject>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CertSubject {
     CommonName(String),
@@ -292,7 +292,7 @@ where
 
 /// The method used to issue a certificate.
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "method", rename_all = "snake_case")]
 pub enum CertIssuanceMethod {
     /// The certificate is to be issued via EST.
@@ -310,7 +310,7 @@ pub enum CertIssuanceMethod {
 }
 
 /// The location of a preloaded cert.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum PreloadedCert {
     /// A URI for the location.
@@ -325,7 +325,7 @@ pub enum PreloadedCert {
 }
 
 /// Map of service names to endpoint URIs.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Endpoints {
     /// The endpoint that the certd service binds to.
     pub aziot_certd: Connector,
@@ -348,7 +348,7 @@ impl Default for Endpoints {
 }
 
 /// Map of a Unix UID to certificate IDs with write access.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Principal {
     /// Unix UID.
     pub uid: libc::uid_t,

--- a/cert/cert-renewal/src/lib.rs
+++ b/cert/cert-renewal/src/lib.rs
@@ -47,7 +47,7 @@ fn test_cert(not_before: i64, not_after: i64) -> openssl::x509::X509 {
 }
 
 /// Common settings for configuring auto-renewal.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct AutoRenewConfig {
     /// Whether to rotate the key. This requires temporary storage for a second
     /// key during credential rotation. Defaults to `true`.

--- a/cert/cert-renewal/src/policy.rs
+++ b/cert/cert-renewal/src/policy.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct RenewalPolicy {
     pub threshold: Policy,
@@ -8,7 +8,7 @@ pub struct RenewalPolicy {
 }
 
 /// Determines the policy for certificate renewal and retries.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Policy {
     /// Renew and retry as a percentage of the certificate's lifetime.
     /// This value is always between 0 and 100.

--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -148,7 +148,7 @@ installTestTools() {
     local os="${distributor_id,,}"
     case "$os" in
         debian|ubuntu)
-            sudo apt-get install dotnet6 -y 
+            sudo apt-get install dotnet6 -y
             release="$(lsb_release -rs)"
             wget "https://packages.microsoft.com/config/$os/$release/packages-microsoft-prod.deb" \
                 -O packages-microsoft-prod.deb

--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -9,7 +9,7 @@ pub const SOCKET_DEFAULT_PERMISSION: u32 = 0o660;
 
 const SD_LISTEN_FDS_START: std::os::unix::io::RawFd = 3;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Connector {
     Tcp {
         host: std::sync::Arc<str>,

--- a/identity/aziot-identityd-config/Cargo.toml
+++ b/identity/aziot-identityd-config/Cargo.toml
@@ -10,14 +10,15 @@ edition = "2021"
 
 
 [dependencies]
-http-common = { path = "../../http-common" }
 libc = "0.2"
+openssl = "0.10"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
+serde_json = "1"
 url = { version = "2", features = ["serde"] }
 
 aziot-identity-common = { path = "../aziot-identity-common" }
 cert-renewal = { path = "../../cert/cert-renewal"}
+http-common = { path = "../../http-common" }
 
 [dev-dependencies]
 toml = "0.5"

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -8,11 +8,14 @@
     clippy::large_enum_variant
 )]
 
+use std::collections::BTreeMap;
 use std::io::ErrorKind;
+
+use serde::{Deserialize, Serialize};
 
 mod check;
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Settings {
     pub hostname: String,
 
@@ -74,9 +77,9 @@ impl Settings {
 
 pub fn deserialize_cloud_timeout<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
-    D: serde::de::Deserializer<'de>,
+    D: serde::Deserializer<'de>,
 {
-    let result: u64 = serde::Deserialize::deserialize(deserializer)?;
+    let result: u64 = Deserialize::deserialize(deserializer)?;
 
     if result == 0 {
         return Err(serde::de::Error::custom(
@@ -87,7 +90,7 @@ where
     Ok(result)
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub struct Principal {
     pub uid: Credentials,
@@ -101,21 +104,19 @@ pub struct Principal {
     pub localid: Option<aziot_identity_common::LocalIdOpts>,
 }
 
-#[derive(
-    Clone, Copy, Debug, Eq, Hash, Ord, PartialOrd, PartialEq, serde::Deserialize, serde::Serialize,
-)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialOrd, PartialEq, Deserialize, Serialize)]
 pub struct Uid(pub libc::uid_t);
 
 pub type Credentials = Uid;
 
 /// Global options for all local identities.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct LocalId {
     /// Identifier for a group of local identity certificates, suffixed to the common name.
     pub domain: String,
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "method")]
 #[serde(rename_all = "lowercase")]
 pub enum ManualAuthMethod {
@@ -124,12 +125,78 @@ pub enum ManualAuthMethod {
     X509 {
         identity_cert: String,
         identity_pk: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        csr_subject: Option<CsrSubject>,
     },
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-#[serde(tag = "method")]
-#[serde(rename_all = "lowercase")]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum CsrSubject {
+    CommonName(String),
+    #[serde(deserialize_with = "subject_from_key_value")]
+    Subject {
+        #[serde(rename(serialize = "CN"))]
+        cn: String,
+        #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+        rest: BTreeMap<String, String>,
+    },
+}
+
+impl CsrSubject {
+    pub fn common_name(&self) -> &str {
+        match self {
+            Self::CommonName(cn) | Self::Subject { cn, .. } => cn,
+        }
+    }
+}
+
+fn subject_from_key_value<'de, D>(de: D) -> Result<(String, BTreeMap<String, String>), D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let mut res = BTreeMap::<String, String>::deserialize(de)?
+        .into_iter()
+        .map(|(k, v)| (k.to_uppercase(), v))
+        .collect::<BTreeMap<_, _>>();
+    Ok((
+        res.remove("CN")
+            .ok_or_else(|| <D::Error as serde::de::Error>::missing_field("CN"))?,
+        res,
+    ))
+}
+
+impl TryFrom<&CsrSubject> for openssl::x509::X509Name {
+    type Error = openssl::error::ErrorStack;
+
+    fn try_from(subject: &CsrSubject) -> Result<Self, Self::Error> {
+        // X.509 requires CNs to be shorter than 64 characters.
+        const CN_MAX_LENGTH: usize = 64;
+
+        let mut builder = openssl::x509::X509Name::builder()?;
+
+        match subject {
+            CsrSubject::CommonName(cn) => {
+                let mut cn = cn.to_string();
+                cn.truncate(CN_MAX_LENGTH);
+                builder.append_entry_by_nid(openssl::nid::Nid::COMMONNAME, &cn)?;
+            }
+            CsrSubject::Subject { cn, rest } => {
+                let mut cn = cn.to_string();
+                cn.truncate(CN_MAX_LENGTH);
+                builder.append_entry_by_nid(openssl::nid::Nid::COMMONNAME, &cn)?;
+                for (name, value) in rest {
+                    builder.append_entry_by_text(name, value)?;
+                }
+            }
+        }
+
+        Ok(builder.build())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase", tag = "method")]
 pub enum DpsAttestationMethod {
     #[serde(rename = "symmetric_key")]
     SymmetricKey {
@@ -137,9 +204,10 @@ pub enum DpsAttestationMethod {
         symmetric_key: String,
     },
     X509 {
-        registration_id: Option<String>,
         identity_cert: String,
         identity_pk: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        registration_id: Option<CsrSubject>,
         #[serde(skip_serializing_if = "Option::is_none")]
         identity_auto_renew: Option<cert_renewal::AutoRenewConfig>,
     },
@@ -148,7 +216,7 @@ pub enum DpsAttestationMethod {
     },
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub struct Provisioning {
     pub local_gateway_hostname: Option<String>,
@@ -157,7 +225,7 @@ pub struct Provisioning {
     pub provisioning: ProvisioningType,
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "source")]
 #[serde(rename_all = "lowercase")]
 pub enum ProvisioningType {
@@ -173,12 +241,11 @@ pub enum ProvisioningType {
         #[serde(skip_serializing_if = "Option::is_none")]
         payload: Option<Payload>,
     },
-
     /// Disables provisioning with IoT Hub for devices that use local identities only.
     None,
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Payload {
     pub uri: url::Url,
 }
@@ -204,7 +271,7 @@ impl Payload {
     }
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
     pub aziot_certd: http_common::Connector,
     pub aziot_identityd: http_common::Connector,


### PR DESCRIPTION
Cherry-pick of 85254fac78696494d6fd177dc9d508f7be4c79fb.

Certificate subject configuration options for EST-issued certificates
were not being propagated to identityd, which meant that CSRs to issue a
certificate would not be generated with the configured certificate
subject.  Add additional configuration options to identityd to receive a
CSR subject configuration and adjust `aziotctl config apply` to hydrate
these options with the certificate issuance options extracted for
`certd`.
