### PR TITLE
Fix E2E test failures caused by Azure Functions version 3.x end-of-life

### DIFF
--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -165,7 +165,7 @@ installTestTools() {
             done
             set -e
 
-            sudo apt-get install -y apt-transport-https dotnet-sdk-6.0 azure-functions-core-tools-4
+            sudo apt-get install -y apt-transport-https dotnet-sdk-6.0 azure-functions-core-tools
             ;;
         *)
             echo "Install of test tools unsupported on OS: $os" >&2

--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -148,6 +148,7 @@ installTestTools() {
     local os="${distributor_id,,}"
     case "$os" in
         debian|ubuntu)
+            sudo apt-get install dotnet6 -y 
             release="$(lsb_release -rs)"
             wget "https://packages.microsoft.com/config/$os/$release/packages-microsoft-prod.deb" \
                 -O packages-microsoft-prod.deb
@@ -164,8 +165,7 @@ installTestTools() {
                 fi
             done
             set -e
-            sudo apt-get remove -y dotnet-sdk-7.0 dotnet-runtime-7.0
-            sudo apt-get install -y apt-transport-https dotnet-sdk-6.0 dotnet-runtime-6.0 azure-functions-core-tools
+            sudo apt-get install -y apt-transport-https azure-functions-core-tools
             ;;
         *)
             echo "Install of test tools unsupported on OS: $os" >&2

--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -107,7 +107,8 @@ setupCustomAllocationPolicy() {
             --resource-group $AZURE_RESOURCE_GROUP_NAME \
             --consumption-plan-location $AZURE_LOCATION \
             --runtime dotnet \
-            --runtime-version 2 \
+            --runtime-version 6 \
+            --functions-version 4 \
             --name "$dps_allocation_functionapp_name" \
             --disable-app-insights \
             --storage-account "$dps_allocation_storage_account" \

--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -107,7 +107,7 @@ setupCustomAllocationPolicy() {
             --resource-group $AZURE_RESOURCE_GROUP_NAME \
             --consumption-plan-location $AZURE_LOCATION \
             --runtime dotnet \
-            --functions-version 3 \
+            --functions-version 4 \
             --name "$dps_allocation_functionapp_name" \
             --disable-app-insights \
             --storage-account "$dps_allocation_storage_account" \

--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -107,7 +107,7 @@ setupCustomAllocationPolicy() {
             --resource-group $AZURE_RESOURCE_GROUP_NAME \
             --consumption-plan-location $AZURE_LOCATION \
             --runtime dotnet \
-            --functions-version 4 \
+            --runtime-version 2 \
             --name "$dps_allocation_functionapp_name" \
             --disable-app-insights \
             --storage-account "$dps_allocation_storage_account" \

--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -164,8 +164,8 @@ installTestTools() {
                 fi
             done
             set -e
-            sudo apt-get remove -y dotnet-sdk-7.0
-            sudo apt-get install -y apt-transport-https dotnet-sdk-6.0 azure-functions-core-tools
+            sudo apt-get remove -y dotnet-sdk-7.0 dotnet-runtime-7.0
+            sudo apt-get install -y apt-transport-https dotnet-sdk-6.0 dotnet-runtime-6.0 azure-functions-core-tools
             ;;
         *)
             echo "Install of test tools unsupported on OS: $os" >&2

--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -164,7 +164,7 @@ installTestTools() {
                 fi
             done
             set -e
-
+            sudo apt-get remove -y dotnet-sdk-7.0
             sudo apt-get install -y apt-transport-https dotnet-sdk-6.0 azure-functions-core-tools
             ;;
         *)


### PR DESCRIPTION
Azure functions version 3 reached EoL on 12/13/2022, after which the E2E tests started failing during the suite setup step that creates and publishes a function app. The changes in this PR resolve the issue causing the failure. They have been tested by running a manual E2E test pipeline/workflow.