### PR TITLE
Fix sed -i commands in build script

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -115,7 +115,7 @@ if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
             sources="$(</etc/apt/sources.list grep . | grep -v '^#' | grep -v '^deb \[arch=amd64\]' || :)"
             if [ -n "$sources" ]; then
                 # Update existing repos to be specifically for amd64
-                sed -ie 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
+                sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
             fi
 
             # Add armhf repos
@@ -143,7 +143,7 @@ if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
             sources="$(</etc/apt/sources.list grep . | grep -v '^#' | grep -v '^deb \[arch=amd64\]' || :)"
             if [ -n "$sources" ]; then
                 # Update existing repos to be specifically for amd64
-                sed -ie 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
+                sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
             fi
 
             # Add arm64 repos
@@ -183,8 +183,8 @@ if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
             esac
 
             # Update existing repos to be specifically for amd64
-            sed -ie '/^Architectures:/d' /etc/apt/sources.list.d/ubuntu.sources
-            sed -ie '/^Components:/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources
+            sed -i -e '/^Architectures:/d' /etc/apt/sources.list.d/ubuntu.sources
+            sed -i -e '/^Components:/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources
 
             # Add arch-specific repos
             </etc/apt/sources.list.d/ubuntu.sources sed \


### PR DESCRIPTION
Some sed commands in one of the build scripts combine the -i (edit files in place) and -e (expression to be executed) options as -ie. This changes the behavior of -i to make a backup of the edited file with 'e' as the suffix. Because these sed commands only had one expression statement on the command line, the expression was still evaluated even though the -e argument was not present. So the result was effectively the same, which the side effect of creating a backup file that no one asked for.

This change updates the sed commands just to avoid confusion.