### PR TITLE
Disable HTTP/2 in http-common.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,25 +1243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "h2"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap 1.9.3",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,7 +1402,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -2573,20 +2553,6 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/http-common/Cargo.toml
+++ b/http-common/Cargo.toml
@@ -10,7 +10,7 @@ base64 = "0.21"
 futures-util = "0.3"
 headers = { version = "0.3" }
 http = "0.2"
-hyper = { version = "0.14", features = ["client", "http1", "http2", "server", "stream", "tcp"] }
+hyper = { version = "0.14", features = ["client", "http1", "server", "stream", "tcp"] }
 hyper-openssl = { version = "0.9" }
 hyper-proxy = { version = "0.9", features = ["openssl-tls"], default-features = false }
 libc = "0.2"


### PR DESCRIPTION
We don't support it as a server and nothing we use it as a client with supports it either, so having it enabled just increased attack surface.