### PR TITLE
feature/snapping: bump snap base to core22

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -10,22 +10,10 @@ toml_new_section() {
 	printf "[%s]\n" "$1"
 }
 
-# Work around the fact that there is no consolidated, machine readable
-# output of `hostnamectl` in the version included in core20. Core22 will
-# be more elegant (i.e. `hostnamectl hostname`)
-get_hostname() {
-	hostname="$(/usr/bin/hostnamectl --static)"
-	if [ -z "$hostname" ] ; then
-		hostname="$(/usr/bin/hostnamectl --transient)"
-	fi
-
-	printf "$hostname"
-}
-
 snapctl get raw-config > /etc/aziot/config.toml
 
 {
-	toml_kvp "hostname" "$(get_hostname)"
+	toml_kvp "hostname" "$(hostnamectl hostname)"
 } | tee /etc/aziot/keyd/config.d/01-snap.toml /etc/aziot/certd/config.d/01-snap.toml /etc/aziot/identityd/config.d/01-snap.toml /etc/aziot/tpmd/config.d/01-snap.toml
 
 $SNAP/bin/aziotctl config apply

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: azure-iot-identity
-base: core20 # the base snap is the execution environment for this snap
+base: core22 # the base snap is the execution environment for this snap
 version: '1.4.0~dev' # should end with '~dev' on the main branch
 summary: Provides provisioning and cryptographic services for Azure IoT Hub devices.
 description: |
@@ -29,7 +29,7 @@ parts:
   iot-identity-services:
     build-environment:
       - PATH: "$PATH:$HOME/.cargo/bin"
-      - ARCH: "$SNAPCRAFT_TARGET_ARCH"
+      - ARCH: "$CRAFT_ARCH_BUILD_FOR"
     after: [ rust-toolchain ]
     plugin: nil
     source: ./
@@ -55,11 +55,15 @@ parts:
         - ca-certificates
         - libcurl4-openssl-dev
     stage-packages:
-      - libtss2-esys0
+      - libtss2-esys-3.0.2-0
+      - libtss2-mu0
+      - libtss2-rc0
+      - libtss2-sys1
+      - libtss2-tctildr0
     override-build: |
       contrib/third-party-notices.sh > THIRD-PARTY-NOTICES
       make install-deb \
-        ARCH=$SNAPCRAFT_TARGET_ARCH \
+        ARCH=$CRAFT_ARCH_BUILD_FOR \
         RELEASE=1 \
         VENDOR_LIBTSS=0 \
         PLATFORM_FEATURES=snapd \
@@ -68,24 +72,22 @@ parts:
         USER_AZIOTKS=root \
         USER_AZIOTTPM=root \
         SOCKET_DIR=/var/sockets/aziot \
-        DESTDIR=$SNAPCRAFT_PART_INSTALL
+        DESTDIR=$CRAFT_PART_INSTALL
     organize:
       usr/: .
-    filesets:
-      exclude-symlinks: [ -libexec/aziot-identity-service/aziot-* ]
     stage:
       - -include
       # - -lib/systemd
       - -var
-      - $exclude-symlinks
+      - -libexec/aziot-identity-service/aziot-*
     override-prime: |
-      snapcraftctl prime
+      craftctl default
       # Recreate expected relative symlinks that were not staged from the install because they link external to the snap
       # and prevent publishing to snapcraft.
-      ln -vrfs $SNAPCRAFT_PRIME/libexec/aziot-identity-service/aziotd $SNAPCRAFT_PRIME/libexec/aziot-certd
-      ln -vrfs $SNAPCRAFT_PRIME/libexec/aziot-identity-service/aziotd $SNAPCRAFT_PRIME/libexec/aziot-identityd
-      ln -vrfs $SNAPCRAFT_PRIME/libexec/aziot-identity-service/aziotd $SNAPCRAFT_PRIME/libexec/aziot-keyd
-      ln -vrfs $SNAPCRAFT_PRIME/libexec/aziot-identity-service/aziotd $SNAPCRAFT_PRIME/libexec/aziot-tpmd
+      ln -vrfs $CRAFT_PRIME/libexec/aziot-identity-service/aziotd $CRAFT_PRIME/libexec/aziot-certd
+      ln -vrfs $CRAFT_PRIME/libexec/aziot-identity-service/aziotd $CRAFT_PRIME/libexec/aziot-identityd
+      ln -vrfs $CRAFT_PRIME/libexec/aziot-identity-service/aziotd $CRAFT_PRIME/libexec/aziot-keyd
+      ln -vrfs $CRAFT_PRIME/libexec/aziot-identity-service/aziotd $CRAFT_PRIME/libexec/aziot-tpmd
   command-chain:
     plugin: dump
     source: ./contrib


### PR DESCRIPTION
migrate to base: core22. this also entails a slight shift in snapcraft syntax (mostly documented [here](https://forum.snapcraft.io/t/micro-howto-migrate-from-core20-to-core22/30188), plus filesets no longer supported)