### PR TITLE
Remove socket path if it is a directory instead of a file

### DIFF
--- a/http-common/src/connector.rs
+++ b/http-common/src/connector.rs
@@ -298,6 +298,10 @@ impl Connector {
                 match std::fs::remove_file(&*socket_path) {
                     Ok(()) => (),
                     Err(err) if err.kind() == std::io::ErrorKind::NotFound => (),
+                    Err(err) if err.raw_os_error() == Some(libc::EISDIR) => {
+                        log::warn!("Could not remove socket file because it is a directory. Removing directory.");
+                        std::fs::remove_dir_all(&*socket_path)?;
+                    }
                     Err(err) => return Err(err),
                 }
 


### PR DESCRIPTION
Cherry-pick #544

Updates the http-common crate to call `remove_dir_all()` if `remove_file()` fails because the specified socket path is a directory. 

This fixes an issue that occurs sometimes in IoT Edge v1.4 where a module fails to start and aziot-edged reports the following errors in its logs:

> aziot-edged[90203]: 2023-08-18T19:02:49Z [INFO] - Starting module SimulatedTemperatureSensor...
> aziot-edged[90203]: 2023-08-18T19:02:49Z [INFO] - Starting new listener for module SimulatedTemperatureSensor
> aziot-edged[90203]: 2023-08-18T19:02:49Z [INFO] - Failed to start module SimulatedTemperatureSensor, error Failed to listen on workload socket: Is a directory (os error 21)
> aziot-edged[90203]: 2023-08-18T19:02:49Z [ERR!] - Could not wait on workload manager response, start of module: SimulatedTemperatureSensor

The above error state was reproduced with the following steps:
1. Start iotedge v1.4.18 w/ a custom module (i.e. the SimulatedTemperatureSensor)
2. Run `docker stop SimulatedTemperatureSensor`
3. Remove the module's workload socket file: `sudo rm /var/lib/aziot/edged/mnt/SimulatedTemperatureSensor.sock`
4. Run `docker start SimulatedTemperatureSensor` and note the error message about failing to mount the workload socket because the host path is a directory and not a file.
5. Run `watch -- iotedge list` and `sudo journalctl -f -u aziot-edged` and observe repeated failed attempts to start the module.

These changes were tested by reproducing the above error state in IoT Edge and then confirming that with the fix, aziot-edged removes the socket directory and is able to then successfully start the module:

> aziot-edged[138358]: 2023-08-18T20:12:08Z [INFO] - Starting workload API...
> aziot-edged[138358]: 2023-08-18T20:12:08Z [INFO] - Starting new listener for module SimulatedTemperatureSensor
> aziot-edged[138358]: 2023-08-18T20:12:08Z [WARN] - Could not remove socket file because it is a directory. Removing directory.