### PR TITLE
Fix `cargo install` invocations to use `--locked`

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -314,9 +314,9 @@ esac
 
 # Mariner build installs the following as part of the specfile.
 if [ "${OS#mariner}" = "$OS" ]; then
-    cargo install bindgen --version "=$BINDGEN_VERSION"
+    cargo install bindgen --version "=$BINDGEN_VERSION" --locked
 
-    cargo install cbindgen --version "=$CBINDGEN_VERSION"
+    cargo install cbindgen --version "=$CBINDGEN_VERSION" --locked
 
     if [ "$OS:$ARCH" = 'ubuntu:22.04:amd64' ]; then
         cargo install cargo-tarpaulin --version '^0.20' --locked


### PR DESCRIPTION
Cherry-pick from main of 3464feb207cd1c17cc7255d0cb52e8f0ceac943d

`bindgen` in particular is broken without it, because one of its transitive dependencies bumped its MSRV to be newer than what we use while keeping a semver-compatible version number.

Fixes #573