### PR TITLE
Update upload/download-artifacts action to v4

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -78,7 +78,7 @@ jobs:
         os_package="$(sed -e 's@[:/]@-@g' <<< "$os_package")"
         echo "artifact-name=packages_${os_package}_${{ matrix.arch }}" >> $GITHUB_OUTPUT
     - name: 'Upload'
-      uses: 'actions/upload-artifact@v3'
+      uses: 'actions/upload-artifact@v4'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: 'packages'
@@ -113,7 +113,7 @@ jobs:
         build-info: true
 
     - name: 'Upload'
-      uses: 'actions/upload-artifact@v3'
+      uses: 'actions/upload-artifact@v4'
       with:
         name: 'packages_snap_${{ matrix.runner.arch }}'
         path: '${{ steps.snapcraft.outputs.snap }}'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
         esac
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Upload'
-      uses: 'actions/upload-artifact@v3'
+      uses: 'actions/upload-artifact@v4'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: |
@@ -113,7 +113,7 @@ jobs:
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
-      uses: 'actions/download-artifact@v3'
+      uses: 'actions/download-artifact@v4'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: 'target/debug'
@@ -165,7 +165,7 @@ jobs:
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
     - name: 'Download'
       id: 'download-artifact'
-      uses: 'actions/download-artifact@v3'
+      uses: 'actions/download-artifact@v4'
       with:
         name: "${{ steps.generate-artifact-properties.outputs.artifact-name }}"
         path: 'target/debug'

--- a/ci/e2e-tests/test-run.sh
+++ b/ci/e2e-tests/test-run.sh
@@ -31,13 +31,17 @@ get_package() {
         return
     fi
 
-    # The download-artifact action does not have a way to download artifacts from other workflows.
+    # The download-artifact@v3 action does not have a way to download artifacts from other workflows.
     # Ref: https://github.com/actions/download-artifact/issues/3
     #
     # So instead we use the GitHub API ourselves.
     #
     # It would be nice to use the v4 graphql API and get the artifact URL in one shot,
     # but it doesn't appear to support artifacts.
+    #
+    # The download-artifact@v4 action now supports downloading artifacts from other workflows, but
+    # we'd need to evaluate it. See
+    # https://github.com/actions/download-artifact#download-artifacts-from-other-workflow-runs-or-repositories
 
     github_curl() {
         if [ -n "${GITHUB_PAT:-}" ]; then


### PR DESCRIPTION
The `download-artifact@v3` and `upload-artifact@v3` GitHub actions will soon be deprecated. This change updates our workflows to use the v4 versions.