### PR TITLE
Upgrade go to 1.21 for Mariner toolkit

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -216,10 +216,10 @@ if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
             apt-get install -y \
                 cmake curl gcc g++ git jq make pkg-config \
                 libclang1 libssl-dev llvm-dev \
-                cpio genisoimage golang-1.20-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+                cpio genisoimage golang-1.21-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
             rm -f /usr/bin/go
-            ln -vs /usr/lib/go-1.20/bin/go /usr/bin/go
+            ln -vs /usr/lib/go-1.21/bin/go /usr/bin/go
             if [ -f /.dockerenv ]; then
                 mv /.dockerenv /.dockerenv.old
             fi


### PR DESCRIPTION
Mariner builds are failing because the Mariner toolkit has upgraded its go depependency requirement to 1.21. This change updates go in Mariner builds.