### PR TITLE
Read latest version from product-versions.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "openssl",
  "openssl-sys2",
  "openssl2",
+ "semver",
  "serde",
  "serde_json",
  "sysinfo",
@@ -2224,6 +2225,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"

--- a/aziotctl/Cargo.toml
+++ b/aziotctl/Cargo.toml
@@ -23,6 +23,7 @@ libc = "0.2"
 nix = "0.26"
 log = { version = "0.4", features = ["std"] }
 openssl = "0.10"
+semver = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.59"
 clap = { version = "4", features = ["derive"] }

--- a/aziotctl/src/internal/check/checks/aziot_version.rs
+++ b/aziotctl/src/internal/check/checks/aziot_version.rs
@@ -99,6 +99,9 @@ impl AziotVersion {
                 }
             };
 
+            let actual_semver = Version::parse(actual_version)
+                .context("could not parse actual version as semver")?;
+
             let versions: Vec<String> = latest_versions
                 .channels
                 .iter()
@@ -109,26 +112,26 @@ impl AziotVersion {
                 .map(|component| component.version.clone())
                 .collect();
 
-            let actual_channel = Version::parse(actual_version)
-                .context("could not parse actual version as semver")?;
-            let expected_version = versions
+            let parsed_versions = versions
                 .iter()
-                .find(|version| {
-                    let expected_channel = Version::parse(version)
-                        .context("could not parse expected version as semver")
-                        .unwrap(); // TODO: What's the right error handling here?
-                    expected_channel.major == actual_channel.major
-                        && expected_channel.minor == actual_channel.minor
+                .map(|version| {
+                    Ok(Version::parse(version)
+                        .context("could not parse expected version as semver")?)
                 })
+                .collect::<Result<Vec<_>>>()?;
+
+            let expected_version = parsed_versions
+                .iter()
+                .find(|semver| semver.major == actual_semver.major && semver.minor == actual_semver.minor)
                 .ok_or_else(|| {
                     anyhow!(
                         "could not find aziot-identity-service version {}.{}.x in list of supported products at {}",
-                        actual_channel.major,
-                        actual_channel.minor,
+                        actual_semver.major,
+                        actual_semver.minor,
                         URI
                     )
                 })?;
-            expected_version.clone()
+            expected_version.to_string()
         };
 
         self.expected_version = Some(expected_version.clone());

--- a/aziotctl/src/internal/check/checks/aziot_version.rs
+++ b/aziotctl/src/internal/check/checks/aziot_version.rs
@@ -115,8 +115,7 @@ impl AziotVersion {
             let parsed_versions = versions
                 .iter()
                 .map(|version| {
-                    Ok(Version::parse(version)
-                        .context("could not parse expected version as semver")?)
+                    Version::parse(version).context("could not parse expected version as semver")
                 })
                 .collect::<Result<Vec<_>>>()?;
 

--- a/aziotctl/src/internal/check/checks/aziot_version.rs
+++ b/aziotctl/src/internal/check/checks/aziot_version.rs
@@ -34,6 +34,7 @@ impl AziotVersion {
         shared: &CheckerShared,
         cache: &mut CheckerCache,
     ) -> Result<CheckResult> {
+        const URI: &str = "https://aka.ms/azure-iotedge-latest-versions";
         let actual_version = env!("CARGO_PKG_VERSION");
         let expected_version = if let Some(expected_aziot_version) =
             &shared.cfg.expected_aziot_version
@@ -54,8 +55,6 @@ impl AziotVersion {
                 http_common::MaybeProxyConnector::new(shared.cfg.proxy_uri.clone(), None, &[])
                     .context("could not initialize HTTP connector")?;
             let client: hyper::Client<_, hyper::Body> = hyper::Client::builder().build(connector);
-
-            const URI: &str = "https://aka.ms/azure-iotedge-latest-versions";
             let mut uri: hyper::Uri = URI.parse().expect("hard-coded URI cannot fail to parse");
             let latest_versions = loop {
                 let req = {

--- a/aziotctl/src/internal/check/mod.rs
+++ b/aziotctl/src/internal/check/mod.rs
@@ -32,7 +32,7 @@ pub struct CheckerCfg {
     pub proxy_uri: Option<hyper::Uri>,
 
     /// If set, the check compares the installed package version to this string.
-    /// Otherwise, the version is fetched from <http://aka.ms/latest-aziot-identity-service>
+    /// Otherwise, the version is fetched from <http://aka.ms/azure-iotedge-latest-versions>
     #[arg(long, value_name = "VERSION")]
     pub expected_aziot_version: Option<String>,
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,9 +19,19 @@ Using Ubuntu 22.04 amd64 as an example:
 
 ```bash
 # query GitHub for the latest versions of IoT Edge and IoT Identity Service
-wget -qO- https://raw.githubusercontent.com/Azure/azure-iotedge/main/latest-aziot-edge.json | jq -r '."aziot-edge"'
+wget -qO- https://raw.githubusercontent.com/Azure/azure-iotedge/main/product-versions.json | jq -r '
+  .channels[]
+  | select(.name == "stable").products[]
+  | select(.id == "aziot-edge").components[]
+  | select(.name == "aziot-edge").version
+'
 # example output: 1.4.20
-wget -qO- https://raw.githubusercontent.com/Azure/azure-iotedge/main/latest-aziot-identity-service.json | jq -r '."aziot-identity-service"'
+wget -qO- https://raw.githubusercontent.com/Azure/azure-iotedge/main/product-versions.json | jq -r '
+  .channels[]
+  | select(.name == "stable").products[]
+  | select(.id == "aziot-edge").components[]
+  | select(.name == "aziot-identity-service").version
+'
 # example output: 1.4.6
 
 # download and install


### PR DESCRIPTION
The "aziot-version" check in `aziotctl check` reads the latest identity service version from https://github.com/Azure/azure-iotedge/blob/main/latest-aziot-identity-service.json. This JSON file has no ability to accomodate multiple releases (e.g., 1.4 and 1.5). However, https://github.com/Azure/azure-iotedge/blob/main/product-versions.json was recently introduced and, while it has a more complex structure, it is capable of providing information about multiple versions of the same product.

This change updates `aziotctl check` to read the latest identity service version from product-versions.json. Since the logic needs to contend with multiple versions, it now uses the MAJOR.MINOR version from the actual version string to match the expected version. For example, if the user has 1.5.0 installed and 1.5.2 and 1.4.10 are the latest versions, it will match on 1.5 and return 1.5.2 as the expected version. It does not differentiate between the same versions on different channels (e.g., stable vs. LTS); it assumes they are the same (in other words, it assumes product-versions.json will never legitimately show version 1.5.3 in the stable channel and 1.5.2 in the LTS channel).