### PR TITLE
Turn off debug symbols for snaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,6 @@ panic = "abort"
 panic = "abort"
 # Release builds will have full symbols. The packaging phase will strip symbols from binaries and
 # make them available in a separate package.
+# Notes: Snaps don't have a good story for debug symbols, so for now we'll override this setting in
+# the snapcraft.yaml file by setting CARGO_PROFILE_RELEASE_DEBUG=0.
 debug = 2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,7 @@ parts:
     build-environment:
       - PATH: "$PATH:$HOME/.cargo/bin"
       - ARCH: "$CRAFT_ARCH_BUILD_FOR"
+      - CARGO_PROFILE_RELEASE_DEBUG: 0
     after: [ rust-toolchain ]
     plugin: nil
     source: ./


### PR DESCRIPTION
There isn't currently a good way to package debuginfo and symbols for snaps. Since we're building with full symbols in cargo and they aren't being stripped out during the snap build, our snap packages are much larger than they should be. This change disables the [debug](https://doc.rust-lang.org/cargo/reference/profiles.html#debug) setting in the cargo release profile for snaps only.

To test, I built the amd64 snap locally with these changes. It went from 66 MB down to 9 MB.