### PR TITLE
Avoid container build by adding /.mariner-toolkit-ignore-dockerenv

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -220,9 +220,7 @@ if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
 
             rm -f /usr/bin/go
             ln -vs /usr/lib/go-1.21/bin/go /usr/bin/go
-            if [ -f /.dockerenv ]; then
-                mv /.dockerenv /.dockerenv.old
-            fi
+            touch /.mariner-toolkit-ignore-dockerenv
 
             BranchTag='2.0-stable'
             MarinerToolkitDir='/tmp/CBL-Mariner'


### PR DESCRIPTION
Our Azure Linux builds started failing in the past week or so because Azure Linux recently made a change to how they detect container builds (see https://github.com/microsoft/azurelinux/pull/11135), so the trick we employed to force a regular build (even though we're building in a container) stopped working. This change removes the trick and takes the recommended approach of adding `/.mariner-toolkit-ignore-dockerenv` to the container.