### PR TITLE
Add retry logic for device provisioning

### DIFF
--- a/aziotctl/aziotctl-common/src/config/apply.rs
+++ b/aziotctl/aziotctl-common/src/config/apply.rs
@@ -329,6 +329,7 @@ pub fn run(
 
         aziot_identityd_config::Provisioning {
             provisioning,
+            retry_seconds: None,
             local_gateway_hostname: parent_hostname,
         }
     };

--- a/identity/aziot-identityd-config/src/lib.rs
+++ b/identity/aziot-identityd-config/src/lib.rs
@@ -224,6 +224,9 @@ pub enum DpsAttestationMethod {
 pub struct Provisioning {
     pub local_gateway_hostname: Option<String>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_seconds: Option<u64>,
+
     #[serde(flatten)]
     pub provisioning: ProvisioningType,
 }


### PR DESCRIPTION
Introduce an optional retry mechanism for device reprovisioning during startup when provisioning with IoT Hub fails and no valid local backup is available.

If not configured, the retry handling is disabled and the daemon will behave just as before and treat this as a fatal error and exit.


This fixes #657 