### PR TITLE
Fix Cargo tools install in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -40,9 +40,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libtss2-dev
-        set -e
-        NO_OS_PACKAGES=1 . ci/install-build-deps.sh
         set +e
+        NO_OS_PACKAGES=1 . ci/install-build-deps.sh
+        set -e
         rm -r third-party/tpm2-tss
         make
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -52,14 +52,6 @@ jobs:
 
         rm -r third-party/tpm2-tss
 
-        echo -n '>>>> BINDGEN: '
-        command -v bindgen
-        bindgen --version
-        echo -n '>>>> CBINDGEN: '
-        command -v cbindgen
-        cbindgen --version
-        echo ">>>> PATH: $PATH"
-
         make
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -37,16 +37,27 @@ jobs:
         languages: ${{ matrix.language }}
 
     - run: |
-        sudo ARCH=amd64 bash -c '
-          . ci/install-build-deps.sh
-          rm -r third-party/tpm2-tss
-          echo -n ">>>> BINDGEN: "
-          command -v bindgen
-          echo -n ">>>> CBINDGEN: "
-          command -v cbindgen;
-          echo ">>>> PATH: $PATH"
-          make
-        '
+        rustup set profile minimal
+
+        BINDGEN_VERSION='0.69.4'
+        CBINDGEN_VERSION='0.26.0'
+
+        cargo install bindgen-cli --version "=$BINDGEN_VERSION" --locked
+        cargo install cbindgen --version "=$CBINDGEN_VERSION" --locked
+
+        export CARGO_INCREMENTAL=0
+
+        rm -r third-party/tpm2-tss
+
+        echo -n '>>>> BINDGEN: '
+        command -v bindgen
+        bindgen --version
+        echo -n '>>>> CBINDGEN: '
+        command -v cbindgen
+        cbindgen --version
+        echo ">>>> PATH: $PATH"
+
+        make
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -37,6 +37,9 @@ jobs:
         languages: ${{ matrix.language }}
 
     - run: |
+        sudo apt-get update
+        sudo apt-get install -y libtss2-dev
+
         rustup set profile minimal
 
         BINDGEN_VERSION='0.69.4'

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -40,9 +40,9 @@ jobs:
         sudo ARCH=amd64 bash -c '
           . ci/install-build-deps.sh
           rm -r third-party/tpm2-tss
-          echo -n '>>>> BINDGEN: '
+          echo -n ">>>> BINDGEN: "
           command -v bindgen
-          echo -n '>>>> CBINDGEN: '
+          echo -n ">>>> CBINDGEN: "
           command -v cbindgen;
           echo ">>>> PATH: $PATH"
           make

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-22.04'
     timeout-minutes: 360
     permissions:
       actions: read

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -40,7 +40,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libtss2-dev
+        set -e
         NO_OS_PACKAGES=1 . ci/install-build-deps.sh
+        set +e
         rm -r third-party/tpm2-tss
         make
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -40,9 +40,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libtss2-dev
-        set +e
+        set +e -x
         NO_OS_PACKAGES=1 . ci/install-build-deps.sh
-        set -e
+        set -e +x
         rm -r third-party/tpm2-tss
         make
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -40,9 +40,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libtss2-dev
-        set +e -x
-        NO_OS_PACKAGES=1 . ci/install-build-deps.sh
-        set -e +x
+        DISABLE_FOR_CODEQL=1 . ci/install-build-deps.sh
         rm -r third-party/tpm2-tss
         make
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,6 +39,14 @@ jobs:
     - run: |
         sudo ARCH=amd64 bash -c '. ci/install-build-deps.sh'
         rm -r third-party/tpm2-tss
+
+        echo -n '>>>> BINDGEN: '
+        command -v bindgen
+        echo -n '>>>> CBINDGEN: '
+        command -v cbindgen;
+        echo -n '>>>> PATH: '
+        echo "$PATH"
+
         sudo make
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -36,22 +36,12 @@ jobs:
       with:
         languages: ${{ matrix.language }}
 
-    - run: |
+    - name: 'Build'
+      run: |
         sudo apt-get update
         sudo apt-get install -y libtss2-dev
-
-        rustup set profile minimal
-
-        BINDGEN_VERSION='0.69.4'
-        CBINDGEN_VERSION='0.26.0'
-
-        cargo install bindgen-cli --version "=$BINDGEN_VERSION" --locked
-        cargo install cbindgen --version "=$CBINDGEN_VERSION" --locked
-
-        export CARGO_INCREMENTAL=0
-
+        NO_OS_PACKAGES=1 . ci/install-build-deps.sh
         rm -r third-party/tpm2-tss
-
         make
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,7 +39,7 @@ jobs:
     - run: |
         sudo ARCH=amd64 bash -c '. ci/install-build-deps.sh'
         rm -r third-party/tpm2-tss
-        make
+        sudo make
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -37,17 +37,16 @@ jobs:
         languages: ${{ matrix.language }}
 
     - run: |
-        sudo ARCH=amd64 bash -c '. ci/install-build-deps.sh'
-        rm -r third-party/tpm2-tss
-
-        echo -n '>>>> BINDGEN: '
-        command -v bindgen
-        echo -n '>>>> CBINDGEN: '
-        command -v cbindgen;
-        echo -n '>>>> PATH: '
-        echo "$PATH"
-
-        sudo make
+        sudo ARCH=amd64 bash -c '
+          . ci/install-build-deps.sh
+          rm -r third-party/tpm2-tss
+          echo -n '>>>> BINDGEN: '
+          command -v bindgen
+          echo -n '>>>> CBINDGEN: '
+          command -v cbindgen;
+          echo ">>>> PATH: $PATH"
+          make
+        '
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ SHELL = /bin/bash
 default:
 	# Re-generate aziot-keys.h if necessary
 	set -euo pipefail; \
-	command -v bindgen; bindgen --version \
+	command -v bindgen; bindgen --version; \
 	aziot_keys_h_new="$$(mktemp --tmpdir 'aziot-keys.h.new.XXXXXXXXXX')"; \
 	trap "$(RM) '$$aziot_keys_h_new'" EXIT; \
 	cp key/aziot-keys/cbindgen.prelude.h "$$aziot_keys_h_new"; \

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ SHELL = /bin/bash
 default:
 	# Re-generate aziot-keys.h if necessary
 	set -euo pipefail; \
+	command -v bindgen; bindgen --version \
 	aziot_keys_h_new="$$(mktemp --tmpdir 'aziot-keys.h.new.XXXXXXXXXX')"; \
 	trap "$(RM) '$$aziot_keys_h_new'" EXIT; \
 	cp key/aziot-keys/cbindgen.prelude.h "$$aziot_keys_h_new"; \

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ SHELL = /bin/bash
 default:
 	# Re-generate aziot-keys.h if necessary
 	set -euo pipefail; \
-	command -v bindgen; bindgen --version; \
+	command -v bindgen; bindgen --version \
 	aziot_keys_h_new="$$(mktemp --tmpdir 'aziot-keys.h.new.XXXXXXXXXX')"; \
 	trap "$(RM) '$$aziot_keys_h_new'" EXIT; \
 	cp key/aziot-keys/cbindgen.prelude.h "$$aziot_keys_h_new"; \

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ SHELL = /bin/bash
 default:
 	# Re-generate aziot-keys.h if necessary
 	set -euo pipefail; \
-	command -v bindgen; bindgen --version \
 	aziot_keys_h_new="$$(mktemp --tmpdir 'aziot-keys.h.new.XXXXXXXXXX')"; \
 	trap "$(RM) '$$aziot_keys_h_new'" EXIT; \
 	cp key/aziot-keys/cbindgen.prelude.h "$$aziot_keys_h_new"; \

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -10,7 +10,7 @@ fi
 
 # OS packages
 
-if [ -z "${NO_OS_PACKAGES:-}" ]; then
+if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
     case "$OS:$ARCH" in
         'debian:11:amd64'|'debian:12:amd64'|'ubuntu:20.04:amd64'|'ubuntu:22.04:amd64')
             export DEBIAN_FRONTEND=noninteractive
@@ -203,15 +203,17 @@ if [ -z "${NO_OS_PACKAGES:-}" ]; then
     esac
 fi
 
-echo "Verifying that third-party/cgmanifest.json is current"
-# SAFETY:
-# The build was started from a fresh image and we are the sole user. The
-# only other way the environment could acquire a rogue ".git" directory
-# is if one of the pipeline steps or dependencies was compromised, in
-# which case the attacker could have run arbitrary commands anyway.
-git config --global safe.directory "*"
-third-party/generate_cgmanifest.sh \
-| diff third-party/cgmanifest.json -
+if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
+    echo "Verifying that third-party/cgmanifest.json is current"
+    # SAFETY:
+    # The build was started from a fresh image and we are the sole user. The
+    # only other way the environment could acquire a rogue ".git" directory
+    # is if one of the pipeline steps or dependencies was compromised, in
+    # which case the attacker could have run arbitrary commands anyway.
+    git config --global safe.directory "*"
+    third-party/generate_cgmanifest.sh \
+    | diff third-party/cgmanifest.json -
+fi
 
 # Rust
 

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -215,7 +215,7 @@ third-party/generate_cgmanifest.sh \
 
 mkdir -p ~/.cargo/bin
 CARGO_BIN=$(readlink -f ~/.cargo/bin)
-export PATH="$CARGO_BIN:$PATH"
+export PATH="$PATH:$CARGO_BIN"
 
 if ! [ -f ~/.cargo/bin/rustup ]; then
     baseArch="$(uname -m)"

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -247,6 +247,9 @@ rustup self update
 # Ref: https://github.com/rust-lang/rustup/issues/2579
 rustup set profile minimal
 
+command -v bindgen
+bindgen --version
+
 BINDGEN_VERSION='0.69.4'
 CBINDGEN_VERSION='0.26.0'
 

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -10,7 +10,7 @@ fi
 
 # OS packages
 
-if [ -z "$NO_OS_PACKAGES" ]; then
+if [ -z "${NO_OS_PACKAGES:-}" ]; then
     case "$OS:$ARCH" in
         'debian:11:amd64'|'debian:12:amd64'|'ubuntu:20.04:amd64'|'ubuntu:22.04:amd64')
             export DEBIAN_FRONTEND=noninteractive

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -215,7 +215,7 @@ third-party/generate_cgmanifest.sh \
 
 mkdir -p ~/.cargo/bin
 CARGO_BIN=$(readlink -f ~/.cargo/bin)
-export PATH="$PATH:$CARGO_BIN"
+export PATH="$CARGO_BIN:$PATH"
 
 if ! [ -f ~/.cargo/bin/rustup ]; then
     baseArch="$(uname -m)"

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -10,196 +10,198 @@ fi
 
 # OS packages
 
-case "$OS:$ARCH" in
-    'debian:11:amd64'|'debian:12:amd64'|'ubuntu:20.04:amd64'|'ubuntu:22.04:amd64')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
+if [ -z "$NO_OS_PACKAGES" ]; then
+    case "$OS:$ARCH" in
+        'debian:11:amd64'|'debian:12:amd64'|'ubuntu:20.04:amd64'|'ubuntu:22.04:amd64')
+            export DEBIAN_FRONTEND=noninteractive
+            export TZ=UTC
 
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y \
-            acl autoconf autoconf-archive automake build-essential clang cmake \
-            curl git jq libclang1 libltdl-dev libssl-dev libtss2-dev libtool \
-            llvm-dev pkg-config
-        ;;
+            apt-get update
+            apt-get upgrade -y
+            apt-get install -y \
+                acl autoconf autoconf-archive automake build-essential clang cmake \
+                curl git jq libclang1 libltdl-dev libssl-dev libtss2-dev libtool \
+                llvm-dev pkg-config
+            ;;
 
-    'debian:11:arm32v7')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
+        'debian:11:arm32v7')
+            export DEBIAN_FRONTEND=noninteractive
+            export TZ=UTC
 
-        dpkg --add-architecture armhf
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-armhf curl git jq \
-            libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
-            libltdl-dev:armhf libssl-dev:armhf libtool libtss2-dev:armhf \
-            llvm-dev pkg-config
-        ;;
+            dpkg --add-architecture armhf
+            apt-get update
+            apt-get upgrade -y
+            apt-get install -y --no-install-recommends \
+                acl autoconf autoconf-archive automake build-essential ca-certificates \
+                clang cmake crossbuild-essential-armhf curl git jq \
+                libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
+                libltdl-dev:armhf libssl-dev:armhf libtool libtss2-dev:armhf \
+                llvm-dev pkg-config
+            ;;
 
-    'debian:12:arm32v7')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
+        'debian:12:arm32v7')
+            export DEBIAN_FRONTEND=noninteractive
+            export TZ=UTC
 
-        dpkg --add-architecture armhf
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-armhf curl git jq \
-            libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
-            libltdl-dev:armhf libssl-dev:armhf libtool libtss2-dev:armhf \
-            llvm-dev pkg-config:armhf
-        ;;
+            dpkg --add-architecture armhf
+            apt-get update
+            apt-get upgrade -y
+            apt-get install -y --no-install-recommends \
+                acl autoconf autoconf-archive automake build-essential ca-certificates \
+                clang cmake crossbuild-essential-armhf curl git jq \
+                libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
+                libltdl-dev:armhf libssl-dev:armhf libtool libtss2-dev:armhf \
+                llvm-dev pkg-config:armhf
+            ;;
 
-    'debian:11:aarch64')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
+        'debian:11:aarch64')
+            export DEBIAN_FRONTEND=noninteractive
+            export TZ=UTC
 
-        dpkg --add-architecture arm64
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-arm64 curl git jq \
-            libc-dev:arm64 libclang1 libcurl4-openssl-dev:arm64 \
-            libltdl-dev:arm64 libssl-dev:arm64 libtool libtss2-dev:arm64 \
-            llvm-dev pkg-config
-        ;;
-    
-    'debian:12:aarch64')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
+            dpkg --add-architecture arm64
+            apt-get update
+            apt-get upgrade -y
+            apt-get install -y --no-install-recommends \
+                acl autoconf autoconf-archive automake build-essential ca-certificates \
+                clang cmake crossbuild-essential-arm64 curl git jq \
+                libc-dev:arm64 libclang1 libcurl4-openssl-dev:arm64 \
+                libltdl-dev:arm64 libssl-dev:arm64 libtool libtss2-dev:arm64 \
+                llvm-dev pkg-config
+            ;;
+        
+        'debian:12:aarch64')
+            export DEBIAN_FRONTEND=noninteractive
+            export TZ=UTC
 
-        dpkg --add-architecture arm64
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-arm64 curl git jq \
-            libc-dev:arm64 libclang1 libcurl4-openssl-dev:arm64 \
-            libltdl-dev:arm64 libssl-dev:arm64 libtool libtss2-dev:arm64 \
-            llvm-dev pkg-config:arm64
-        ;;
+            dpkg --add-architecture arm64
+            apt-get update
+            apt-get upgrade -y
+            apt-get install -y --no-install-recommends \
+                acl autoconf autoconf-archive automake build-essential ca-certificates \
+                clang cmake crossbuild-essential-arm64 curl git jq \
+                libc-dev:arm64 libclang1 libcurl4-openssl-dev:arm64 \
+                libltdl-dev:arm64 libssl-dev:arm64 libtool libtss2-dev:arm64 \
+                llvm-dev pkg-config:arm64
+            ;;
 
-    'platform:el8:amd64')
-        export VENDOR_LIBTSS=1
+        'platform:el8:amd64')
+            export VENDOR_LIBTSS=1
 
-        dnf install -y \
-            autoconf autoconf-archive automake clang cmake curl gcc gcc-c++ \
-            git jq make libcurl-devel libtool llvm-devel openssl openssl-devel \
-            pkgconfig
-        ;;
+            dnf install -y \
+                autoconf autoconf-archive automake clang cmake curl gcc gcc-c++ \
+                git jq make libcurl-devel libtool llvm-devel openssl openssl-devel \
+                pkgconfig
+            ;;
 
-    'platform:el9:amd64')
-        export VENDOR_LIBTSS=1
+        'platform:el9:amd64')
+            export VENDOR_LIBTSS=1
 
-        dnf install -y \
-            autoconf autoconf-archive automake clang cmake diffutils gcc gcc-c++ \
-            git jq make libcurl-devel libtool llvm-devel openssl-devel \
-            pkgconfig
-        ;;
+            dnf install -y \
+                autoconf autoconf-archive automake clang cmake diffutils gcc gcc-c++ \
+                git jq make libcurl-devel libtool llvm-devel openssl-devel \
+                pkgconfig
+            ;;
 
-    'platform:el8:aarch64'|'platform:el8:arm32v7'|'platform:el9:aarch64'|'platform:el9:arm32v7')
-        echo "Cross-compilation on $OS $ARCH is not supported" >&2
-        exit 1
-        ;;
+        'platform:el8:aarch64'|'platform:el8:arm32v7'|'platform:el9:aarch64'|'platform:el9:arm32v7')
+            echo "Cross-compilation on $OS $ARCH is not supported" >&2
+            exit 1
+            ;;
 
 
-    'ubuntu:20.04:arm32v7'|'ubuntu:22.04:arm32v7')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
+        'ubuntu:20.04:arm32v7'|'ubuntu:22.04:arm32v7')
+            export DEBIAN_FRONTEND=noninteractive
+            export TZ=UTC
 
-        sources="$(</etc/apt/sources.list grep . | grep -v '^#' | grep -v '^deb \[arch=amd64\]' || :)"
-        if [ -n "$sources" ]; then
-            # Update existing repos to be specifically for amd64
-            sed -ie 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
-        fi
+            sources="$(</etc/apt/sources.list grep . | grep -v '^#' | grep -v '^deb \[arch=amd64\]' || :)"
+            if [ -n "$sources" ]; then
+                # Update existing repos to be specifically for amd64
+                sed -ie 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
+            fi
 
-        # Add armhf repos
-        </etc/apt/sources.list sed \
-            -e 's/^deb \[arch=amd64\] /deb [arch=armhf] /g' \
-            -e 's| http://archive.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
-            -e 's| http://security.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
-            >/etc/apt/sources.list.d/ports.list
+            # Add armhf repos
+            </etc/apt/sources.list sed \
+                -e 's/^deb \[arch=amd64\] /deb [arch=armhf] /g' \
+                -e 's| http://archive.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
+                -e 's| http://security.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
+                >/etc/apt/sources.list.d/ports.list
 
-        dpkg --add-architecture armhf
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-armhf curl git jq \
-            libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
-            libltdl-dev:armhf libssl-dev:armhf libtool libtss2-dev:armhf \
-            llvm-dev pkg-config
-        ;;
+            dpkg --add-architecture armhf
+            apt-get update
+            apt-get upgrade -y
+            apt-get install -y --no-install-recommends \
+                acl autoconf autoconf-archive automake build-essential ca-certificates \
+                clang cmake crossbuild-essential-armhf curl git jq \
+                libc-dev:armhf libclang1 libcurl4-openssl-dev:armhf \
+                libltdl-dev:armhf libssl-dev:armhf libtool libtss2-dev:armhf \
+                llvm-dev pkg-config
+            ;;
 
-    'ubuntu:20.04:aarch64'|'ubuntu:22.04:aarch64')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
+        'ubuntu:20.04:aarch64'|'ubuntu:22.04:aarch64')
+            export DEBIAN_FRONTEND=noninteractive
+            export TZ=UTC
 
-        sources="$(</etc/apt/sources.list grep . | grep -v '^#' | grep -v '^deb \[arch=amd64\]' || :)"
-        if [ -n "$sources" ]; then
-            # Update existing repos to be specifically for amd64
-            sed -ie 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
-        fi
+            sources="$(</etc/apt/sources.list grep . | grep -v '^#' | grep -v '^deb \[arch=amd64\]' || :)"
+            if [ -n "$sources" ]; then
+                # Update existing repos to be specifically for amd64
+                sed -ie 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
+            fi
 
-        # Add arm64 repos
-        </etc/apt/sources.list sed \
-            -e 's/^deb \[arch=amd64\] /deb [arch=arm64] /g' \
-            -e 's| http://archive.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
-            -e 's| http://security.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
-            >/etc/apt/sources.list.d/ports.list
+            # Add arm64 repos
+            </etc/apt/sources.list sed \
+                -e 's/^deb \[arch=amd64\] /deb [arch=arm64] /g' \
+                -e 's| http://archive.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
+                -e 's| http://security.ubuntu.com/ubuntu/ | http://ports.ubuntu.com/ubuntu-ports/ |g' \
+                >/etc/apt/sources.list.d/ports.list
 
-        dpkg --add-architecture arm64
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y --no-install-recommends \
-            acl autoconf autoconf-archive automake build-essential ca-certificates \
-            clang cmake crossbuild-essential-arm64 curl git jq \
-            libc-dev:arm64 libclang1 libcurl4-openssl-dev:arm64 \
-            libltdl-dev:arm64 libssl-dev:arm64 libtool libtss2-dev:arm64 \
-            llvm-dev pkg-config
-        ;;
+            dpkg --add-architecture arm64
+            apt-get update
+            apt-get upgrade -y
+            apt-get install -y --no-install-recommends \
+                acl autoconf autoconf-archive automake build-essential ca-certificates \
+                clang cmake crossbuild-essential-arm64 curl git jq \
+                libc-dev:arm64 libclang1 libcurl4-openssl-dev:arm64 \
+                libltdl-dev:arm64 libssl-dev:arm64 libtool libtss2-dev:arm64 \
+                llvm-dev pkg-config
+            ;;
 
-    'mariner:2:amd64' | 'mariner:2:aarch64')
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=UTC
+        'mariner:2:amd64' | 'mariner:2:aarch64')
+            export DEBIAN_FRONTEND=noninteractive
+            export TZ=UTC
 
-        apt-get update
-        apt-get upgrade -y
-        apt-get install -y software-properties-common
-        add-apt-repository -y ppa:longsleep/golang-backports
-        apt-get update
-        apt-get install -y \
-            cmake curl gcc g++ git jq make pkg-config \
-            libclang1 libssl-dev llvm-dev \
-            cpio genisoimage golang-1.20-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+            apt-get update
+            apt-get upgrade -y
+            apt-get install -y software-properties-common
+            add-apt-repository -y ppa:longsleep/golang-backports
+            apt-get update
+            apt-get install -y \
+                cmake curl gcc g++ git jq make pkg-config \
+                libclang1 libssl-dev llvm-dev \
+                cpio genisoimage golang-1.20-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
-        rm -f /usr/bin/go
-        ln -vs /usr/lib/go-1.20/bin/go /usr/bin/go
-        if [ -f /.dockerenv ]; then
-            mv /.dockerenv /.dockerenv.old
-        fi
+            rm -f /usr/bin/go
+            ln -vs /usr/lib/go-1.20/bin/go /usr/bin/go
+            if [ -f /.dockerenv ]; then
+                mv /.dockerenv /.dockerenv.old
+            fi
 
-        BranchTag='2.0-stable'
-        MarinerToolkitDir='/tmp/CBL-Mariner'
-        if ! [ -f "$MarinerToolkitDir/toolkit.tar.gz" ]; then
-            rm -rf "$MarinerToolkitDir"
-            git clone 'https://github.com/microsoft/CBL-Mariner.git' --branch "$BranchTag" --depth 1 "$MarinerToolkitDir"
-            pushd "$MarinerToolkitDir/toolkit/" || exit
-            make REBUILD_TOOLS=y package-toolkit
-            popd || exit
-            cp "$MarinerToolkitDir"/out/toolkit-*.tar.gz "$MarinerToolkitDir/toolkit.tar.gz"
-        fi
-        ;;
+            BranchTag='2.0-stable'
+            MarinerToolkitDir='/tmp/CBL-Mariner'
+            if ! [ -f "$MarinerToolkitDir/toolkit.tar.gz" ]; then
+                rm -rf "$MarinerToolkitDir"
+                git clone 'https://github.com/microsoft/CBL-Mariner.git' --branch "$BranchTag" --depth 1 "$MarinerToolkitDir"
+                pushd "$MarinerToolkitDir/toolkit/" || exit
+                make REBUILD_TOOLS=y package-toolkit
+                popd || exit
+                cp "$MarinerToolkitDir"/out/toolkit-*.tar.gz "$MarinerToolkitDir/toolkit.tar.gz"
+            fi
+            ;;
 
-    *)
-        echo "Unsupported OS:ARCH $OS:$ARCH" >&2
-        exit 1
-        ;;
-esac
+        *)
+            echo "Unsupported OS:ARCH $OS:$ARCH" >&2
+            exit 1
+            ;;
+    esac
+fi
 
 echo "Verifying that third-party/cgmanifest.json is current"
 # SAFETY:

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -247,9 +247,6 @@ rustup self update
 # Ref: https://github.com/rust-lang/rustup/issues/2579
 rustup set profile minimal
 
-command -v bindgen
-bindgen --version
-
 BINDGEN_VERSION='0.69.4'
 CBINDGEN_VERSION='0.26.0'
 


### PR DESCRIPTION
The `ubuntu-latest` GitHub runner recently updated its version of bindgen, which exposed a problem in our CodeQL workflow. We need to be using the pinned version of bindgen we install, but we were unknowingly using the pre-installed version because our install script was running in a subshell, so any exported variables were discarded.

This change updates the workflow to source the script in the current shell, and as a non-root user to match the way it calls make. The script now detects the presence of the `DISABLE_FOR_CODEQL` variable and skips parts of the script which (1) require root access or (2) assume the presence of submodules (which are intentionally not present for the CodeQL build to avoid analyzing code we don't own).