### PR TITLE
Update the golang to 1.20 for Mariner Toolkit

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -268,6 +268,8 @@ case "$OS:$ARCH" in
             cmake curl gcc g++ git jq make pkg-config \
             libclang1 libssl-dev llvm-dev \
             cpio genisoimage golang-1.20-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+        apt-get update
+        apt-get upgrade -y
 
         rm -f /usr/bin/go
         ln -vs /usr/lib/go-1.20/bin/go /usr/bin/go

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -268,6 +268,7 @@ case "$OS:$ARCH" in
             cmake curl gcc g++ git jq make pkg-config \
             libclang1 libssl-dev llvm-dev setfacl \
             cpio genisoimage golang-1.20-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+
         apt-get update
         apt-get upgrade -y
 

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -267,10 +267,10 @@ case "$OS:$ARCH" in
         apt-get install -y \
             cmake curl gcc g++ git jq make pkg-config \
             libclang1 libssl-dev llvm-dev \
-            cpio genisoimage golang-1.19-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+            cpio genisoimage golang-1.20-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
         rm -f /usr/bin/go
-        ln -vs /usr/lib/go-1.19/bin/go /usr/bin/go
+        ln -vs /usr/lib/go-1.20/bin/go /usr/bin/go
         if [ -f /.dockerenv ]; then
             mv /.dockerenv /.dockerenv.old
         fi

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -266,7 +266,7 @@ case "$OS:$ARCH" in
         apt-get update
         apt-get install -y \
             cmake curl gcc g++ git jq make pkg-config \
-            libclang1 libssl-dev llvm-dev \
+            libclang1 libssl-dev llvm-dev setfacl \
             cpio genisoimage golang-1.20-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
         apt-get update
         apt-get upgrade -y

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -266,7 +266,7 @@ case "$OS:$ARCH" in
         apt-get update
         apt-get install -y \
             cmake curl gcc g++ git jq make pkg-config \
-            libclang1 libssl-dev llvm-dev setfacl \
+            libclang1 libssl-dev llvm-dev \
             cpio genisoimage golang-1.20-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
         apt-get update


### PR DESCRIPTION
Update the golang to 1.20 for Mariner Toolkit