### PR TITLE
Fix `cargo install` invocations to use `--locked`

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -311,9 +311,9 @@ esac
 
 # Mariner build installs the following as part of the specfile.
 if [ "${OS#mariner}" = "$OS" ]; then
-    cargo install bindgen --version "=$BINDGEN_VERSION"
+    cargo install bindgen --version "=$BINDGEN_VERSION" --locked
 
-    cargo install cbindgen --version "=$CBINDGEN_VERSION"
+    cargo install cbindgen --version "=$CBINDGEN_VERSION" --locked
 
     if [ "$OS:$ARCH" = 'ubuntu:22.04:amd64' ]; then
         cargo install cargo-tarpaulin --version '^0.20' --locked


### PR DESCRIPTION
`bindgen` in particular is broken without it, because one of its transitive dependencies bumped its MSRV to be newer than what we use while keeping a semver-compatible version number.

Fixes #573