### PR TITLE
Restore version option in aziotctl

### DIFF
--- a/aziotctl/src/main.rs
+++ b/aziotctl/src/main.rs
@@ -44,6 +44,7 @@ async fn main() {
 }
 
 #[derive(Parser)]
+#[command(version)]
 enum Options {
     /// Work with the configuration of the Azure IoT Identity Service and related services.
     #[command(subcommand)]


### PR DESCRIPTION
The EFLOW team uses `aziotctl --version` as part of their smoke test against final installed bits when they release, and they reported that the `--version` option isn't available in aziot-identity-service 1.5. It looks we used to get the option automatically, but when we upgraded to clap v4 the behavior changed.

This change updates aziotctl to explicitly opt in to the `--version` option.

To test, I built the changes and confirmed the option is reported in `--help`, and that the version is displayed when the option is given on the command line.