### PR TITLE
E2E Test: Move dotnet6 install after apt-get update

### DIFF
--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -148,7 +148,6 @@ installTestTools() {
     local os="${distributor_id,,}"
     case "$os" in
         debian|ubuntu)
-            sudo apt-get install dotnet6 -y 
             release="$(lsb_release -rs)"
             wget "https://packages.microsoft.com/config/$os/$release/packages-microsoft-prod.deb" \
                 -O packages-microsoft-prod.deb
@@ -165,7 +164,7 @@ installTestTools() {
                 fi
             done
             set -e
-            sudo apt-get install -y apt-transport-https azure-functions-core-tools
+            sudo apt-get install -y dotnet6 apt-transport-https azure-functions-core-tools
             ;;
         *)
             echo "Install of test tools unsupported on OS: $os" >&2


### PR DESCRIPTION
Fixes an issue we run into after each .NET release, where the the scheduled E2E workflow fails during the suite-setup job's install of the dotnet6 package. This is because `apt-get update` needs to be run before `apt-get install dotnet6`.

This change has been tested using a manual E2E workflow run: https://github.com/Azure/iot-identity-service/actions/runs/5325634976