### PR TITLE
Bump openssl to patch vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,9 +1904,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",


### PR DESCRIPTION
Cherry-pick 65354c469e84d2fd3883d20f116474df161e9d68.

This change updates openssl to 0.10.48 and openssl-sys to 0.9.83 to fix [vulnerabilities](https://github.com/sfackler/rust-openssl/commit/5efceaabd69c540b487f6372be4982cf94884008).