### PR TITLE
Use isolated worker model in e2e test functions app

### DIFF
--- a/ci/e2e-tests/helper-functions.sh
+++ b/ci/e2e-tests/helper-functions.sh
@@ -83,9 +83,9 @@ setupCustomAllocationPolicy() {
         echo 'Creating an Azure Function for use as a DPS custom allocation policy...' >&2
         
         # Initialize function app project and function
-        func init DpsCustomAllocationFunctionProj --dotnet
+        func init DpsCustomAllocationFunctionProj --worker-runtime dotnet-isolated
         pushd DpsCustomAllocationFunctionProj
-        func new --name "$dps_allocation_function_name" --template "HTTP trigger" --authlevel "anonymous" --language C# --force
+        func new --name "$dps_allocation_function_name" --template "HTTP trigger" --authlevel "anonymous" --force
         
         # Copy source code into function app project
         cp "$GITHUB_WORKSPACE/ci/e2e-tests/DpsCustomAllocation.csfunc" ./DpsCustomAllocation.cs
@@ -107,7 +107,7 @@ setupCustomAllocationPolicy() {
             --resource-group $AZURE_RESOURCE_GROUP_NAME \
             --consumption-plan-location $AZURE_LOCATION \
             --runtime dotnet \
-            --runtime-version 6 \
+            --runtime-version 8 \
             --functions-version 4 \
             --name "$dps_allocation_functionapp_name" \
             --disable-app-insights \


### PR DESCRIPTION
I received an email saying, "Beginning 10 November 2026, the in-process model for .NET apps in Azure Functions will no longer be supported."

The Functions app we create for the end-to-end tests uses the in-process model, and in fact is running on .NET 6, which is EOL. This Functions app needs a refresh generally, so I added a few (untested) changes to the script that generates the app, as a placeholder to visit later.

Handy links:
[Migrate .NET apps from the in-process model to the isolated worker model](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model?tabs=net8)
[az functionapp reference](https://learn.microsoft.com/en-us/cli/azure/functionapp?view=azure-cli-latest)
[Develop Azure Functions locally using Core Tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=linux%2Cisolated-process%2Cnode-v4%2Cpython-v2%2Chttp-trigger%2Ccontainer-apps&pivots=programming-language-csharp)
[Azure Functions Core Tools reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-core-tools-reference?tabs=v2)