### PR TITLE
Remove support for Azure Linux 2.0

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -39,9 +39,6 @@ jobs:
         include:
         - container_os: 'ubuntu:22.04'
           arch: 'amd64'
-          os: 'mariner:2'
-        - container_os: 'ubuntu:22.04'
-          arch: 'amd64'
           os: 'azurelinux:3'
 
     steps:

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -204,7 +204,7 @@ if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
                 llvm-dev pkg-config:$arch_alias
             ;;
 
-        'mariner:2:amd64'|'mariner:2:aarch64'|'azurelinux:3:amd64'|'azurelinux:3:aarch64')
+        'azurelinux:3:amd64'|'azurelinux:3:aarch64')
             export DEBIAN_FRONTEND=noninteractive
             export TZ=UTC
 
@@ -224,10 +224,6 @@ if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
             touch /.mariner-toolkit-ignore-dockerenv
 
             case "$OS" in
-                'mariner:2')
-                    BranchTag='2.0-stable'
-                    ;;
-
                 'azurelinux:3')
                     BranchTag='3.0-stable'
                     ;;

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -105,7 +105,7 @@ case "$OS" in
             "packages/$TARGET_DIR/"
         ;;
 
-    'mariner:2'|'azurelinux:3')
+    'azurelinux:3')
         case "$ARCH" in
             'arm32v7')
                 echo "Cross-compilation on $OS is not supported" >&2
@@ -133,11 +133,6 @@ case "$OS" in
         popd
 
         case "$OS" in
-            'mariner:2')
-                UsePreview=n
-                TARGET_DIR="mariner2/$ARCH"
-                PackageExtension="cm2"
-                ;;
             'azurelinux:3')
                 UsePreview=n
                 TARGET_DIR="azurelinux3/$ARCH"


### PR DESCRIPTION
Azure Linux (aka Mariner) 2.0 went out of support in July 2025. This change removes it from our builds.