### PR TITLE
Fix workspace manifest to use E2021 resolver.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
 	"tpm/aziot-tpmd",
 	"tpm/tss-minimal",
 ]
+resolver = "2"
 
 # Don't let panics from callbacks cross FFI boundary
 


### PR DESCRIPTION
While individual crates default to resolver v2 if they are E2021, workspaces are virtual manifests with no edition so they continue to default to resolver v1. cargo raises a warning about this but only sometimes, so this wasn't easily noticeable.

This change fixes the workspace manifest to use resolver v2.