### PR TITLE
Add RHEL 9

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -51,6 +51,7 @@ jobs:
         - 'debian:11'
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
         # - 'platform:el8'
+        - 'platform:el9'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'

--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -17,10 +17,10 @@ on:
 
 jobs:
   suite-setup:
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ github.event.inputs.branch }}"
 
@@ -39,7 +39,7 @@ jobs:
   test-run:
     needs: 'suite-setup'
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -63,7 +63,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ github.event.inputs.branch }}"
 
@@ -104,10 +104,10 @@ jobs:
     needs: 'test-run'
     if: "${{ success() }}"
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ github.event.inputs.branch }}"
 
@@ -127,10 +127,10 @@ jobs:
     needs: 'test-run'
     if: "${{ failure() }}"
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ github.event.inputs.branch }}"
 

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -19,7 +19,7 @@ jobs:
   suite-setup:
     if: "github.repository == 'Azure/iot-identity-service'"
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -32,7 +32,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ matrix.branch }}"
 
@@ -52,7 +52,7 @@ jobs:
     if: "github.repository == 'Azure/iot-identity-service'"
     needs: 'suite-setup'
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -79,7 +79,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ matrix.branch }}"
 
@@ -120,7 +120,7 @@ jobs:
     if: "${{ github.repository == 'Azure/iot-identity-service' && success() }}"
     needs: 'test-run'
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -133,7 +133,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ matrix.branch }}"
 
@@ -153,7 +153,7 @@ jobs:
     needs: 'test-run'
     if: "${{ failure() }}"
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-22.04'
 
     strategy:
       fail-fast: false
@@ -166,7 +166,7 @@ jobs:
       max-parallel: 10
 
     steps:
-    - uses: 'actions/checkout@v1'
+    - uses: 'actions/checkout@v3'
       with:
         ref: "${{ matrix.branch }}"
 

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -67,6 +67,7 @@ jobs:
         - 'debian:11'
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
         # - 'platform:el8'
+        - 'platform:el9'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -17,6 +17,7 @@ jobs:
         - 'debian:10-slim'
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
+        - 'redhat/ubi9:latest'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'
@@ -33,10 +34,14 @@ jobs:
           arch: 'arm32v7'
         - container_os: 'centos:7'
           arch: 'aarch64'
-        # More investigation needed for RHEL 8. Excluding for now.
+        # More investigation needed for RHEL 8 and 9. Excluding for now.
         - container_os: 'redhat/ubi8:latest'
           arch: 'arm32v7'
         - container_os: 'redhat/ubi8:latest'
+          arch: 'aarch64'
+        - container_os: 'redhat/ubi9:latest'
+          arch: 'arm32v7'
+        - container_os: 'redhat/ubi9:latest'
           arch: 'aarch64'
         # Include this for mariner package builds. Mariner cannot be built on its own OS so we need an Ubuntu container.
         include:

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -79,7 +79,7 @@ jobs:
           os_package="$OS"
         fi
         os_package="$(sed -e 's@[:/]@-@g' <<< "$os_package")"
-        echo "::set-output name=artifact-name::packages_${os_package}_${{ matrix.arch }}"
+        echo "artifact-name=packages_${os_package}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
     - name: 'Upload'
       uses: 'actions/upload-artifact@v3'
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,14 +45,14 @@ jobs:
       run: |
         container_os="${{ matrix.container_os }}"
         container_os="$(sed -e 's@[:/]@-@g' <<< "$container_os")"
-        echo "::set-output name=artifact-name::test-artifacts_${container_os}_${{ matrix.arch }}"
+        echo "artifact-name=test-artifacts_${container_os}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
         case "${{ matrix.arch }}" in
           'amd64') target_dir='x86_64-unknown-linux-gnu' ;;
           'arm32v7') target_dir='armv7-unknown-linux-gnueabihf' ;;
           'aarch64') target_dir='aarch64-unknown-linux-gnu' ;;
         esac
-        echo "::set-output name=target_dir::$target_dir"
+        echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Upload'
       uses: 'actions/upload-artifact@v2'
       with:
@@ -103,14 +103,14 @@ jobs:
       run: |
         container_os="${{ matrix.container_os }}"
         container_os="$(sed -e 's@[:/]@-@g' <<< "$container_os")"
-        echo "::set-output name=artifact-name::test-artifacts_${container_os}_${{ matrix.arch }}"
+        echo "artifact-name=test-artifacts_${container_os}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
         case "${{ matrix.arch }}" in
           'amd64') target_dir='x86_64-unknown-linux-gnu' ;;
           'arm32v7') target_dir='armv7-unknown-linux-gnueabihf' ;;
           'aarch64') target_dir='aarch64-unknown-linux-gnu' ;;
         esac
-        echo "::set-output name=target_dir::$target_dir"
+        echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
       uses: 'actions/download-artifact@v2'
@@ -157,14 +157,14 @@ jobs:
       run: |
         container_os="${{ matrix.container_os }}"
         container_os="$(sed -e 's@[:/]@-@g' <<< "$container_os")"
-        echo "::set-output name=artifact-name::test-artifacts_${container_os}_${{ matrix.arch }}"
+        echo "artifact-name=test-artifacts_${container_os}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
 
         case "${{ matrix.arch }}" in
           'amd64') target_dir='x86_64-unknown-linux-gnu' ;;
           'arm32v7') target_dir='armv7-unknown-linux-gnueabihf' ;;
           'aarch64') target_dir='aarch64-unknown-linux-gnu' ;;
         esac
-        echo "::set-output name=target_dir::$target_dir"
+        echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
       uses: 'actions/download-artifact@v2'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
         - 'debian:10-slim'
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
+        - 'redhat/ubi9:latest'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'
@@ -79,6 +80,7 @@ jobs:
         - 'debian:10-slim'
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
+        - 'redhat/ubi9:latest'
         - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'
@@ -142,6 +144,7 @@ jobs:
         - 'centos:7'
         - 'debian:10-slim'
         - 'redhat/ubi8:latest'
+        - 'redhat/ubi9:latest'
         - 'ubuntu:18.04'
         arch:
         - 'amd64'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
         esac
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Upload'
-      uses: 'actions/upload-artifact@v2'
+      uses: 'actions/upload-artifact@v3'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: |
@@ -113,7 +113,7 @@ jobs:
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
-      uses: 'actions/download-artifact@v2'
+      uses: 'actions/download-artifact@v3'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: 'target/debug'
@@ -167,7 +167,7 @@ jobs:
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
-      uses: 'actions/download-artifact@v2'
+      uses: 'actions/download-artifact@v3'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: 'target/debug'

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ rpm:
 	# which we can get from openssl 1.1 with `openssl version -e` but not from openssl 1.0.
 	# Also, the filename for 1.0 should have a `lib` prefix.
 	#
-	# CentOS 7 has 1.0 and RedHat 8 has 1.1, so we need to support both here.
+	# CentOS 7 has 1.0 and RedHat 8 has 1.1, so we need to support both here. RedHat 9 has 3.0.
 	#
 	# Since there is no RPM macro for those two things, we have to infer them from
 	# the output of `openssl version` and `openssl version -e` ourselves. This wouldn't be right
@@ -339,7 +339,7 @@ rpm:
 	command -v openssl # Assert that openssl exists
 	case "$$(openssl version)" in \
 		'OpenSSL 1.0.'*) OPENSSL_ENGINE_FILENAME='%\{_libdir\}/openssl/engines/libaziot_keys.so' ;; \
-		'OpenSSL 1.1.'*) OPENSSL_ENGINE_FILENAME="$$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/')/aziot_keys.so" ;; \
+		'OpenSSL 1.1.'* | 'OpenSSL 3.0.'*) OPENSSL_ENGINE_FILENAME="$$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/')/aziot_keys.so" ;; \
 		*) echo "Unknown openssl version [$$(openssl version)]"; exit 1 ;; \
 	esac; \
 	case "$$PACKAGE_DIST" in \
@@ -347,7 +347,7 @@ rpm:
 			DEVTOOLSET=devtoolset-9-; \
 			LLVM_TOOLSET=llvm-toolset-7-; \
 			;; \
-		'el8') \
+		'el8'|'el9') \
 			DEVTOOLSET=; \
 			LLVM_TOOLSET=; \
 			;; \

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -101,6 +101,10 @@ get_package() {
             artifact_name='redhat-ubi8-latest'
             ;;
 
+        'platform:el9')
+            artifact_name='redhat-ubi9-latest'
+            ;;
+
         'ubuntu:18.04')
             artifact_name='ubuntu-18.04'
             ;;
@@ -192,6 +196,11 @@ get_package() {
 
         'platform:el8')
             unzip -j package.zip 'el8/amd64/aziot-identity-service-*.x86_64.rpm' -x '*-debuginfo-*.rpm' '*-devel-*.rpm' >&2
+            printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
+            ;;
+
+        'platform:el9')
+            unzip -j package.zip 'el9/amd64/aziot-identity-service-*.x86_64.rpm' -x '*-debuginfo-*.rpm' '*-devel-*.rpm' >&2
             printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
             ;;
 
@@ -585,6 +594,19 @@ case "$OS" in
         #
         # The Azure SP does not have permissions to do this. Use your regular Azure account.
         vm_image='almalinux:almalinux:8_4-gen2:latest'
+        ;;
+
+     'platform:el9')
+        # az vm image list --all \
+        #     --publisher 'almalinux' --offer 'almalinux' --sku '9-gen2' \
+        #     --query "[?publisher == 'almalinux' && offer == 'almalinux'].{ sku: sku, version: version, urn: urn }" --output table
+        #
+        # When changing this, accept the VM image terms with
+        #
+        #    az vm image terms accept --urn "$vm_image"
+        #
+        # The Azure SP does not have permissions to do this. Use your regular Azure account.
+        vm_image='almalinux:almalinux:9-gen2:latest'
         ;;
 
     'ubuntu:18.04')

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -902,7 +902,7 @@ ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" "
         exit 1
     fi
 
-    if [ \"$OS\" != 'ubuntu:22.04' ] || [[ \"$test_name\" != *'-x509'* ]]; then
+    if [[ (\"$OS\" != 'ubuntu:22.04' && \"$OS\" != 'platform:el9') ||  \"$test_name\" != *'-x509'* ]]; then
         device_twin=\"\$(~/iothub-get-twin.sh \"\$device_identity\")\"
         printf 'Device twin: %s\n' \"\$device_twin\" >&2
     fi
@@ -928,7 +928,7 @@ ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" "
         exit 1
     fi
 
-    if [ \"$OS\" != 'ubuntu:22.04' ] || [[ \"$test_name\" != *'-x509'* ]]; then
+    if [[ (\"$OS\" != 'ubuntu:22.04' && \"$OS\" != 'platform:el9') ||  \"$test_name\" != *'-x509'* ]]; then
         module_twin=\"\$(~/iothub-get-twin.sh \"\$module_identity\")\"
         printf 'Module twin: %s\n' \"\$module_twin\" >&2
     fi

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -350,7 +350,7 @@ EOF
                 --query "invokeUrlTemplate" --output tsv \
                 --name $dps_allocation_functionapp_name
         )"
-        
+
         echo 'Creating symmetric key enrollment group in DPS...' >&2
         dps_symmetric_key="$(
             az iot dps enrollment-group create \
@@ -880,8 +880,10 @@ ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" "
         exit 1
     fi
 
-    device_twin=\"\$(~/iothub-get-twin.sh \"\$device_identity\")\"
-    printf 'Device twin: %s\n' \"\$device_twin\" >&2
+    if [ \"$OS\" != 'ubuntu:22.04' ] || [[ \"$test_name\" != *'-x509'* ]]; then
+        device_twin=\"\$(~/iothub-get-twin.sh \"\$device_identity\")\"
+        printf 'Device twin: %s\n' \"\$device_twin\" >&2
+    fi
 
     module_identity=\"\$(
         curl --unix-socket '/run/aziot/identityd.sock' \\
@@ -904,7 +906,9 @@ ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" "
         exit 1
     fi
 
-    module_twin=\"\$(~/iothub-get-twin.sh \"\$module_identity\")\"
-    printf 'Module twin: %s\n' \"\$module_twin\" >&2
+    if [ \"$OS\" != 'ubuntu:22.04' ] || [[ \"$test_name\" != *'-x509'* ]]; then
+        module_twin=\"\$(~/iothub-get-twin.sh \"\$module_identity\")\"
+        printf 'Module twin: %s\n' \"\$module_twin\" >&2
+    fi
 "
 echo 'Test passed.' >&2

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -126,7 +126,16 @@ case "$OS:$ARCH" in
             pkgconfig
         ;;
 
-    'platform:el8:aarch64'|'platform:el8:arm32v7')
+     'platform:el9:amd64')
+        export VENDOR_LIBTSS=1
+
+        dnf install -y \
+            autoconf autoconf-archive automake clang cmake diffutils gcc gcc-c++ \
+            git jq make libcurl-devel libtool llvm-devel openssl-devel \
+            pkgconfig
+        ;;
+
+    'platform:el8:aarch64'|'platform:el8:arm32v7'|'platform:el9:aarch64'|'platform:el9:arm32v7')
         echo "Cross-compilation on $OS $ARCH is not supported" >&2
         exit 1
         ;;

--- a/ci/mock-iot-tests/mock-iot-setup.sh
+++ b/ci/mock-iot-tests/mock-iot-setup.sh
@@ -10,7 +10,7 @@ case "$CONTAINER_OS" in
         cp "$ROOT_CERT" /usr/local/share/ca-certificates/dps_root_cert.crt
         update-ca-certificates
         ;;
-    'centos:7' | 'redhat/ubi8:latest')
+    'centos:7' | 'redhat/ubi8:latest' | 'redhat/ubi9:latest')
         mkdir -p /etc/pki/ca-trust/source/anchors
         cp "$ROOT_CERT" /etc/pki/ca-trust/source/anchors/dps_root_cert.crt
         update-ca-trust

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -11,7 +11,7 @@ mkdir -p packages
 
 
 case "$OS" in
-    'centos:7'|'platform:el8')
+    'centos:7'|'platform:el8'|'platform:el9')
         case "$ARCH" in
             'arm32v7'|'aarch64')
                 echo "Cross-compilation on $OS is not supported" >&2
@@ -29,6 +29,12 @@ case "$OS" in
                 TARGET_DIR="el8/$ARCH"
                 PACKAGE_DIST="el8"
                 ;;
+
+            'platform:el9')
+                TARGET_DIR="el9/$ARCH"
+                PACKAGE_DIST="el9"
+                ;;
+
         esac
 
         yum -y install rpm-build

--- a/ci/test-aziot-key-openssl-engine-shared.sh
+++ b/ci/test-aziot-key-openssl-engine-shared.sh
@@ -13,7 +13,7 @@ case "$OS" in
             /usr/lib64/openssl/engines/libaziot_keys.so
         ;;
 
-    'debian:10'|'debian:11'|'platform:el8'|'ubuntu:18.04'|'ubuntu:20.04'|'ubuntu:22.04')
+    'debian:10'|'debian:11'|'platform:el8'|'platform:el9'|'ubuntu:18.04'|'ubuntu:20.04'|'ubuntu:22.04')
         cp \
             ./target/debug/libaziot_key_openssl_engine_shared.so \
             "$(openssl version -e | sed -E 's/^ENGINESDIR: "(.*)"$/\1/')/aziot_keys.so"

--- a/docs-dev/packages.md
+++ b/docs-dev/packages.md
@@ -19,6 +19,10 @@ This repository contains three services - `aziot-certd`, `aziot-identityd` and `
 <td>RHEL 8 compatible</td>
 <td><code>redhat/ubi8:latest</code></td>
 </tr>
+<<tr>
+<td>RHEL 9 compatible</td>
+<td><code>redhat/ubi9:latest</code></td>
+</tr>
 <tr>
 <td>Debian 10 / Raspberry Pi OS 10</td>
 <td><code>debian:10-slim</code></td>
@@ -133,5 +137,7 @@ The first file is the binary package, the second through fourth file together co
 1. Building ARM32 and ARM64 packages for CentOS 7 is currently not supported, because CentOS 7 does do not have functional cross compilers for those architectures. (It has the `gcc` cross compiler itself but not a cross `glibc` for the compiled binary to link to, because the cross compiler is only intended for cross-compiling the kernel.)
 
 1. Building ARM32 and ARM64 packages for RHEL 8 is currently not supported. More investigation would be required to determine feasibility.
+
+1. Building ARM32 and ARM64 packages for RHEL 9 is currently not supported. More investigation would be required to determine feasibility.
 
 1. The packages script is also run in our CI, via the `.github/workflows/packages.yaml` file.


### PR DESCRIPTION
Cherry-pick
* 0437197bda6e0d09e6439fbfca879c2ee1ef8963 Use github environment files in workflows
* 0236a869c36d6ee5745ac75538172af130cd4e7b Update all uses of checkout, upload-artifact and download-artifact Actions to v3.
* f930d8a6e450d2c08cb7f8a3ce5c67a926d4e618 Disable X.509 E2E tests on Ubuntu 22.04
* ec0ee94356938b0dd1ccefedd2946e3b152bd65f Add RHEL 9
* 8519225ca1c6a24ad847ef1f6314b649d3f29333 Disable X.509 E2E tests on RHEL 9