### PR TITLE
Upgade CI runners to ubuntu:22.04

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   packages:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -48,7 +48,7 @@ jobs:
           os: 'mariner:2'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         submodules: 'recursive'
     - name: 'Run'
@@ -81,7 +81,7 @@ jobs:
         os_package="$(sed -e 's@[:/]@-@g' <<< "$os_package")"
         echo "::set-output name=artifact-name::packages_${os_package}_${{ matrix.arch }}"
     - name: 'Upload'
-      uses: 'actions/upload-artifact@v1'
+      uses: 'actions/upload-artifact@v3'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: 'packages'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   basic:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -28,7 +28,7 @@ jobs:
         - 'amd64'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         submodules: 'recursive'
     - name: 'Run'
@@ -68,7 +68,7 @@ jobs:
 
 
   aziot-key-openssl-engine-shared:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -95,7 +95,7 @@ jobs:
     needs: 'basic'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         submodules: 'recursive'
     - name: 'Generate artifact properties'
@@ -132,7 +132,7 @@ jobs:
         PKCS11_BACKEND: "${{ matrix.pkcs11_backend }}"
 
   mock-iot-tests:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -151,7 +151,7 @@ jobs:
     needs: 'basic'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
     - name: 'Generate artifact properties'
       id: 'generate-artifact-properties'
       run: |
@@ -194,19 +194,19 @@ jobs:
         SERVER_KEY: '/src/mock_iot_server_certs/server_cert_key.pem'
 
   openapi:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
     - name: 'Test OpenAPI specs'
       run: |
         make target/openapi-schema-validated
 
   codecoverage:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         submodules: 'recursive'
 


### PR DESCRIPTION
Ubunutu 18.04 is deprecated on GitHub actions. Upgrade CI runners to Ubuntu 22.04.