### PR TITLE
When creating an AES PKCS#11 key, test it with a dummy encryption to ensure that the token can perform AES-GCM.

### DIFF
--- a/key/aziot-keys/src/lib.rs
+++ b/key/aziot-keys/src/lib.rs
@@ -8,6 +8,7 @@
     clippy::default_trait_access,
     clippy::doc_markdown, // clippy wants "IoT" in a code fence
     clippy::let_and_return,
+    clippy::let_underscore_drop,
     clippy::let_unit_value,
     clippy::missing_safety_doc,
     clippy::shadow_unrelated,


### PR DESCRIPTION
Cherry-pick from main of 8cb888d8a956af09c52283aa67bad45e2678cf52

It is possible for PKCS#11 implementations to support AES keys only with AES-CBC etc but not with AES-GCM. Before this change, creating the key would succeed, and then encrypting with it would fail, at which point it would be too late.

With this change, we do a dummy encruption with the key just to be sure that it can be used with AES-GCM. If that fails, we continue to the next location, usually the filesystem ie openssl keys.