### PR TITLE
Update build to work with OpenSSL 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ rpm:
 	# Engine needs to be installed to what openssl considers the enginesdir, which we can get from
 	# openssl 1.1 and 3.0 with `openssl version -e`.
 	command -v openssl # Assert that openssl exists
-	OPENSSL_ENGINE_FILENAME="$$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/')/aziot_keys.so" \
+	OPENSSL_ENGINE_FILENAME="$$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/')/aziot_keys.so"; \
 	case "$$PACKAGE_DIST" in \
 		'el7') \
 			DEVTOOLSET=devtoolset-9-; \

--- a/Makefile
+++ b/Makefile
@@ -355,10 +355,7 @@ rpm:
 	# Engine needs to be installed to what openssl considers the enginesdir, which we can get from
 	# openssl 1.1 and 3.0 with `openssl version -e`.
 	command -v openssl # Assert that openssl exists
-	case "$$(openssl version)" in \
-		'OpenSSL 1.1.'* | 'OpenSSL 3.0.'*) OPENSSL_ENGINE_FILENAME="$$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/')/aziot_keys.so" ;; \
-		*) echo "Unknown openssl version [$$(openssl version)]"; exit 1 ;; \
-	esac; \
+	OPENSSL_ENGINE_FILENAME="$$(openssl version -e | sed 's/^ENGINESDIR: "\(.*\)"$$/\1/')/aziot_keys.so" \
 	case "$$PACKAGE_DIST" in \
 		'el7') \
 			DEVTOOLSET=devtoolset-9-; \

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -40,7 +40,7 @@ override_dh_auto_install:
 		'*') exit 1;; \
 	esac; \
 	case "$$(openssl version)" in \
-	    'OpenSSL 3.0.'*) engines_dir="/usr/lib/$$arch_libdir/engines-3";; \
+	    'OpenSSL 3.'*) engines_dir="/usr/lib/$$arch_libdir/engines-3";; \
 	    'OpenSSL 1.1.'*) engines_dir="/usr/lib/$$arch_libdir/engines-1.1";; \
 		'*') exit 1;; \
 	esac; \


### PR DESCRIPTION
From recent builds, it appears that RHEL 9 has upgraded from OpenSSL 3.0 to 3.2, which breaks our builds. I found two places where we filter on the OpenSSL version.

In Makefile, I removed the filter because we no longer support OpenSSL 1.0, which is why the case statement was added. All versions of OpenSSL we support should behave the same, so there's no need to filter on the version.

In contrib/debian/rules, I relaxed the filter to handle any 3.x version of OpenSSL.