### PR TITLE
Prepare for release 1.5.6

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -65,7 +65,7 @@ jobs:
       env:
         ARCH: "${{ matrix.arch }}"
         OS: "${{ matrix.os }}"
-        PACKAGE_VERSION: '1.5.5'
+        PACKAGE_VERSION: '1.5.6'
         # PACKAGE_RELEASE should always be '1'.
         PACKAGE_RELEASE: '1'
     - name: 'Generate artifact properties'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "aziotctl"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "aziotd"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "aziot-certd",
  "aziot-identityd",

--- a/aziotctl/Cargo.toml
+++ b/aziotctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aziotctl"
-version = "1.5.5"
+version = "1.5.6"
 authors = ["Azure IoT Edge Devs"]
 edition = "2021"
 homepage = "https://azure.github.io/iot-identity-service/"

--- a/aziotd/Cargo.toml
+++ b/aziotd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aziotd"
-version = "1.5.5"
+version = "1.5.6"
 authors = ["Azure IoT Edge Devs"]
 edition = "2021"
 homepage = "https://azure.github.io/iot-identity-service/"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: azure-iot-identity
 base: core24 # the base snap is the execution environment for this snap
-version: '1.5.5'
+version: '1.5.6'
 summary: Provides provisioning and cryptographic services for Azure IoT Hub devices.
 description: |
   The Identity Service provisions a device's identity and any modules it runs. The device identity can be based


### PR DESCRIPTION
Updates in this release:
0452db3f15c4e7d0ee21acf545a314e18ff866d2 - Add support for Azure Linux 3.0
0c33b7b80a3fff060aa3e8e1ba226901e4154b6a - Handle network errors from parent Edge hub
31a213ced93685884d93ce8ee4b8bc346abdb06d - Remove support for Ubuntu 20.04
e62c0e3d06930dbcf33e1c951e3c5d2a32663bc6 - Enable service sockets in systemd for Azure Linux