### PR TITLE
Add content interface to snap for sharing aziot_keys.so

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,7 @@ parts:
         ARCH=$CRAFT_ARCH_BUILD_FOR \
         RELEASE=1 \
         VENDOR_LIBTSS=0 \
-        OPENSSL_ENGINES_DIR="$SNAP/lib/engines-3" \
+        OPENSSL_ENGINES_DIR="/lib/engines-3" \
         PLATFORM_FEATURES=snapd \
         USER_AZIOTID=root \
         USER_AZIOTCS=root \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -164,6 +164,11 @@ slots:
     content: aziotctl-executables
     source:
       read: [ $SNAP/bin ]
+  aziot-keys-library:
+    interface: content
+    content: aziot-keys-library
+    source:
+      read: [ $SNAP/lib/engines-1.1 ]
   identity-service:
     interface: content
     content: aziot-identity-service

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,7 @@ parts:
         ARCH=$CRAFT_ARCH_BUILD_FOR \
         RELEASE=1 \
         VENDOR_LIBTSS=0 \
-        OPENSSL_ENGINES_DIR="$SNAP/lib/engines-3" \
+        OPENSSL_ENGINES_DIR=/usr/lib/$ARCH-linux-gnu/engines-3 \
         PLATFORM_FEATURES=snapd \
         USER_AZIOTID=root \
         USER_AZIOTCS=root \
@@ -185,3 +185,5 @@ layout:
     symlink: $SNAP_DATA/shared/sockets/aziot
   /etc/aziot:
     symlink: $SNAP_DATA/shared/config/aziot
+  /usr/lib/$CRAFT_ARCH_BUILD_FOR-linux-gnu/engines-3:
+    symlink: $SNAP/lib/$CRAFT_ARCH_BUILD_FOR-linux-gnu/engines-3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -169,7 +169,7 @@ slots:
     interface: content
     content: aziot-keys-openssl-engine
     source:
-      read: [ $SNAP/lib/engines-1.1 ]
+      read: [ $SNAP/lib/engines-3 ]
   identity-service:
     interface: content
     content: aziot-identity-service

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,6 +73,7 @@ parts:
         ARCH=$CRAFT_ARCH_BUILD_FOR \
         RELEASE=1 \
         VENDOR_LIBTSS=0 \
+        OPENSSL_ENGINES_DIR="$SNAP/lib/engines-3" \
         PLATFORM_FEATURES=snapd \
         USER_AZIOTID=root \
         USER_AZIOTCS=root \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -164,9 +164,9 @@ slots:
     content: aziotctl-executables
     source:
       read: [ $SNAP/bin ]
-  aziot-keys-library:
+  aziot-keys-openssl-engine:
     interface: content
-    content: aziot-keys-library
+    content: aziot-keys-openssl-engine
     source:
       read: [ $SNAP/lib/engines-1.1 ]
   identity-service:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,7 @@ parts:
         ARCH=$CRAFT_ARCH_BUILD_FOR \
         RELEASE=1 \
         VENDOR_LIBTSS=0 \
-        OPENSSL_ENGINES_DIR=/usr/lib/$ARCH-linux-gnu/engines-3 \
+        OPENSSL_ENGINES_DIR="$SNAP/lib/engines-3" \
         PLATFORM_FEATURES=snapd \
         USER_AZIOTID=root \
         USER_AZIOTCS=root \
@@ -185,5 +185,3 @@ layout:
     symlink: $SNAP_DATA/shared/sockets/aziot
   /etc/aziot:
     symlink: $SNAP_DATA/shared/config/aziot
-  /usr/lib/$CRAFT_ARCH_BUILD_FOR-linux-gnu/engines-3:
-    symlink: $SNAP/lib/$CRAFT_ARCH_BUILD_FOR-linux-gnu/engines-3


### PR DESCRIPTION
Our snap does not allow dependent snaps to access aziot_keys.so, so they cannot use our OpenSSL engine library for mTLS when their client certificate's private key is backed by our key store. This change adds a content interface for the $SNAP/lib/engines-3 folder, where aziot_keys.so lives.