### PR TITLE
Update dependencies for Azure Linux builds

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -218,7 +218,7 @@ if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
             fi
 
             apt-get install -y \
-                cmake cpio curl g++ gcc genisoimage git golang-1.21-go jq libclang1 libssl-dev \
+                acl cmake cpio curl g++ gcc genisoimage git golang-1.21-go jq libclang1 libssl-dev \
                 llvm-dev make pigz pkg-config python3-distutils python3-pip qemu-utils rpm tar \
                 wget zstd
 


### PR DESCRIPTION
Azure Linux 3.0 builds recently began failing with

```
+ make build-packages LOG_LEVEL=debug PACKAGE_BUILD_LIST=aziot-identity-service SRPM_FILE_SIGNATURE_HANDLING=update USE_PREVIEW_REPO=n CONFIG_FILE= -j 4
Initializing daily build ID sanitization
make: *** [/src/AzureLinux-Build/toolkit/scripts/utils.mk:103: /src/AzureLinux-Build/build/make_status/no_repo_acl.flag] Error 127
```

Line 103 of utils.mk (from the microsoft/azurelinux repo) is:

```
@setfacl -bnR $(PROJECT_ROOT) &>/dev/null && ...
```

...so the problem is that `setfacl` is not present on the build host.

This change updates the build dependencies script to install the `acl` package in the build container, which makes `setfacl` available and resolves the error.