### PR TITLE
Fix Azure Linux build.

### DIFF
--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -214,7 +214,7 @@ if [ -z "${DISABLE_FOR_CODEQL:-}" ]; then
                 acl cmake cpio curl g++ gcc genisoimage git jq libclang1 libssl-dev llvm-dev make \
                 pigz pkg-config python3-distutils python3-pip qemu-utils rpm tar wget zstd
 
-            GO_VERSION=1.23.0
+            GO_VERSION=1.24.0
             [ "$ARCH" == 'aarch64' ] && GO_ARCH='arm64' || GO_ARCH='amd64'
             mkdir -p /usr/local/go
             curl -sSL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" | tar -C /usr/local -xzf -


### PR DESCRIPTION
Ref: https://github.com/microsoft/azurelinux/commit/f51be08c3faaeaa652189729c23d5f9f24a07af9

The 3.0-stable tag now requires golang 1.24.0 or higher to build the toolkit.