### PR TITLE
Fix endless reparsing of config if it's modified once after startup.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "log",
- "notify-debouncer-mini",
+ "notify-debouncer-full",
  "serde",
  "tokio",
  "toml",
@@ -1119,16 +1119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "esys-sys"
 version = "0.1.0"
 dependencies = [
@@ -1139,10 +1129,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
+name = "file-id"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1838,12 +1831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,15 +1986,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "notify-debouncer-mini"
+name = "notify-debouncer-full"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17849edfaabd9a5fef1c606d99cfc615a8e99f7ac4366406d86c7942a3184cf2"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
 dependencies = [
+ "file-id",
  "log",
  "notify",
  "notify-types",
- "tempfile",
+ "walkdir",
 ]
 
 [[package]]
@@ -2535,19 +2523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,19 +2831,6 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "pkg-config",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ libc = "0.2"
 log = { version = "0.4", features = ["std"] }
 
 nix = "0.31"
-notify-debouncer-mini = "0.7"
+notify-debouncer-full = "0.7"
 
 openssl = "0.10"
 openssl-errors = "0.2"

--- a/config-common/Cargo.toml
+++ b/config-common/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2024"
 [dependencies]
 async-trait = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
-notify-debouncer-mini = { workspace = true, optional = true }
+notify-debouncer-full = { workspace = true, optional = true }
 serde = { workspace = true }
 tokio = { workspace = true, optional = true }
 toml = { workspace = true }
 
 
 [features]
-watcher = ["async-trait", "log", "notify-debouncer-mini", "tokio"]
+watcher = ["async-trait", "log", "notify-debouncer-full", "tokio"]
 
 
 [lints]

--- a/config-common/src/watcher.rs
+++ b/config-common/src/watcher.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use notify_debouncer_mini::notify;
+use notify_debouncer_full::notify;
 
 #[async_trait]
 pub trait UpdateConfig {
@@ -58,8 +58,9 @@ pub fn start_watcher<TApi>(
             let (file_watcher_tx, file_watcher_rx) = std::sync::mpsc::channel();
 
             // Create a watcher object, delivering debounced events.
-            let mut file_watcher = notify_debouncer_mini::new_debouncer(
+            let mut file_watcher = notify_debouncer_full::new_debouncer(
                 std::time::Duration::from_secs(10),
+                None,
                 file_watcher_tx,
             )
             .unwrap();
@@ -67,23 +68,32 @@ pub fn start_watcher<TApi>(
             // Add configuration paths to be watched.
             if config_directory_path.exists() {
                 file_watcher
-                    .watcher()
                     .watch(&config_directory_path, notify::RecursiveMode::NonRecursive)
                     .expect("Watching config directory path should not fail.");
             }
 
             if config_path.exists() {
                 file_watcher
-                    .watcher()
                     .watch(&config_path, notify::RecursiveMode::NonRecursive)
                     .expect("Watching config file should not fail.");
             }
 
-            loop {
-                let event = file_watcher_rx.recv();
-                log::debug!("Incoming file watcher event: {:?}", &event);
-                if event.is_ok() {
-                    _ = file_changed_tx.blocking_send(());
+            while let Ok(events) = file_watcher_rx.recv() {
+                let Ok(events) = events else {
+                    continue;
+                };
+                for event in events {
+                    log::debug!("Incoming file watcher event: {:?}", &event);
+                    match event.event.kind {
+                        notify::event::EventKind::Any
+                        | notify::event::EventKind::Create(_)
+                        | notify::event::EventKind::Modify(_)
+                        | notify::event::EventKind::Remove(_)
+                        | notify::event::EventKind::Other => {
+                            _ = file_changed_tx.blocking_send(());
+                        }
+                        notify::event::EventKind::Access(_) => (),
+                    }
                 }
             }
         }


### PR DESCRIPTION
Since aziotd responds to config changes by reparsing the config. This reparsing would itself generate a notify events (access) after 5s, which would trigger aziotd to parse the config again, which would generate an access event, ad infinitum.

This regressed in 3fc8a1441971ee315dcbfa31a0e1e17e994ef8bf ; before that commit there was a filter to ignore access events but that commit accidentally removed the filter. This commit adds it back.