### PR TITLE
Port changes from the release branch back to main

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -135,7 +135,7 @@ case "$OS:$ARCH" in
             pkgconfig
         ;;
 
-    'platform:el8:aarch64'|'platform:el8:arm32v7'|'platform:el9:aarc64'|'platform:el9:arm32v7')
+    'platform:el8:aarch64'|'platform:el8:arm32v7'|'platform:el9:aarch64'|'platform:el9:arm32v7')
         echo "Cross-compilation on $OS $ARCH is not supported" >&2
         exit 1
         ;;

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -27,7 +27,9 @@ PRIVATE_LIBS = /usr/lib/aziot-identity-service
 
 override_dh_auto_build:
 	# Default behavior is `make -j1`, which is not quite right for us.
-	echo Skipping... Build should have happened already.
+	make -j \
+		RELEASE=1 \
+		V=1
 
 override_dh_auto_install:
 	# Default behavior is `make -j1 install DESTDIR=$$PWD/debian/aziot-identity-service`, which is not quite right for us.


### PR DESCRIPTION
I found two changes in the release branch that are not found in main:
- #512 cherry-picked #463 from main, but also updated contrib/debian/rules to address a [PR comment](https://github.com/Azure/iot-identity-service/pull/512#discussion_r1101962049). The main branch was never updated.
- #528 cherry-picked #480 from main, but also fixed a typo in ci\install-build-deps.sh. The main branch was never updated.
This change makes both updates.