### PR TITLE
Remove packages.microsoft.com registration from test script

### DIFF
--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -148,11 +148,7 @@ installTestTools() {
     local os="${distributor_id,,}"
     case "$os" in
         debian|ubuntu)
-            release="$(lsb_release -rs)"
-            wget "https://packages.microsoft.com/config/$os/$release/packages-microsoft-prod.deb" \
-                -O packages-microsoft-prod.deb
-            sudo dpkg -i packages-microsoft-prod.deb
-            rm packages-microsoft-prod.deb
+            # these next commands assume that packages.microsoft.com has already been added to the apt sources list
             set +e
             for retry in {0..3}; do
                 if [ "$retry" != "0" ]; then


### PR DESCRIPTION
The custom agents which run the end-to-end test workflows (manual and scheduled) already register packages.microsoft.com with apt, and they sign the registration with a specific keyring file. This clashes with the method of registration happening in the end-to-end tests, causing errors like:
```
Setting up packages-microsoft-prod (1.0-ubuntu22.04.1) ...
E: Conflicting values set for option Signed-By regarding source https://packages.microsoft.com/ubuntu/22.04/prod/ jammy...
```

This change removes the redundant and conflicting registration from the test script. It is assumed that packages.microsoft.com has already been registered when the tests run.

To test, I ran the manual workflow against the PR and verifying that it got past the above error.