### PR TITLE
Remove Mariner 1 from builds

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -46,9 +46,6 @@ jobs:
         include:
         - container_os: 'ubuntu:20.04'
           arch: 'amd64'
-          os: 'mariner:1'
-        - container_os: 'ubuntu:20.04'
-          arch: 'amd64'
           os: 'mariner:2'
 
     steps:

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -197,7 +197,7 @@ case "$OS:$ARCH" in
             llvm-dev pkg-config
         ;;
 
-    'mariner:1:amd64' | 'mariner:2:amd64' | 'mariner:1:aarch64' | 'mariner:2:aarch64')
+    'mariner:2:amd64' | 'mariner:2:aarch64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
 
@@ -217,15 +217,7 @@ case "$OS:$ARCH" in
             mv /.dockerenv /.dockerenv.old
         fi
 
-        case "$OS" in
-            'mariner:1')
-                BranchTag='1.0-stable'
-                ;;
-            'mariner:2')
-                BranchTag='2.0-stable'
-                ;;
-        esac
-
+        BranchTag='2.0-stable'
         MarinerToolkitDir='/tmp/CBL-Mariner'
         if ! [ -f "$MarinerToolkitDir/toolkit.tar.gz" ]; then
             rm -rf "$MarinerToolkitDir"

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -110,7 +110,7 @@ case "$OS" in
             "packages/$TARGET_DIR/"
         ;;
 
-    'mariner:1' | 'mariner:2')
+    'mariner:2')
         case "$ARCH" in
             'arm32v7')
                 echo "Cross-compilation on $OS is not supported" >&2
@@ -137,18 +137,9 @@ case "$OS" in
         tar xzvf toolkit.tar.gz
         popd
 
-        case "$OS" in
-            'mariner:1')
-                UsePreview=n
-                TARGET_DIR="mariner1/$ARCH"
-                PackageExtension="cm1"
-                ;;
-            'mariner:2')
-                UsePreview=n
-                TARGET_DIR="mariner2/$ARCH"
-                PackageExtension="cm2"
-                ;;
-        esac
+        UsePreview=n
+        TARGET_DIR="mariner2/$ARCH"
+        PackageExtension="cm2"
 
         # move tarballed iot-identity-service source to building directory
         mkdir -p "$MarinerSourceDir"


### PR DESCRIPTION
Extracted from 657b163c8ecdf89cebcc57e1751d47cb1999de2c in the release branch. Mariner 1 is out of support so we don't need to continue building it.