### PR TITLE
Set snap grade according to version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,6 @@ description: |
 
 license: MIT 
 
-grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict
 
 parts:
@@ -61,6 +60,13 @@ parts:
       - libtss2-sys1
       - libtss2-tctildr0
     override-build: |
+      # if version contains substring "dev" set grade to devel, else stable
+      SC_VERSION="$(craftctl get version)"
+      if test "${SC_VERSION#*dev}" != "$SC_VERSION" ; then
+        craftctl set grade=devel
+      else
+        craftctl set grade=stable
+      fi
       contrib/third-party-notices.sh > THIRD-PARTY-NOTICES
       make install-deb \
         ARCH=$CRAFT_ARCH_BUILD_FOR \


### PR DESCRIPTION
Snaps are currently built with grade=devel, which means they can't be promoted to the stable channel. We want dev builds (e.g., builds from main) to keep grade=devel so they can't accidentally be promoted, but we want release builds to be grade=stable. This change adds the logic to do that, and is patterned after similar logic in the azure-iot-edge snap.