### PR TITLE
Use 1ES-hosted pools for end-to-end tests

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -17,7 +17,10 @@ on:
 
 jobs:
   suite-setup:
-    runs-on: 'ubuntu-22.04'
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=iot-identity-1es-hosted-linux-amd64
+    - 1ES.ImageOverride=agent-aziotedge-ubuntu-22.04-msmoby
 
     steps:
     - uses: 'actions/checkout@v3'
@@ -39,7 +42,10 @@ jobs:
   test-run:
     needs: 'suite-setup'
 
-    runs-on: 'ubuntu-22.04'
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=iot-identity-1es-hosted-linux-amd64
+    - 1ES.ImageOverride=agent-aziotedge-ubuntu-22.04-msmoby
 
     strategy:
       fail-fast: false
@@ -104,7 +110,10 @@ jobs:
     needs: 'test-run'
     if: "${{ success() }}"
 
-    runs-on: 'ubuntu-22.04'
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=iot-identity-1es-hosted-linux-amd64
+    - 1ES.ImageOverride=agent-aziotedge-ubuntu-22.04-msmoby
 
     steps:
     - uses: 'actions/checkout@v3'
@@ -127,7 +136,10 @@ jobs:
     needs: 'test-run'
     if: "${{ failure() }}"
 
-    runs-on: 'ubuntu-22.04'
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=iot-identity-1es-hosted-linux-amd64
+    - 1ES.ImageOverride=agent-aziotedge-ubuntu-22.04-msmoby
 
     steps:
     - uses: 'actions/checkout@v3'

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -19,7 +19,10 @@ jobs:
   suite-setup:
     if: "github.repository == 'Azure/iot-identity-service'"
 
-    runs-on: 'ubuntu-22.04'
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=iot-identity-1es-hosted-linux-amd64
+    - 1ES.ImageOverride=agent-aziotedge-ubuntu-22.04-msmoby
 
     strategy:
       fail-fast: false
@@ -52,7 +55,10 @@ jobs:
     if: "github.repository == 'Azure/iot-identity-service'"
     needs: 'suite-setup'
 
-    runs-on: 'ubuntu-22.04'
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=iot-identity-1es-hosted-linux-amd64
+    - 1ES.ImageOverride=agent-aziotedge-ubuntu-22.04-msmoby
 
     strategy:
       fail-fast: false
@@ -126,7 +132,10 @@ jobs:
     if: "${{ github.repository == 'Azure/iot-identity-service' && success() }}"
     needs: 'test-run'
 
-    runs-on: 'ubuntu-22.04'
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=iot-identity-1es-hosted-linux-amd64
+    - 1ES.ImageOverride=agent-aziotedge-ubuntu-22.04-msmoby
 
     strategy:
       fail-fast: false
@@ -159,7 +168,10 @@ jobs:
     needs: 'test-run'
     if: "${{ failure() }}"
 
-    runs-on: 'ubuntu-22.04'
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=iot-identity-1es-hosted-linux-amd64
+    - 1ES.ImageOverride=agent-aziotedge-ubuntu-22.04-msmoby
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This change updates the end-to-end test workflows to use Microsoft-internal runner pools instead of shared GitHub pools. This means authorized resource operations won't originate from outside Microsoft-controlled networks.