### PR TITLE
Add pkcs11 interface to keyd in azure-iot-identity snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,6 +134,7 @@ apps:
     daemon: simple
     plugs:
       - network-bind
+      - pkcs11
     sockets:
       unix:
         listen-stream: $SNAP_DATA/shared/sockets/aziot/keyd.sock


### PR DESCRIPTION
Users of the azure-iot-identity snap package report that they are unable to use PKCS#11 functionality in keyd unless they install the snap with `--devmode`. This is because the snap does not have the `pkcs11` interface connected. This change adds the interface.