### PR TITLE
Block the ability to created nested derived keys.

### DIFF
--- a/key/aziot-keyd/src/lib.rs
+++ b/key/aziot-keyd/src/lib.rs
@@ -271,6 +271,16 @@ impl Api {
         base_handle: &aziot_key_common::KeyHandle,
         derivation_data: &[u8],
     ) -> Result<aziot_key_common::KeyHandle, Error> {
+        match key_handle_to_id(base_handle, &mut self.keys)?.0 {
+            KeyId::KeyPair(_) | KeyId::Key(_) => (),
+            KeyId::Derived(..) => {
+                return Err(Error::invalid_parameter(
+                    "handle",
+                    "nested derived keys are not supported, import the outer derived key first",
+                ));
+            }
+        }
+
         let handle = key_id_to_handle(
             &KeyId::Derived(
                 std::borrow::Cow::Borrowed(base_handle),
@@ -574,74 +584,85 @@ fn key_handle_to_id(
     handle: &aziot_key_common::KeyHandle,
     keys: &mut keys::Keys,
 ) -> Result<(KeyId<'static>, std::ffi::CString), Error> {
-    // DEVNOTE:
-    //
-    // Map errors from using the handle validation key to Error::Internal instead of relying on `?`,
-    // because all errors from using the handle validation key are internal errors.
+    fn key_handle_to_id_inner(
+        handle: &aziot_key_common::KeyHandle,
+        keys: &mut keys::Keys,
+    ) -> Result<KeyId<'static>, Error> {
+        // DEVNOTE:
+        //
+        // Map errors from using the handle validation key to Error::Internal instead of relying on `?`,
+        // because all errors from using the handle validation key are internal errors.
 
-    let params = handle.0.split('&');
+        let params = handle.0.split('&');
 
-    let mut sr = None;
-    let mut sig = None;
+        let mut sr = None;
+        let mut sig = None;
 
-    let engine = base64::engine::general_purpose::STANDARD;
+        let engine = base64::engine::general_purpose::STANDARD;
 
-    for param in params {
-        if let Some(value) = param.strip_prefix("sr=") {
-            let value = base64::Engine::decode(&engine, value.as_bytes())
-                .map_err(|_e| Error::invalid_parameter("handle", "invalid handle"))?;
-            let value = String::from_utf8(value)
-                .map_err(|_e| Error::invalid_parameter("handle", "invalid handle"))?;
-            sr = Some(value);
-        } else if let Some(value) = param.strip_prefix("sig=") {
-            let value = base64::Engine::decode(&engine, value.as_bytes())
-                .map_err(|_e| Error::invalid_parameter("handle", "invalid handle"))?;
-            sig = Some(value);
+        for param in params {
+            if let Some(value) = param.strip_prefix("sr=") {
+                let value = base64::Engine::decode(&engine, value.as_bytes())
+                    .map_err(|_e| Error::invalid_parameter("handle", "invalid handle"))?;
+                let value = String::from_utf8(value)
+                    .map_err(|_e| Error::invalid_parameter("handle", "invalid handle"))?;
+                sr = Some(value);
+            } else if let Some(value) = param.strip_prefix("sig=") {
+                let value = base64::Engine::decode(&engine, value.as_bytes())
+                    .map_err(|_e| Error::invalid_parameter("handle", "invalid handle"))?;
+                sig = Some(value);
+            }
         }
+
+        let sr = sr.ok_or_else(|| Error::invalid_parameter("handle", "invalid handle"))?;
+        let sig = sig.ok_or_else(|| Error::invalid_parameter("handle", "invalid handle"))?;
+
+        let handle_validation_key = handle_validation_key_id(keys)?;
+        let ok = keys
+            .verify(
+                handle_validation_key,
+                keys::sys::AZIOT_KEYS_SIGN_MECHANISM_HMAC_SHA256,
+                std::ptr::null(),
+                sr.as_bytes(),
+                &sig,
+            )
+            .map_err(|err| Error::Internal(InternalError::Verify(err)))?;
+        if !ok {
+            return Err(Error::invalid_parameter("handle", "invalid handle"));
+        }
+
+        let sr: Sr<'static> = serde_json::from_str(&sr)
+            .map_err(|_e| Error::invalid_parameter("handle", "invalid handle"))?;
+
+        Ok(sr.key_id)
     }
 
-    let sr = sr.ok_or_else(|| Error::invalid_parameter("handle", "invalid handle"))?;
-    let sig = sig.ok_or_else(|| Error::invalid_parameter("handle", "invalid handle"))?;
-
-    let handle_validation_key = handle_validation_key_id(keys)?;
-    let ok = keys
-        .verify(
-            handle_validation_key,
-            keys::sys::AZIOT_KEYS_SIGN_MECHANISM_HMAC_SHA256,
-            std::ptr::null(),
-            sr.as_bytes(),
-            &sig,
-        )
-        .map_err(|err| Error::Internal(InternalError::Verify(err)))?;
-    if !ok {
-        return Err(Error::invalid_parameter("handle", "invalid handle"));
-    }
-
-    let sr: Sr<'static> = serde_json::from_str(&sr)
-        .map_err(|_e| Error::invalid_parameter("handle", "invalid handle"))?;
-
-    let id = sr.key_id;
-
-    let id_cstr = match &id {
+    Ok(match key_handle_to_id_inner(handle, keys)? {
         KeyId::KeyPair(id) => {
             let id_cstr = std::ffi::CString::new(id.clone().into_owned())
                 .map_err(|err| Error::invalid_parameter("handle", err))?;
-            id_cstr
+            (KeyId::KeyPair(id), id_cstr)
         }
-
         KeyId::Key(id) => {
             let id_cstr = std::ffi::CString::new(id.clone().into_owned())
                 .map_err(|err| Error::invalid_parameter("handle", err))?;
-            id_cstr
+            (KeyId::Key(id), id_cstr)
         }
-
-        KeyId::Derived(base_handle, _) => {
-            let (_, base_id_cstr) = key_handle_to_id(base_handle, keys)?;
-            base_id_cstr
+        KeyId::Derived(base_handle, derivation_data) => {
+            let base_id = match key_handle_to_id_inner(&base_handle, keys)? {
+                KeyId::KeyPair(id) | KeyId::Key(id) => id,
+                KeyId::Derived(..) => {
+                    return Err(Error::invalid_parameter(
+                        "handle",
+                        "nested derived keys are not supported, import the outer derived key first",
+                    ));
+                }
+            };
+            let base_id_cstr = std::ffi::CString::new(base_id.into_owned())
+                .map_err(|err| Error::invalid_parameter("handle", err))?;
+            (KeyId::Derived(base_handle, derivation_data), base_id_cstr)
         }
-    };
-
-    Ok((id, id_cstr))
+    })
 }
 
 fn key_id_to_handle(


### PR DESCRIPTION
Cherry-pick from main of b36c9a322497e012a9942fd7c231e3769167e038

This was considered when we first implemented derived keys, but not fully implemented:

- `fn key_handle_to_id` was parsing such keys but throwing away all the intermediate derivation data, so the effect was that `derive(derive(base, A), B)` created the same key as `derive(base, B)`.

- libaziot-keys' API allows `AZIOT_KEYS_SIGN_DERIVED_PARAMETERS::mechanism` to be `AZIOT_KEYS_SIGN_MECHANISM_DERIVED` and thus chain arbitrarily, but the actual implementation in `derive_key_for_sign` only acted on the top layer.

We considered finishing the implementation, but there is no known use case for nested derivation. If the client really needs a nested derived key, they can import each derived key except for the last. In any case, given nested derivation did not work in the current code, we know that there cannot be any clients that depend on nested derivation behaving correctly.

So this change blocks the ability to create new nested derived key handles, and also blocks the usage of any existing nested derived key handles from being used with sign etc API.

Clients that depend on the broken behavior (that `derive(derive(base, A), B)` acts like `derive(base, B)` will be broken by this change, but we want such clients to be broken, because they should not have had the ability to generate `derive(base, B)` in this way.