### PR TITLE
Fix failure to create VM in el9 scheduled E2E tests

### DIFF
--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -598,15 +598,15 @@ case "$OS" in
 
      'platform:el9')
         # az vm image list --all \
-        #     --publisher 'almalinux' --offer 'almalinux' --sku '9-gen2' \
-        #     --query "[?publisher == 'almalinux' && offer == 'almalinux'].{ sku: sku, version: version, urn: urn }" --output table
+        #     --publisher 'RedHat' --offer 'RHEL' --sku '9-lvm-gen2' \
+        #     --query "[?publisher == 'RedHat' && offer == 'RHEL'].{ sku: sku, version: version, urn: urn }" --output table
         #
         # When changing this, accept the VM image terms with
         #
         #    az vm image terms accept --urn "$vm_image"
         #
         # The Azure SP does not have permissions to do this. Use your regular Azure account.
-        vm_image='almalinux:almalinux:9-gen2:latest'
+        vm_image='RedHat:RHEL:9-lvm-gen2:latest'
         ;;
 
     'ubuntu:18.04')


### PR DESCRIPTION
Switches from the Alma Linux 9 image to the RedHat 9 image. This resolves the el9 E2E test failures caused by the 'az vm create' command timing out.

Changes have been tested by running the e2e-manual-test workflow in my forked repo. The 4 el9 tests now run to completion, however the manual and DPS x509 tests now fail due to what looks like an openssl3 bug. These failures will be addressed at a later time.