### PR TITLE
Add psmisc dependency to Debian package since the postrm script uses it.

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -10,7 +10,7 @@ Vcs-Git: https://github.com/azure/iot-identity-service
 
 Package: aziot-identity-service
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, psmisc
 Conflicts: iotedge, libiothsm-std
 Description: Azure IoT Identity Service and related services
  This package contains the Azure IoT device runtime, comprised of the following services:


### PR DESCRIPTION
Cherry-pick from main of 79ca1cb0b508552fcd881c47e19dbb1327ccc614

Fixes #578