### PR TITLE
Add support for handling network errors from parent edgeHub

### DIFF
--- a/http-common/src/lib.rs
+++ b/http-common/src/lib.rs
@@ -27,7 +27,7 @@ mod proxy;
 pub use proxy::{get_proxy_uri, MaybeProxyConnector};
 
 mod request;
-pub use request::HttpRequest;
+pub use request::{HttpRequest, HttpResponse};
 
 pub mod server;
 

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -506,7 +506,7 @@ mod tests {
 
     #[derive(Debug, serde::Deserialize)]
     struct HubError {
-        #[serde(rename = "Message", alias = "errorMessage")]
+        #[serde(rename = "Message")]
         pub message: String,
     }
 

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -293,6 +293,10 @@ pub struct HttpResponse {
 }
 
 impl HttpResponse {
+    pub fn status(&self) -> hyper::StatusCode {
+        self.status
+    }
+
     pub fn into_parts(self) -> (hyper::StatusCode, hyper::body::Bytes) {
         (self.status, self.body)
     }

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -118,29 +118,32 @@ where
         if response_status == hyper::StatusCode::NO_CONTENT {
             Ok(())
         } else {
-            Err(Error::new(ErrorKind::Other, "invalid HTTP status code"))
+            Err(Error::new(
+                ErrorKind::Other,
+                format!("unexpected HTTP status code: {}", response_status),
+            ))
         }
     }
 
     pub async fn json_response(self) -> Result<HttpResponse, Error> {
         let (status, headers, body) = self.process_request(true).await?;
 
-        let is_json_response = if let Some(content_type) = headers.get(hyper::header::CONTENT_TYPE)
-        {
+        // Some servers will return JSON responses without setting "content-type: application/json",
+        // so just check that the content-type header is not something else.
+        if let Some(content_type) = headers.get(hyper::header::CONTENT_TYPE) {
             let content_type = content_type
                 .to_str()
-                .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
+                .map_err(|err| Error::new(ErrorKind::InvalidData, err))?
+                .to_lowercase();
 
-            content_type.contains(CONTENT_TYPE_JSON)
-        } else {
-            false
-        };
-
-        if !is_json_response {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "invalid Content-Type; expected JSON",
-            ));
+            // Some response headers will contain charset in addition to content-type, so use .contains
+            // rather an an exact match.
+            if !content_type.contains(CONTENT_TYPE_JSON) {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "invalid Content-Type; expected JSON",
+                ));
+            }
         }
 
         Ok(HttpResponse {
@@ -316,10 +319,17 @@ impl HttpResponse {
 
             Ok(response)
         } else if self.status.is_client_error() || self.status.is_server_error() {
-            let error: TError = serde_json::from_slice(&self.body)
-                .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
+            if self.body.is_empty() {
+                Err(Error::new(
+                    ErrorKind::Other,
+                    format!("HTTP error {}", self.status),
+                ))
+            } else {
+                let error: TError = serde_json::from_slice(&self.body)
+                    .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
 
-            Err(error.into())
+                Err(error.into())
+            }
         } else {
             Err(Error::new(
                 ErrorKind::Other,

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -506,7 +506,7 @@ mod tests {
 
     #[derive(Debug, serde::Deserialize)]
     struct HubError {
-        #[serde(rename = "Message")]
+        #[serde(rename = "Message", alias = "errorMessage")]
         pub message: String,
     }
 

--- a/http-common/src/request.rs
+++ b/http-common/src/request.rs
@@ -120,7 +120,7 @@ where
         } else {
             Err(Error::new(
                 ErrorKind::Other,
-                format!("unexpected HTTP status code: {}", response_status),
+                format!("unexpected HTTP status code: {response_status}"),
             ))
         }
     }

--- a/identity/aziot-cloud-client-async/src/hub/mod.rs
+++ b/identity/aziot-cloud-client-async/src/hub/mod.rs
@@ -16,13 +16,13 @@ struct HubError {
     // In nested mode, identity service will not be able to detect network errors between
     // the parent and IoT Hub. The parent edgeHub must detect network errors and propogate
     // them here.
-    #[serde(rename = "parentNetworkError")]
-    pub parent_network_error: Option<bool>,
+    #[serde(rename = "networkError")]
+    pub network_error: Option<bool>,
 }
 
 impl std::convert::From<HubError> for Error {
     fn from(err: HubError) -> Error {
-        let error_kind = if err.parent_network_error == Some(true) {
+        let error_kind = if err.network_error == Some(true) {
             ErrorKind::NotConnected
         } else {
             ErrorKind::Other

--- a/identity/aziot-cloud-client-async/src/hub/mod.rs
+++ b/identity/aziot-cloud-client-async/src/hub/mod.rs
@@ -10,7 +10,7 @@ const API_VERSION: &str = "api-version=2017-11-08-preview";
 
 #[derive(Debug, serde::Deserialize)]
 struct HubError {
-    #[serde(rename = "Message")]
+    #[serde(rename = "Message", alias = "errorMessage")]
     pub message: String,
 }
 


### PR DESCRIPTION
In nested mode, child devices are not able to detect if the network between the parent and IoT Hub is down. This leads to some incorrect behavior where the child assumes IoT Hub is available during its startup. edgeHub will return a 500 Internal Server Error in this case. This PR adds handling of 500 Internal Server Errors from edgeHub as network errors so identity service starts correctly when connection to IoT Hub is down.

Also improves the logging of HTTP errors by logging the HTTP error code instead of a JSON parse error.