### PR TITLE
Revert changes to manual e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests-manual.yaml
+++ b/.github/workflows/e2e-tests-manual.yaml
@@ -52,8 +52,6 @@ jobs:
 
       matrix:
         os:
-        - 'centos:7'
-        - 'debian:10'
         - 'debian:11'
         # EL8 VMs spontaneously lose ssh after installing updates. Disable it for now.
         # - 'platform:el8'
@@ -65,12 +63,6 @@ jobs:
         - 'manual-x509'
         - 'dps-symmetric-key'
         - 'dps-x509'
-        exclude:
-          # centos:7 and debian:10 are supported in 1.4, not 1.5
-          - os: 'centos:7'
-            branch: 'main'
-          - os: 'debian:10'
-            branch: 'main'
 
       max-parallel: 10
 


### PR DESCRIPTION
A recent change (see 0180a54b431d6dd95c4d463d5c778c1bae3a597f) was made to both the manual and scheduled end-to-end test workflows, but should have only been made to scheduled because manual only operates on a single given branch. This update reverts the change on the manual workflow.