### PR TITLE
Add prefer_module_identity_cache option

### DIFF
--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -27,6 +27,7 @@ pub fn run(
         cloud_timeout_sec,
         cloud_retries,
         aziot_max_requests,
+        prefer_module_identity_cache,
         mut aziot_keys,
         mut preloaded_keys,
         cert_issuance,
@@ -342,6 +343,8 @@ pub fn run(
         },
 
         homedir: super::AZIOT_IDENTITYD_HOMEDIR_PATH.into(),
+
+        prefer_module_identity_cache,
 
         max_requests: aziot_max_requests.identityd,
 

--- a/aziotctl/aziotctl-common/src/config/super_config.rs
+++ b/aziotctl/aziotctl-common/src/config/super_config.rs
@@ -54,6 +54,9 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "AziotMaxRequests::is_default")]
     pub aziot_max_requests: AziotMaxRequests,
 
+    #[serde(default)]
+    pub prefer_module_identity_cache: bool,
+
     pub provisioning: Provisioning,
 
     pub localid: Option<aziot_identityd_config::LocalId>,

--- a/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key-no-pad/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key-no-pad/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-symmetric-key/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-tpm/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-tpm/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-est-bootstrap-auto-renew/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-bootstrap/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-custom-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-custom-bootstrap/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est-subject-dn-bootstrap/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-est/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11-localca/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509-pkcs11/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/dps-x509/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/dps-x509/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/aziotctl/aziotctl-common/test-files/apply/local-gateway/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/local-gateway/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 local_gateway_hostname = "my-gateway-device"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-connection-string/config.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-connection-string/config.toml
@@ -1,3 +1,5 @@
+prefer_module_identity_cache = true
+
 [provisioning]
 source = "manual"
 connection_string = "HostName=example.azure-devices.net;DeviceId=my-device;SharedAccessKey=YXppb3QtaWRlbnRpdHktc2VydmljZXxhemlvdC1pZGU="

--- a/aziotctl/aziotctl-common/test-files/apply/manual-connection-string/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-connection-string/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = true
 
 [provisioning]
 source = "manual"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-symmetric-key-no-pad/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-symmetric-key-no-pad/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-symmetric-key/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-symmetric-key/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-custom-http/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-custom-http/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-custom/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-custom/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-est-subject-dn/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509-pkcs11/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509-pkcs11/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/aziotctl/aziotctl-common/test-files/apply/manual-x509/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/manual-x509/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/aziotctl/aziotctl-common/test-files/apply/throttle-limits/identityd.toml
+++ b/aziotctl/aziotctl-common/test-files/apply/throttle-limits/identityd.toml
@@ -1,5 +1,6 @@
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 max_requests = 50
 
 [provisioning]

--- a/aziotctl/config/unix/template.toml
+++ b/aziotctl/config/unix/template.toml
@@ -29,14 +29,28 @@
 # cloud_retries controls how many times a request may be retried should it fail.
 # The client will always send at least one attempt, so its value will be the number
 # of retries after the first attempt should that fail (i.e. cloud_retries = 2
-# means that the client will make a total of 3 attempts). 
+# means that the client will make a total of 3 attempts).
 #
-# cloud_timeout_sec has a minimum of 70s to allow hub to throttle requests. 
+# cloud_timeout_sec has a minimum of 70s to allow hub to throttle requests.
 # If a request is throttled, it will enter an exponential backoff with 4 retries instead
 # of using the configured value. The configured value is used for all other errors.
 #
 # cloud_timeout_sec = 70
 # cloud_retries = 1
+
+# ==============================================================================
+# Module identity cache preference
+# ==============================================================================
+#
+# The default behavior is to request module identities from IoT Hub and fall back to a
+# cached backup if the Hub request fails. This keeps identities in sync with IoT Hub,
+# but results in extra requests to Hub that may not be necessary depending on use case.
+#
+# Setting prefer_module_identity_cache to true reverses the behavior so that the cached
+# identities are preferred to IoT Hub requests. Requests to Hub are still made if identities
+# are not found in the cache.
+#
+# prefer_module_identity_cache = false
 
 # ==============================================================================
 # Provisioning

--- a/aziotctl/src/config/mp.rs
+++ b/aziotctl/src/config/mp.rs
@@ -75,6 +75,8 @@ To reconfigure IoT Identity Service, run:
 
         aziot_max_requests: Default::default(),
 
+        prefer_module_identity_cache: Default::default(),
+
         aziot_keys: Default::default(),
 
         preloaded_keys: Default::default(),

--- a/aziotctl/src/internal/check/checks/host_connect_iothub.rs
+++ b/aziotctl/src/internal/check/checks/host_connect_iothub.rs
@@ -219,6 +219,7 @@ mod tests {
             max_requests: 10,
             cloud_retries: 1,
             cloud_timeout_sec: 1,
+            prefer_module_identity_cache: false,
             provisioning: device_provisioning,
             principal: Vec::new(),
             endpoints: Endpoints::default(),

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -267,10 +267,10 @@ case "$OS:$ARCH" in
         apt-get install -y \
             cmake curl gcc g++ git jq make pkg-config \
             libclang1 libssl-dev llvm-dev \
-            cpio genisoimage golang-1.17-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+            cpio genisoimage golang-1.19-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
         rm -f /usr/bin/go
-        ln -vs /usr/lib/go-1.17/bin/go /usr/bin/go
+        ln -vs /usr/lib/go-1.19/bin/go /usr/bin/go
         if [ -f /.dockerenv ]; then
             mv /.dockerenv /.dockerenv.old
         fi

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -21,6 +21,9 @@ pub struct Settings {
 
     pub homedir: std::path::PathBuf,
 
+    #[serde(default)]
+    pub prefer_module_identity_cache: bool,
+
     /// Maximum number of simultaneous requests per user that identityd will service.
     #[serde(
         default = "http_common::Incoming::default_max_requests",

--- a/identity/aziot-identityd/src/identity.rs
+++ b/identity/aziot-identityd/src/identity.rs
@@ -20,6 +20,7 @@ pub(crate) const DEVICE_BACKUP_LOCATION: &str = "device_info";
 
 pub struct IdentityManager {
     homedir_path: std::path::PathBuf,
+    prefer_module_identity_cache: bool,
     req_timeout: std::time::Duration,
     req_retries: u32,
     key_client: Arc<aziot_key_client_async::Client>,
@@ -46,6 +47,7 @@ impl IdentityManager {
     ) -> Self {
         IdentityManager {
             homedir_path: settings.homedir.clone(),
+            prefer_module_identity_cache: settings.prefer_module_identity_cache,
             req_timeout: std::time::Duration::from_secs(settings.cloud_timeout_sec),
             req_retries: settings.cloud_retries,
             key_client,
@@ -295,9 +297,7 @@ impl IdentityManager {
 
         match &self.iot_hub_device {
             Some(device) => {
-                let prefer_module_identity_cache = true;
-
-                let module = if prefer_module_identity_cache {
+                let module = if self.prefer_module_identity_cache {
                     let module = ModuleBackup::get_module_backup(
                         &self.homedir_path,
                         &device.iothub_hostname,

--- a/identity/aziot-identityd/src/lib.rs
+++ b/identity/aziot-identityd/src/lib.rs
@@ -421,7 +421,7 @@ impl Api {
         }
 
         match_id_type!(id_type {
-            ID_TYPE_AZIOT => { self.id_manager.get_module_identities().await },
+            ID_TYPE_AZIOT => { self.id_manager.get_module_identities(true).await },
         })
     }
 


### PR DESCRIPTION
Adds the prefer_module_identity_cache (defaults to false) option in identityd's configuration.

Current behavior is to request module identities from IoT Hub and fall back to a cached backup if the Hub request fails. This keeps identities in sync with IoT Hub, but results in extra requests to Hub that may not be necessary depending on use case.

Setting prefer_module_identity_cache to true reverses the behavior so that the cached identities are preferred to IoT Hub requests. Requests to Hub are still made if identities are not found in the cache.