### PR TITLE
Add back CentOS 7 & Debian 10 for 1.4 end-to-end tests

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -71,6 +71,7 @@ jobs:
             branch: 'main'
           - os: 'debian:10'
             branch: 'main'
+
       max-parallel: 10
 
     steps:

--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -52,6 +52,8 @@ jobs:
 
       matrix:
         os:
+        - 'centos:7'
+        - 'debian:10'
         - 'debian:11'
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
         # - 'platform:el8'
@@ -63,7 +65,12 @@ jobs:
         - 'manual-x509'
         - 'dps-symmetric-key'
         - 'dps-x509'
-
+        exclude:
+          # centos:7 and debian:10 are supported in 1.4, not 1.5
+          - os: 'centos:7'
+            branch: 'main'
+          - os: 'debian:10'
+            branch: 'main'
       max-parallel: 10
 
     steps:

--- a/.github/workflows/e2e-tests-scheduled.yaml
+++ b/.github/workflows/e2e-tests-scheduled.yaml
@@ -68,6 +68,8 @@ jobs:
         - 'main'
         - 'release/1.4'
         os:
+        - 'centos:7'
+        - 'debian:10'
         - 'debian:11'
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
         # - 'platform:el8'
@@ -80,6 +82,11 @@ jobs:
         - 'dps-symmetric-key'
         - 'dps-x509'
         exclude:
+          # centos:7 and debian:10 are supported in 1.4, not 1.5
+          - os: 'centos:7'
+            branch: 'main'
+          - os: 'debian:10'
+            branch: 'main'
           # The scheduled E2E test in the release/1.x branch would fail until the changes are merged. Excluding for now.
           - os: 'ubuntu:22.04'
             branch: 'release/1.4'


### PR DESCRIPTION
Support for CentOS 7 and Debian 10 were recently removed from the end-to-end test workflows in main because they will not be supported in version 1.5. But the workflow in main runs the tests for both main and release/1.4 branches and those platforms are still supported in 1.4 until they reach end of life (June 2024). This change adds them back for 1.4.