### PR TITLE
Reduce http-common logging noise in logs.

### DIFF
--- a/http-common/src/server.rs
+++ b/http-common/src/server.rs
@@ -234,12 +234,12 @@ macro_rules! make_service {
                 }
 
                 // TODO: When we get distributed tracing, associate these two logs with the tracing ID.
-                log::info!("<-- {:?} {:?} {:?}", req.method(), req.uri(), req.headers());
+                log::debug!("<-- {:?} {:?} {:?}", req.method(), req.uri(), req.headers());
                 let res = call_inner(self, req);
                 Box::pin(async move {
                     let res = res.await;
                     match &res {
-                        Ok(res) => log::info!("--> {:?} {:?}", res.status(), res.headers()),
+                        Ok(res) => log::debug!("--> {:?} {:?}", res.status(), res.headers()),
                         Err(err) => log::error!("-!> {:?}", err),
                     }
                     res


### PR DESCRIPTION
Currently, the aziot-edged logs are littered with the request/response data coming from the http-common server crate included from this repo. That logging level is probably more appropriately debug.  Adjust accordingly.

```bash
Dec 27 22:17:58 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:17:58Z [INFO] - <-- GET /modules?api-version=2020-07-07 {"accept": "application/json", "host": "mgmt.sock:80", "connection": "close"}
Dec 27 22:17:58 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:17:58Z [INFO] - --> 200 {"content-type": "application/json"}
Dec 27 22:18:03 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:03Z [INFO] - <-- GET /modules?api-version=2020-07-07 {"accept": "application/json", "host": "mgmt.sock:80", "connection": "close"}
Dec 27 22:18:03 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:03Z [INFO] - --> 200 {"content-type": "application/json"}
Dec 27 22:18:08 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:08Z [INFO] - <-- GET /modules?api-version=2020-07-07 {"accept": "application/json", "host": "mgmt.sock:80", "connection": "close"}
Dec 27 22:18:08 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:08Z [INFO] - --> 200 {"content-type": "application/json"}
Dec 27 22:18:13 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:13Z [INFO] - <-- GET /modules?api-version=2020-07-07 {"accept": "application/json", "host": "mgmt.sock:80", "connection": "close"}
Dec 27 22:18:13 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:13Z [INFO] - --> 200 {"content-type": "application/json"}
Dec 27 22:18:18 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:18Z [INFO] - <-- GET /modules?api-version=2020-07-07 {"accept": "application/json", "host": "mgmt.sock:80", "connection": "close"}
Dec 27 22:18:18 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:18Z [INFO] - --> 200 {"content-type": "application/json"}
Dec 27 22:18:23 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:23Z [INFO] - <-- GET /modules?api-version=2020-07-07 {"accept": "application/json", "host": "mgmt.sock:80", "connection": "close"}
Dec 27 22:18:23 SOLU424200002 aziot-edged[2546]: 2023-12-27T22:18:23Z [INFO] - --> 200 {"content-type": "application/json"}
```