### PR TITLE
Make updates for v1.5

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -52,7 +52,6 @@ jobs:
 
       matrix:
         os:
-        - 'debian:10'
         - 'debian:11'
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
         # - 'platform:el8'

--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -52,7 +52,6 @@ jobs:
 
       matrix:
         os:
-        - 'centos:7'
         - 'debian:10'
         - 'debian:11'
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -68,7 +68,6 @@ jobs:
         - 'main'
         - 'release/1.4'
         os:
-        - 'centos:7'
         - 'debian:10'
         - 'debian:11'
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -68,7 +68,6 @@ jobs:
         - 'main'
         - 'release/1.4'
         os:
-        - 'debian:10'
         - 'debian:11'
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
         # - 'platform:el8'

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -13,7 +13,6 @@ jobs:
 
       matrix:
         container_os:
-        - 'debian:10-slim'
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
         - 'redhat/ubi9:latest'

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -69,8 +69,7 @@ jobs:
       env:
         ARCH: "${{ matrix.arch }}"
         OS: "${{ matrix.os }}"
-        # PACKAGE_VERSION should end with '~dev' on the main branch.
-        PACKAGE_VERSION: '1.4.0~dev'
+        PACKAGE_VERSION: '1.5.0'
         # PACKAGE_RELEASE should always be '1'.
         PACKAGE_RELEASE: '1'
     - name: 'Generate artifact properties'

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -13,7 +13,6 @@ jobs:
 
       matrix:
         container_os:
-        - 'centos:7'
         - 'debian:10-slim'
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
@@ -27,12 +26,6 @@ jobs:
         os:
         - ''
         exclude:
-        # CentOS 7 does not have functioning cross compilers. The Azure/iotedge repo builds CentOS 7 arm32v7 and aarch64 packages
-        # by running the arm32v7 / aarch64 containers under qemu. For now we don't care to replicate that here.
-        - container_os: 'centos:7'
-          arch: 'arm32v7'
-        - container_os: 'centos:7'
-          arch: 'aarch64'
         # More investigation needed for RHEL 8 and 9. Excluding for now.
         - container_os: 'redhat/ubi8:latest'
           arch: 'arm32v7'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,6 @@ jobs:
 
       matrix:
         container_os:
-        - 'debian:10-slim'
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
         - 'redhat/ubi9:latest'
@@ -74,7 +73,6 @@ jobs:
 
       matrix:
         container_os:
-        - 'debian:10-slim'
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
         - 'redhat/ubi9:latest'
@@ -137,7 +135,6 @@ jobs:
 
       matrix:
         container_os:
-        - 'debian:10-slim'
         - 'redhat/ubi8:latest'
         - 'redhat/ubi9:latest'
         arch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,6 @@ jobs:
 
       matrix:
         container_os:
-        - 'centos:7'
         - 'debian:10-slim'
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
@@ -75,7 +74,6 @@ jobs:
 
       matrix:
         container_os:
-        - 'centos:7'
         - 'debian:10-slim'
         - 'debian:11-slim'
         - 'redhat/ubi8:latest'
@@ -139,7 +137,6 @@ jobs:
 
       matrix:
         container_os:
-        - 'centos:7'
         - 'debian:10-slim'
         - 'redhat/ubi8:latest'
         - 'redhat/ubi9:latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aziotctl"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "aziotd"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aziot-certd",
  "aziot-identityd",

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ codecov: default
 # Packaging
 #
 # - `make PACKAGE_VERSION='...' PACKAGE_RELEASE='...' deb` builds deb packages for Debian and Ubuntu.
-# - `make PACKAGE_VERSION='...' PACKAGE_RELEASE='...' rpm` builds RPM packages for CentOS.
+# - `make PACKAGE_VERSION='...' PACKAGE_RELEASE='...' rpm` builds RPM packages for RHEL.
 
 # Creates a source tarball at /tmp/aziot-identity-service-$(PACKAGE_VERSION).tar.gz
 dist:
@@ -352,19 +352,10 @@ rpm:
 	# Copy spec file to rpmbuild specs directory
 	mkdir -p $(RPMBUILDDIR)/SPECS
 
-	# Engine needs to be installed to what openssl considers the enginesdir,
-	# which we can get from openssl 1.1 with `openssl version -e` but not from openssl 1.0.
-	# Also, the filename for 1.0 should have a `lib` prefix.
-	#
-	# CentOS 7 has 1.0 and RedHat 8 has 1.1, so we need to support both here. RedHat 9 has 3.0.
-	#
-	# Since there is no RPM macro for those two things, we have to infer them from
-	# the output of `openssl version` and `openssl version -e` ourselves. This wouldn't be right
-	# if we were cross-compiling, but we don't support cross-compiling for either of those two OSes,
-	# so it's fine.
+	# Engine needs to be installed to what openssl considers the enginesdir, which we can get from
+	# openssl 1.1 and 3.0 with `openssl version -e`.
 	command -v openssl # Assert that openssl exists
 	case "$$(openssl version)" in \
-		'OpenSSL 1.0.'*) OPENSSL_ENGINE_FILENAME='%\{_libdir\}/openssl/engines/libaziot_keys.so' ;; \
 		'OpenSSL 1.1.'* | 'OpenSSL 3.0.'*) OPENSSL_ENGINE_FILENAME="$$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/')/aziot_keys.so" ;; \
 		*) echo "Unknown openssl version [$$(openssl version)]"; exit 1 ;; \
 	esac; \

--- a/aziotctl/Cargo.toml
+++ b/aziotctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aziotctl"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Azure IoT Edge Devs"]
 edition = "2021"
 homepage = "https://azure.github.io/iot-identity-service/"

--- a/aziotd/Cargo.toml
+++ b/aziotd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aziotd"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Azure IoT Edge Devs"]
 edition = "2021"
 homepage = "https://azure.github.io/iot-identity-service/"

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -85,10 +85,6 @@ get_package() {
     echo "Artifacts URL: $artifacts_url" >&2
 
     case "$OS" in
-        'debian:10')
-            artifact_name='debian-10-slim'
-            ;;
-
         'debian:11')
             artifact_name='debian-11-slim'
             ;;
@@ -171,11 +167,6 @@ get_package() {
 
     echo 'Extracting package...' >&2
     case "$OS" in
-        'debian:10')
-            unzip -j package.zip 'debian10/amd64/aziot-identity-service_*_amd64.deb' >&2
-            printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
-            ;;
-
         'debian:11')
             unzip -j package.zip 'debian11/amd64/aziot-identity-service_*_amd64.deb' >&2
             printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
@@ -540,15 +531,6 @@ echo 'Creating VM...' >&2
 # Choice of publisher is determined by
 # https://docs.microsoft.com/en-us/troubleshoot/azure/cloud-services/support-linux-open-source-technology
 case "$OS" in
-    'debian:10')
-        # Not listed on the docs.microsoft.com page, but credativ doesn't publish Debian 10+ images.
-        #
-        # az vm image list --all \
-        #     --publisher 'Debian' --offer 'debian-10' --sku '10' \
-        #     --query "[?publisher == 'Debian' && offer == 'debian-10'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='Debian:debian-10:10-gen2:latest'
-        ;;
-
     'debian:11')
         # Not listed on the docs.microsoft.com page, but credativ doesn't publish Debian 10+ images.
         #

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -711,7 +711,7 @@ fi
 
 echo 'Installing package...' >&2
 case "$OS" in
-    |platform:el*)
+    platform:el*)
         scp -i "$PWD/vm-ssh-key" "$package" "aziot@$vm_public_ip:/home/aziot/aziot-identity-service.rpm"
 
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -85,10 +85,6 @@ get_package() {
     echo "Artifacts URL: $artifacts_url" >&2
 
     case "$OS" in
-        'centos:7')
-            artifact_name='centos-7'
-            ;;
-
         'debian:10')
             artifact_name='debian-10-slim'
             ;;
@@ -175,11 +171,6 @@ get_package() {
 
     echo 'Extracting package...' >&2
     case "$OS" in
-        'centos:7')
-            unzip -j package.zip 'centos7/amd64/aziot-identity-service-*.x86_64.rpm' -x '*-debuginfo-*.rpm' '*-devel-*.rpm' >&2
-            printf '%s/%s\n' "$PWD" aziot-identity-service-*.x86_64.rpm
-            ;;
-
         'debian:10')
             unzip -j package.zip 'debian10/amd64/aziot-identity-service_*_amd64.deb' >&2
             printf '%s/%s\n' "$PWD" aziot-identity-service_*_amd64.deb
@@ -549,13 +540,6 @@ echo 'Creating VM...' >&2
 # Choice of publisher is determined by
 # https://docs.microsoft.com/en-us/troubleshoot/azure/cloud-services/support-linux-open-source-technology
 case "$OS" in
-    'centos:7')
-        # az vm image list --all \
-        #     --publisher 'OpenLogic' --offer 'CentOS' --sku '7' \
-        #     --query "[?publisher == 'OpenLogic' && offer == 'CentOS'].{ sku: sku, version: version, urn: urn }" --output table
-        vm_image='OpenLogic:CentOS:7_9-gen2:latest'
-        ;;
-
     'debian:10')
         # Not listed on the docs.microsoft.com page, but credativ doesn't publish Debian 10+ images.
         #
@@ -673,19 +657,6 @@ fi
 
 echo 'Updating VM...' >&2
 case "$OS" in
-    centos:*)
-        ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
-            set -euxo pipefail
-
-            sudo yum -y clean all
-            sudo yum -y makecache
-            sudo yum -y update
-
-            # The test needs jq
-            sudo yum -y install epel-release
-        '
-        ;;
-
     debian:*|ubuntu:*)
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '
             for retry in {0..3}; do
@@ -758,7 +729,7 @@ fi
 
 echo 'Installing package...' >&2
 case "$OS" in
-    centos:*|platform:el*)
+    |platform:el*)
         scp -i "$PWD/vm-ssh-key" "$package" "aziot@$vm_public_ip:/home/aziot/aziot-identity-service.rpm"
 
         ssh -i "$PWD/vm-ssh-key" "aziot@$vm_public_ip" '

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -11,25 +11,6 @@ fi
 # OS packages
 
 case "$OS:$ARCH" in
-    'centos:7:amd64')
-        export VENDOR_LIBTSS=1
-
-        yum install -y centos-release-scl epel-release
-        yum install -y \
-            autoconf autoconf-archive automake curl devtoolset-9-gcc devtoolset-9-gcc-c++ \
-            git jq libcurl-devel libtool llvm-toolset-7-clang llvm-toolset-7-llvm-devel \
-            make openssl openssl-devel pkgconfig
-
-        set +eu # scl_source fails with -eu
-        . scl_source enable devtoolset-9 llvm-toolset-7
-        set -eu
-        ;;
-
-    'centos:7:arm32v7'|'centos:7:aarch64')
-        echo "Cross-compilation on $OS $ARCH is not supported" >&2
-        exit 1
-        ;;
-
     'debian:10:amd64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -11,19 +11,6 @@ fi
 # OS packages
 
 case "$OS:$ARCH" in
-    'debian:10:amd64')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
-        export VENDOR_LIBTSS=1
-
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y \
-            acl autoconf autoconf-archive automake build-essential clang cmake \
-            curl git jq libclang1 libltdl-dev libssl-dev libtool llvm-dev \
-            pkg-config
-        ;;
-
     'debian:11:amd64'|'ubuntu:20.04:amd64'|'ubuntu:22.04:amd64')
         export DEBIAN_FRONTEND=noninteractive
         export TZ=UTC
@@ -34,22 +21,6 @@ case "$OS:$ARCH" in
             acl autoconf autoconf-archive automake build-essential clang cmake \
             curl git jq libclang1 libltdl-dev libssl-dev libtss2-dev libtool \
             llvm-dev pkg-config
-        ;;
-
-    'debian:10:arm32v7')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
-        export VENDOR_LIBTSS=1
-
-        dpkg --add-architecture armhf
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-armhf curl git jq \
-            libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
-            libltdl-dev:armhf libssl-dev:armhf libtool llvm-dev \
-            pkg-config
         ;;
 
     'debian:11:arm32v7')
@@ -65,22 +36,6 @@ case "$OS:$ARCH" in
             libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
             libltdl-dev:armhf libssl-dev:armhf libtool libtss2-dev:armhf \
             llvm-dev pkg-config
-        ;;
-
-    'debian:10:aarch64')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
-        export VENDOR_LIBTSS=1
-
-        dpkg --add-architecture arm64
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-arm64 curl git jq \
-            libc-dev:arm64 libclang1 libcurl4-openssl-dev:arm64 \
-            libltdl-dev:arm64 libssl-dev:arm64 libtool llvm-dev \
-            pkg-config
         ;;
 
     'debian:11:aarch64')

--- a/ci/install-runtime-deps.sh
+++ b/ci/install-runtime-deps.sh
@@ -42,8 +42,8 @@ case "$OS" in
         esac
         ;;
 
-    'debian:10'|'debian:11'|'ubuntu:20.04'|'ubuntu:22.04')
-        # openssl 1.1.1 for Debian 10/11, Ubuntu 20.04, RHEL 8
+    'debian:11'|'ubuntu:20.04'|'ubuntu:22.04')
+        # openssl 1.1.1 for Debian 11, Ubuntu 20.04, RHEL 8
         # openssl 3.0 for Ubuntu 22.04, RHEL 9
 
         apt-get update -y

--- a/ci/install-runtime-deps.sh
+++ b/ci/install-runtime-deps.sh
@@ -6,9 +6,7 @@
 OS="$(. /etc/os-release; echo "${PLATFORM_ID:-$ID:$VERSION_ID}")"
 
 case "$OS" in
-    'centos:7'|'platform:el8'|'platform:el9')
-        # openssl 1.0
-
+    'platform:el8'|'platform:el9')
         # If using RHEL 8/9 UBI images without a subscription then they only have access to a
         # subset of packages. Workaround to enable EPEL.
         if [ "$OS" = 'platform:el8' ] && [ "$(. /etc/os-release; echo "$ID")" = 'rhel' ]; then
@@ -45,8 +43,8 @@ case "$OS" in
         ;;
 
     'debian:10'|'debian:11'|'ubuntu:20.04'|'ubuntu:22.04')
-        # openssl 1.1.1 for Debian 10/11 and Ubuntu 20.04
-        # openssl 3.0 for Ubuntu 22.04
+        # openssl 1.1.1 for Debian 10/11, Ubuntu 20.04, RHEL 8
+        # openssl 3.0 for Ubuntu 22.04, RHEL 9
 
         apt-get update -y
         DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y curl jq openssl ca-certificates libtss2-dev

--- a/ci/install-test-deps.sh
+++ b/ci/install-test-deps.sh
@@ -10,13 +10,6 @@
 # OS packages
 
 case "$OS" in
-    'centos:7')
-        export SKIP_TSS_MINIMAL=0
-        export USE_SWTPM_PKG=0
-
-        yum install -y expect json-glib-devel libtasn1-devel net-tools python3 socat
-        ;;
-
     # NOTE: ubuntu:20.04 uses libtss2-dev provided through the package
     # repositories, but the available version does not provide a TCTI
     # module for swtpm.  So, we skip testing tss-minimal on

--- a/ci/mock-iot-tests/mock-iot-setup.sh
+++ b/ci/mock-iot-tests/mock-iot-setup.sh
@@ -10,7 +10,7 @@ case "$CONTAINER_OS" in
         cp "$ROOT_CERT" /usr/local/share/ca-certificates/dps_root_cert.crt
         update-ca-certificates
         ;;
-    'centos:7' | 'redhat/ubi8:latest' | 'redhat/ubi9:latest')
+    'redhat/ubi8:latest' | 'redhat/ubi9:latest')
         mkdir -p /etc/pki/ca-trust/source/anchors
         cp "$ROOT_CERT" /etc/pki/ca-trust/source/anchors/dps_root_cert.crt
         update-ca-trust

--- a/ci/mock-iot-tests/mock-iot-setup.sh
+++ b/ci/mock-iot-tests/mock-iot-setup.sh
@@ -5,11 +5,6 @@ set -eu
 # Install mock-iot-server's root CA certificate.
 # Don't modify trusted certificates if not running on a CI container OS.
 case "$CONTAINER_OS" in
-    'debian:10-slim')
-        mkdir -p /usr/local/share/ca-certificates
-        cp "$ROOT_CERT" /usr/local/share/ca-certificates/dps_root_cert.crt
-        update-ca-certificates
-        ;;
     'redhat/ubi8:latest' | 'redhat/ubi9:latest')
         mkdir -p /etc/pki/ca-trust/source/anchors
         cp "$ROOT_CERT" /etc/pki/ca-trust/source/anchors/dps_root_cert.crt

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -48,17 +48,12 @@ case "$OS" in
             "packages/$TARGET_DIR/"
         ;;
 
-    'debian:10'|'debian:11'|'ubuntu:20.04'|'ubuntu:22.04')
+    'debian:11'|'ubuntu:20.04'|'ubuntu:22.04')
         DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y dh-make debhelper
 
         make ARCH="$ARCH" PACKAGE_VERSION="$PACKAGE_VERSION" PACKAGE_RELEASE="$PACKAGE_RELEASE" VENDOR_LIBTSS="${VENDOR_LIBTSS:-0}" V=1 deb
 
         case "$OS" in
-            'debian:10')
-                TARGET_DIR="debian10/$ARCH"
-                DBGSYM_EXT='deb'
-                ;;
-
             'debian:11')
                 TARGET_DIR="debian11/$ARCH"
                 DBGSYM_EXT='deb'

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -11,7 +11,7 @@ mkdir -p packages
 
 
 case "$OS" in
-    'centos:7'|'platform:el8'|'platform:el9')
+    'platform:el8'|'platform:el9')
         case "$ARCH" in
             'arm32v7'|'aarch64')
                 echo "Cross-compilation on $OS is not supported" >&2
@@ -20,11 +20,6 @@ case "$OS" in
         esac
 
         case "$OS" in
-            'centos:7')
-                TARGET_DIR="centos7/$ARCH"
-                PACKAGE_DIST="el7"
-                ;;
-
             'platform:el8')
                 TARGET_DIR="el8/$ARCH"
                 PACKAGE_DIST="el8"

--- a/ci/test-aziot-key-openssl-engine-shared.sh
+++ b/ci/test-aziot-key-openssl-engine-shared.sh
@@ -7,7 +7,7 @@ cd /src
 . ./ci/install-runtime-deps.sh
 
 case "$OS" in
-    'debian:10'|'debian:11'|'platform:el8'|'platform:el9'|'ubuntu:20.04'|'ubuntu:22.04')
+    'debian:11'|'platform:el8'|'platform:el9'|'ubuntu:20.04'|'ubuntu:22.04')
         cp \
             ./target/debug/libaziot_key_openssl_engine_shared.so \
             "$(openssl version -e | sed -E 's/^ENGINESDIR: "(.*)"$/\1/')/aziot_keys.so"

--- a/ci/test-aziot-key-openssl-engine-shared.sh
+++ b/ci/test-aziot-key-openssl-engine-shared.sh
@@ -7,12 +7,6 @@ cd /src
 . ./ci/install-runtime-deps.sh
 
 case "$OS" in
-    'centos:7')
-        cp \
-            ./target/debug/libaziot_key_openssl_engine_shared.so \
-            /usr/lib64/openssl/engines/libaziot_keys.so
-        ;;
-
     'debian:10'|'debian:11'|'platform:el8'|'platform:el9'|'ubuntu:20.04'|'ubuntu:22.04')
         cp \
             ./target/debug/libaziot_key_openssl_engine_shared.so \

--- a/contrib/enterprise-linux/aziot-identity-service.spec.in
+++ b/contrib/enterprise-linux/aziot-identity-service.spec.in
@@ -23,7 +23,7 @@ BuildRequires: pkgconfig
 BuildRequires: systemd
 
 
-# Since we vendor tpm2-tss (VENDOR_LIBTSS=1 for all CentOS and EL packages), we need to tell rpm that
+# Since we vendor tpm2-tss (VENDOR_LIBTSS=1 for all EL packages), we need to tell rpm that
 # we do not want it showing up in the package's Requires or Provides lists.
 # If it shows up in the Provides list it will force the distro tpm2-tss package to be uninstalled,
 # and if it's removed from the Provides list but not the Requires list it will force

--- a/docs-dev/packages.md
+++ b/docs-dev/packages.md
@@ -12,10 +12,6 @@ This repository contains three services - `aziot-certd`, `aziot-identityd` and `
 </thead>
 <tbody>
 <tr>
-<td>CentOS 7</td>
-<td><code>centos:7</code></td>
-</tr>
-<tr>
 <td>RHEL 8 compatible</td>
 <td><code>redhat/ubi8:latest</code></td>
 </tr>
@@ -93,7 +89,7 @@ el8/amd64/aziot-identity-service-devel-1.4.0-0.x86_64.rpm
 
 These files in order are:
 
-1. The source package. This contains the contents of this repository but pre-processed for CentOS 7-specific customizations. The other packages were built from this package.
+1. The source package. This contains the contents of this repository but pre-processed for RHEL 8/9-specific customizations. The other packages were built from this package.
 1. The binary package. This is the package a user would install on their device.
 1. The debug symbols package. A developer would need this package to debug coredumps generated from services in the corresponding binary package.
 1. A devel package containing the `aziot-keys.h` C header, which contains the API definitions of `libaziot_keys.so`. A user would install this package if they wanted to make their own implementation of `libaziot_keys.so`. It's not needed for a production device.
@@ -121,7 +117,7 @@ debian11/arm32v7/aziot-identity-service_1.4.0.orig.tar.gz
 debian11/arm32v7/aziot-identity-service-dbgsym_1.4.0-0_armhf.deb
 ```
 
-The first file is the binary package, the second through fourth file together constitute the source package, and the fifth is the debug symbols package. The meanings are the same as the CentOS example. Note that there is no `-dev` package equivalent of the CentOS `-devel` package; the C header is included in the binary package.
+The first file is the binary package, the second through fourth file together constitute the source package, and the fifth is the debug symbols package. The meanings are the same as the RHEL example. Note that there is no `-dev` package equivalent of the RHEL `-devel` package; the C header is included in the binary package.
 
 
 ## Miscellaneous
@@ -129,8 +125,6 @@ The first file is the binary package, the second through fourth file together co
 1. Make sure to run the script in a Docker container instead of directly on your machine, even if your machine happens to be the same distro as the one you want to build the package for. The script installs dependencies and modifies system files like `/etc/apt`, so you don't want these to be done to your host machine.
 
 1. The script must be run on an `x86_64` host, even for building ARM32 and ARM64 packages. The ARM32 and ARM64 packages are built via cross-compilation.
-
-1. Building ARM32 and ARM64 packages for CentOS 7 is currently not supported, because CentOS 7 does do not have functional cross compilers for those architectures. (It has the `gcc` cross compiler itself but not a cross `glibc` for the compiled binary to link to, because the cross compiler is only intended for cross-compiling the kernel.)
 
 1. Building ARM32 and ARM64 packages for RHEL 8 is currently not supported. More investigation would be required to determine feasibility.
 

--- a/docs-dev/packages.md
+++ b/docs-dev/packages.md
@@ -20,11 +20,7 @@ This repository contains three services - `aziot-certd`, `aziot-identityd` and `
 <td><code>redhat/ubi9:latest</code></td>
 </tr>
 <tr>
-<td>Debian 10 / Raspberry Pi OS 10</td>
-<td><code>debian:10-slim</code></td>
-</tr>
-<tr>
-<td>Debian 11 / Raspberry Pi OS 11</td>
+<td>Debian 11</td>
 <td><code>debian:11-slim</code></td>
 </tr>
 <tr>

--- a/docs-dev/packaging.md
+++ b/docs-dev/packaging.md
@@ -122,4 +122,4 @@ For example, if you have a module process, the process needs to interact with th
 
 ## Package dependencies
 
-The binaries and libraries shipped in this package only depend on OpenSSL (v1.0 on CentOS 7, v1.1 on other supported distributions).
+The binaries and libraries shipped in this package only depend on OpenSSL (v3.0 on Ubuntu 22.04 and RHEL 9, v1.1 on other supported distributions).

--- a/key/test-aziot-key-openssl-engine-shared.sh
+++ b/key/test-aziot-key-openssl-engine-shared.sh
@@ -208,11 +208,6 @@ sleep 1
 
 # Connect with `curl` and print the response.
 case "$OS" in
-    'centos:7')
-        # CentOS 7's curl doesn't support openssl engines.
-        # So, skip the curl check.
-        ;;
-
     *)
         curl \
             -D /dev/stderr \

--- a/key/test-aziot-key-openssl-engine-shared.sh
+++ b/key/test-aziot-key-openssl-engine-shared.sh
@@ -10,8 +10,7 @@
 # Also set the KEY_TYPE env var to one of "ec-p256", "rsa-2048" and "rsa-4096" to evaluate that kind of asymmetric key pair.
 #
 # Lastly, ensure that libaziot_key_openssl_engine_shared.so has been installed in the openssl engines directory
-# as printed by `openssl version -e` (`/usr/lib64/openssl/engines` for CentOS 7),
-# with the name "aziot_keys.so" ("libaziot_keys.so" for CentOS 7).
+# as printed by `openssl version -e`, with the name "aziot_keys.so".
 #
 # The web server test requires an open TCP port to bind to. The default is 8443. Set the PORT env var to override it.
 #

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: azure-iot-identity
 base: core22 # the base snap is the execution environment for this snap
-version: '1.4.0~dev' # should end with '~dev' on the main branch
+version: '1.5.0'
 summary: Provides provisioning and cryptographic services for Azure IoT Hub devices.
 description: |
   The Identity Service provisions a device's identity and any modules it runs. The device identity can be based


### PR DESCRIPTION
Note we typically cut a release branch and make version changes there. This time we'll start by working directly from main. We can move to a release branch at any time if needed.

Changes:
- Removed support for CentOS 7 and Debian 10. These will continue to be supported in v1.4 until they go out of support this summer (June 2024), but they won't be supported in 1.5.
- Bumped the version in various files.