### PR TITLE
Remove Ubuntu 18.04 support

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -52,7 +52,6 @@ jobs:
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
         # - 'platform:el8'
         - 'platform:el9'
-        - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'
         test_name:

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -68,7 +68,6 @@ jobs:
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
         # - 'platform:el8'
         - 'platform:el9'
-        - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'
         test_name:

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -18,7 +18,6 @@ jobs:
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
         - 'redhat/ubi9:latest'
-        - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'
         arch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,6 @@ jobs:
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
         - 'redhat/ubi9:latest'
-        - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'
         arch:
@@ -81,7 +80,6 @@ jobs:
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
         - 'redhat/ubi9:latest'
-        - 'ubuntu:18.04'
         - 'ubuntu:20.04'
         - 'ubuntu:22.04'
         pkcs11_backend:
@@ -145,7 +143,6 @@ jobs:
         - 'debian:10-slim'
         - 'redhat/ubi8:latest'
         - 'redhat/ubi9:latest'
-        - 'ubuntu:18.04'
         arch:
         - 'amd64'
         test:
@@ -223,7 +220,7 @@ jobs:
           -e "ARCH=$ARCH" \
           --privileged \
           --name "code-cov" \
-          "ubuntu:18.04" \
+          "ubuntu:22.04" \
           '/src/ci/code-coverage.sh'
         sudo chown -R runner:docker $GITHUB_WORKSPACE/coverage
       env:

--- a/aziotctl/aziotctl-common/src/host_info.rs
+++ b/aziotctl/aziotctl-common/src/host_info.rs
@@ -50,7 +50,7 @@ impl Default for DmiInfo {
 ///  CentOS 7            | centos              | 7
 ///  Debian 9            | debian              | 9
 ///  openSUSE Tumbleweed | opensuse-tumbleweed | 20190325
-///  Ubuntu 18.04        | ubuntu              | 18.04
+///  Ubuntu 22.04        | ubuntu              | 22.04
 /// ```
 ///
 /// Ref: <https://www.freedesktop.org/software/systemd/man/os-release.html>

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -105,10 +105,6 @@ get_package() {
             artifact_name='redhat-ubi9-latest'
             ;;
 
-        'ubuntu:18.04')
-            artifact_name='ubuntu-18.04'
-            ;;
-
         'ubuntu:20.04')
             artifact_name='ubuntu-20.04'
             ;;
@@ -202,11 +198,6 @@ get_package() {
         'platform:el9')
             unzip -j package.zip 'el9/amd64/aziot-identity-service-*.x86_64.rpm' -x '*-debuginfo-*.rpm' '*-devel-*.rpm' >&2
             printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
-            ;;
-
-        'ubuntu:18.04')
-            unzip -j package.zip 'ubuntu1804/amd64/aziot-identity-service_*_amd64.deb' >&2
-            printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
             ;;
 
         'ubuntu:20.04')
@@ -607,13 +598,6 @@ case "$OS" in
         #
         # The Azure SP does not have permissions to do this. Use your regular Azure account.
         vm_image='RedHat:RHEL:9-lvm-gen2:latest'
-        ;;
-
-    'ubuntu:18.04')
-        # az vm image list --all \
-        #     --publisher 'Canonical' --offer 'UbuntuServer' --sku '18' \
-        #     --query "[?publisher == 'Canonical' && offer == 'UbuntuServer'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Canonical:UbuntuServer:18_04-lts-gen2:latest'
         ;;
 
     'ubuntu:20.04')

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -30,7 +30,7 @@ case "$OS:$ARCH" in
         exit 1
         ;;
 
-    'debian:10:amd64'|'ubuntu:18.04:amd64')
+    'debian:10:amd64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
         export VENDOR_LIBTSS=1
@@ -141,35 +141,6 @@ case "$OS:$ARCH" in
         ;;
 
 
-    'ubuntu:18.04:arm32v7')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
-        export VENDOR_LIBTSS=1
-
-        sources="$(</etc/apt/sources.list grep . | grep -v '^#' | grep -v '^deb \[arch=amd64\]' || :)"
-        if [ -n "$sources" ]; then
-            # Update existing repos to be specifically for amd64
-            sed -ie 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
-        fi
-
-        # Add armhf repos
-        </etc/apt/sources.list sed \
-            -e 's/^deb \[arch=amd64\] /deb [arch=armhf] /g' \
-            -e 's| http://archive.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
-            -e 's| http://security.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
-            >/etc/apt/sources.list.d/ports.list
-
-        dpkg --add-architecture armhf
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-armhf curl git jq \
-            libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
-            libltdl-dev:armhf libssl-dev:armhf libtool llvm-dev \
-            pkg-config
-        ;;
-
     'ubuntu:20.04:arm32v7'|'ubuntu:22.04:arm32v7')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
@@ -196,35 +167,6 @@ case "$OS:$ARCH" in
             libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
             libltdl-dev:armhf libssl-dev:armhf libtool libtss2-dev:armhf \
             llvm-dev pkg-config
-        ;;
-
-    'ubuntu:18.04:aarch64')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
-        export VENDOR_LIBTSS=1
-
-        sources="$(</etc/apt/sources.list grep . | grep -v '^#' | grep -v '^deb \[arch=amd64\]' || :)"
-        if [ -n "$sources" ]; then
-            # Update existing repos to be specifically for amd64
-            sed -ie 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
-        fi
-
-        # Add arm64 repos
-        </etc/apt/sources.list sed \
-            -e 's/^deb \[arch=amd64\] /deb [arch=arm64] /g' \
-            -e 's| http://archive.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
-            -e 's| http://security.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
-            >/etc/apt/sources.list.d/ports.list
-
-        dpkg --add-architecture arm64
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-arm64 curl git jq \
-            libc-dev:arm64 libclang1 libcurl4-openssl-dev:arm64 \
-            libltdl-dev:arm64 libssl-dev:arm64 libtool llvm-dev \
-            pkg-config
         ;;
 
     'ubuntu:20.04:aarch64'|'ubuntu:22.04:aarch64')
@@ -373,7 +315,7 @@ if [ "${OS#mariner}" = "$OS" ]; then
 
     cargo install cbindgen --version "=$CBINDGEN_VERSION"
 
-    if [ "$OS:$ARCH" = 'ubuntu:18.04:amd64' ]; then
+    if [ "$OS:$ARCH" = 'ubuntu:22.04:amd64' ]; then
         cargo install cargo-tarpaulin --version '^0.20' --locked
     fi
 fi

--- a/ci/install-runtime-deps.sh
+++ b/ci/install-runtime-deps.sh
@@ -46,7 +46,7 @@ case "$OS" in
 
     'debian:10'|'debian:11'|'ubuntu:20.04'|'ubuntu:22.04')
         # openssl 1.1.1 for Debian 10/11 and Ubuntu 20.04
-	    # openssl 3.0 for Ubuntu 22.04
+        # openssl 3.0 for Ubuntu 22.04
 
         apt-get update -y
         DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y curl jq openssl ca-certificates

--- a/ci/install-runtime-deps.sh
+++ b/ci/install-runtime-deps.sh
@@ -44,9 +44,9 @@ case "$OS" in
         esac
         ;;
 
-    'debian:10'|'debian:11'|'ubuntu:18.04'|'ubuntu:20.04'|'ubuntu:22.04')
-        # openssl 1.1.0 for Debian 9, 1.1.1 for Debian 10/11 and Ubuntu 18.04/20.04
-	# openssl 3.0 for Ubuntu 22.04
+    'debian:10'|'debian:11'|'ubuntu:20.04'|'ubuntu:22.04')
+        # openssl 1.1.1 for Debian 10/11 and Ubuntu 20.04
+	    # openssl 3.0 for Ubuntu 22.04
 
         apt-get update -y
         DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y curl jq openssl ca-certificates

--- a/ci/install-test-deps.sh
+++ b/ci/install-test-deps.sh
@@ -21,7 +21,7 @@ case "$OS" in
     # repositories, but the available version does not provide a TCTI
     # module for swtpm.  So, we skip testing tss-minimal on
     # ubuntu:20.04.
-    'debian:'*|'ubuntu:18.04')
+    'debian:'*)
         export SKIP_TSS_MINIMAL=0
         export USE_SWTPM_PKG=0
 

--- a/ci/mock-iot-tests/mock-iot-setup.sh
+++ b/ci/mock-iot-tests/mock-iot-setup.sh
@@ -5,7 +5,7 @@ set -eu
 # Install mock-iot-server's root CA certificate.
 # Don't modify trusted certificates if not running on a CI container OS.
 case "$CONTAINER_OS" in
-    'ubuntu:18.04' | 'debian:10-slim')
+    'debian:10-slim')
         mkdir -p /usr/local/share/ca-certificates
         cp "$ROOT_CERT" /usr/local/share/ca-certificates/dps_root_cert.crt
         update-ca-certificates

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -53,7 +53,7 @@ case "$OS" in
             "packages/$TARGET_DIR/"
         ;;
 
-    'debian:10'|'debian:11'|'ubuntu:18.04'|'ubuntu:20.04'|'ubuntu:22.04')
+    'debian:10'|'debian:11'|'ubuntu:20.04'|'ubuntu:22.04')
         DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y dh-make debhelper
 
         make ARCH="$ARCH" PACKAGE_VERSION="$PACKAGE_VERSION" PACKAGE_RELEASE="$PACKAGE_RELEASE" VENDOR_LIBTSS="${VENDOR_LIBTSS:-0}" V=1 deb
@@ -67,11 +67,6 @@ case "$OS" in
             'debian:11')
                 TARGET_DIR="debian11/$ARCH"
                 DBGSYM_EXT='deb'
-                ;;
-
-            'ubuntu:18.04')
-                TARGET_DIR="ubuntu1804/$ARCH"
-                DBGSYM_EXT='ddeb'
                 ;;
 
             'ubuntu:20.04')

--- a/ci/test-aziot-key-openssl-engine-shared.sh
+++ b/ci/test-aziot-key-openssl-engine-shared.sh
@@ -13,7 +13,7 @@ case "$OS" in
             /usr/lib64/openssl/engines/libaziot_keys.so
         ;;
 
-    'debian:10'|'debian:11'|'platform:el8'|'platform:el9'|'ubuntu:18.04'|'ubuntu:20.04'|'ubuntu:22.04')
+    'debian:10'|'debian:11'|'platform:el8'|'platform:el9'|'ubuntu:20.04'|'ubuntu:22.04')
         cp \
             ./target/debug/libaziot_key_openssl_engine_shared.so \
             "$(openssl version -e | sed -E 's/^ENGINESDIR: "(.*)"$/\1/')/aziot_keys.so"

--- a/docs-dev/e2e-tests.md
+++ b/docs-dev/e2e-tests.md
@@ -124,7 +124,7 @@ export GITHUB_RUN_NUMBER='1'
 
 
 # One of the supported OSes. The full list can be found in the workflows files.
-export OS='ubuntu:18.04'
+export OS='ubuntu:22.04'
 
 
 # Suite-level setup for things shared between all tests (IoT Hub, DPS, etc)

--- a/docs-dev/packages.md
+++ b/docs-dev/packages.md
@@ -32,10 +32,6 @@ This repository contains three services - `aziot-certd`, `aziot-identityd` and `
 <td><code>debian:11-slim</code></td>
 </tr>
 <tr>
-<td>Ubuntu 18.04</td>
-<td><code>ubuntu:18.04</code></td>
-</tr>
-<tr>
 <td>Ubuntu 20.04</td>
 <td><code>ubuntu:20.04</code></td>
 </tr>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,94 +1,31 @@
 # Installing the Azure IoT Identity Service
 
-The Azure IoT Identity Service can be installed on your device by installing the appropriate `aziot-identity-service`. Packages are provided for the following distributions and architectures with each [release of Azure IoT Edge as of v1.2](https://github.com/Azure/azure-iotedge/releases):
-
-<table>
-<thead>
-<tr>
-<th>OS</th>
-<th>Architectures</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Debian 10, Raspberry Pi OS 10</td>
-<td>amd64, arm32v7, aarch64</td>
-</tr>
-<tr>
-<td>Debian 11, Raspberry Pi OS 11</td>
-<td>amd64, arm32v7, aarch64</td>
-</tr>
-<tr>
-<td>Ubuntu 18.04</td>
-<td>amd64, arm32v7, aarch64</td>
-</tr>
-<tr>
-<td>Ubuntu 20.04</td>
-<td>amd64, arm32v7, aarch64</td>
-</tr>
-<tr>
-<td>CentOS 7</td>
-<td>amd64</td>
-</tr>
-<tr>
-<td>RHEL 8</td>
-<td>amd64</td>
-</tr>
-</tbody>
-</table>
-
-Packages for some of these distros are available on packages.microsoft.com. 
+The Azure IoT Identity Service can be installed on your device by installing the appropriate `aziot-identity-service` package. Packages are provided for several distributions and architectures on the [GitHub releases page](https://github.com/Azure/azure-iotedge/releases) for Azure IoT Edge, as of v1.2. Packages for a subset of these distributions and architectures are also available on packages.microsoft.com. See the Azure IoT Edge's list of [Tier 1 supported platforms](https://learn.microsoft.com/en-us/azure/iot-edge/support#tier-1) for more details.
 
 ## Install from packages.microsoft.com
-**Applies to:** Ubuntu 18.04, 20.04, Raspberry Pi OS Bullseye
+
 
 ```bash
 sudo apt install aziot-identity-service
 ```
 
-You may need to first add the `packages.microsoft.com` to your repo sources.
-
-1. On Ubuntu 18.04
-
-    ```bash
-    wget https://packages.microsoft.com/config/ubuntu/18.04/multiarch/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-    sudo dpkg -i packages-microsoft-prod.deb
-    rm packages-microsoft-prod.deb
-    ```
-
-2. On Ubuntu 20.04
-
-    ```bash
-    wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-    sudo dpkg -i packages-microsoft-prod.deb
-    rm packages-microsoft-prod.deb
-    ```
-
-3. On Raspberry Pi OS Bullseye
-
-    ```bash
-    wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-    sudo dpkg -i packages-microsoft-prod.deb
-    rm packages-microsoft-prod.deb
-    ```
-
-4. On RedHat Enterprise Linux 8
-
-    ```bash
-    wget https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm -O packages-microsoft-prod.rpm
-    sudo yum localinstall packages-microsoft-prod.rpm
-    rm packages-microsoft-prod.rpm
-    ```
+You may need to first add the `packages.microsoft.com` to your repo sources. Instructions can be found [here](https://learn.microsoft.com/en-us/azure/iot-edge/how-to-provision-single-device-linux-symmetric#install-iot-edge).
 
 ## Install for an alternative distro / architecture
 
-Download and install the `aziot-identity-service` pre-built package for your respective distro / architecture from [the IoT Edge release collateral for v1.4 or later](https://github.com/Azure/azure-iotedge/releases/tag/1.4.0).
+Download and install the `aziot-identity-service` pre-built package for your respective distro / architecture from [the IoT Edge releases page](https://github.com/Azure/azure-iotedge/releases).
 
-Using Ubuntu 20.04 amd64 as an example:
+Using Ubuntu 22.04 amd64 as an example:
 
 ```bash
-wget https://github.com/Azure/azure-iotedge/releases/download/1.4.0/aziot-identity-service_1.4.0-1_ubuntu20.04_amd64.deb -o aziot-identity-service.deb
+# query GitHub for the latest versions of IoT Edge and IoT Identity Service
+wget -qO- https://raw.githubusercontent.com/Azure/azure-iotedge/main/latest-aziot-edge.json | jq -r '."aziot-edge"'
+# example output: 1.4.20
+wget -qO- https://raw.githubusercontent.com/Azure/azure-iotedge/main/latest-aziot-identity-service.json | jq -r '."aziot-identity-service"'
+# example output: 1.4.6
 
+# download and install
+wget https://github.com/Azure/azure-iotedge/releases/download/1.4.20/aziot-identity-service_1.4.6-1_ubuntu22.04_amd64.deb -O aziot-identity-service.deb
 sudo apt install ./aziot-identity-service.deb
 ```
 


### PR DESCRIPTION
Ubuntu 18.04 went out of support in May 2023. This change updates our build/release pipelines so that they won't produce Ubuntu 18.04 packages. It also removes Ubuntu 18.04 references generally.

Note: We can merge this change to main at any point, but we shouldn't make this change in the release/1.4 branch until after November 30, 2023, which is when we documented that we'll stop producing Ubuntu 18.04 packages.