### PR TITLE
Disable shared key access on test storage account

### DIFF
--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -100,7 +100,8 @@ setupCustomAllocationPolicy() {
             --location $AZURE_LOCATION \
             --resource-group $AZURE_RESOURCE_GROUP_NAME \
             --sku Standard_LRS \
-            --tags "suite_id=$suite_id"
+            --tags "suite_id=$suite_id" \
+            --allow-shared-key-access false
 
         # Create function app
         az functionapp create \


### PR DESCRIPTION
We create a temporary storage account for use by an Azure Function in the scheduled and manual end-to-end tests. Per best practices, we want to create it with shared key access disabled. This change updates the Azure CLI command that creates the storage account.