### PR TITLE
Update snap base image and remove unnecessary config

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-
 toml_kvp() {
 	printf "%s = \"%s\"\n" "$1" "$2"
 }
@@ -11,9 +10,5 @@ toml_new_section() {
 }
 
 snapctl get raw-config > /etc/aziot/config.toml
-
-{
-	toml_kvp "hostname" "$(hostnamectl hostname)"
-} | tee /etc/aziot/keyd/config.d/01-snap.toml /etc/aziot/certd/config.d/01-snap.toml /etc/aziot/identityd/config.d/01-snap.toml /etc/aziot/tpmd/config.d/01-snap.toml
 
 $SNAP/bin/aziotctl config apply

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: azure-iot-identity
-base: core22 # the base snap is the execution environment for this snap
+base: core24 # the base snap is the execution environment for this snap
 version: '1.5.1'
 summary: Provides provisioning and cryptographic services for Azure IoT Hub devices.
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,7 +57,6 @@ parts:
         - libcurl4-openssl-dev
     stage-packages:
       - libtss2-esys-3.0.2-0
-      - libtss2-mu0
       - libtss2-rc0
       - libtss2-sys1
       - libtss2-tctildr0


### PR DESCRIPTION
To be consistent with the azure-iot-edge snap (see Azure/iotedge#7351), this change updates the azure-iot-identity snap base to core24. It also removes logic from the configure hook that was unnecessarily populating the hostname field in the identityd, certd, keyd, and tpmd config files. Identityd is the only service that defines hostname in its config, and the field will be automatically set by `aziotctl config apply`, which the configure hook already calls.