### PR TITLE
Fix snap grade

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,7 @@ description: |
 license: MIT 
 
 confinement: strict
+adopt-info: iot-identity-services
 
 parts:
   rust-toolchain:


### PR DESCRIPTION
Cherry-pick 604f83fc27c9df3b70cd783e59e440fadfe0ef3c.

In the release branch, where the grade logic resolves to "stable", the build failed. Adding the `adopt-info` key in snapcraft.yaml fixed the issue. In the main branch, grade should always resolve to "devel", which doesn't have this problem. But I'm cherry-picking the change from the release branch anyway for consistency.