### PR TITLE
feature/snapping: fix file permissions issues

### DIFF
--- a/aziotctl/aziotctl-common/src/config/mod.rs
+++ b/aziotctl/aziotctl-common/src/config/mod.rs
@@ -62,13 +62,22 @@ pub fn write_file(
     let path = path.as_ref();
     let path_displayable = path.display();
 
+    // We're about to truncate the file anyway, but it is a little safer to
+    // fully remove it, as a truncating write does not actually reset ownership
+    // or user permissions (which can lead to needing CAP_FOWNER, as then we 
+    // encounter a set_permissions call on a file we may or may not own). We
+    // can just ignore any errors returned here as they either mean a) the file
+    // doesn't exist, in which case great, or b) there is some sort of permission
+    // or path error which will just crop up in the fs::write call anyway
+
+    let _ = fs::remove_file(path);
+
     let () = fs::write(path, content)
         .with_context(|| format!("could not create {}", path_displayable))?;
-    let () = unistd::chown(path, Some(user.uid), Some(user.gid))
-        .with_context(|| format!("could not set ownership on {}", path_displayable))?;
-    #[cfg(not(feature = "snapctl"))] // Workaround - set_permissions hits a permission denied in a snapped environment. The 2 above work.
     let () = fs::set_permissions(path, fs::Permissions::from_mode(mode))
         .with_context(|| format!("could not set permissions on {}", path_displayable))?;
+    let () = unistd::chown(path, Some(user.uid), Some(user.gid))
+        .with_context(|| format!("could not set ownership on {}", path_displayable))?;
 
     Ok(())
 }


### PR DESCRIPTION
The aziotctl_common::config::write_file function first changes ownership of a file, then changes the permissions.

Changing the permissions on a file owned by another user requires CAP_FOWNER. While this is not normally a problem for root, the assumption that root ALWAYS has CAP_FOWNER is erroneous (snaps are a counter example).

This commit simply reorders the operation, so that the file is still owned by the creator when the permissions get changed.

NB: afaict this doesn't actually have any meaningful effects on the snapped identity service by itself (because everything runs as root, so no files ever actually change ownership.) It *does* impact iotedge, which leverages this code in a way that breaks in confinement.