### PR TITLE
feature/snapping: hostname reading fix on Ubuntu Core

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -10,8 +10,20 @@ toml_new_section() {
 	printf "[%s]\n" "$1"
 }
 
+# Work around the fact that there is no consolidated, machine readable
+# output of `hostnamectl` in the version included in core20. Core22 will
+# be more elegant (i.e. `hostnamectl hostname`)
+get_hostname() {
+	hostname="$(/usr/bin/hostnamectl --static)"
+	if [ -z "$hostname" ] ; then
+		hostname="$(/usr/bin/hostnamectl --transient)"
+	fi
+
+	printf "$hostname"
+}
+
 {
-	toml_kvp "hostname" "$(cat /etc/hostname)"
+	toml_kvp "hostname" "$(get_hostname)"
 
 	snapctl get raw-config
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,6 +140,13 @@ apps:
         listen-stream: $SNAP_DATA/shared/sockets/aziot/tpmd.sock
         socket-mode: 0666
 
+hooks:
+  configure:
+    plugs:
+      - hostname-control
+      - log-observe
+      - mount-observe
+
 environment:
   LD_LIBRARY_PATH: $SNAP/lib/aziot-identity-service
 


### PR DESCRIPTION
This fixes how the snap reads the device's hostname on Ubuntu Core, and should be more robust in general.